### PR TITLE
HLS decryption

### DIFF
--- a/include/gpac/internal/m3u8.h
+++ b/include/gpac/internal/m3u8.h
@@ -54,6 +54,7 @@ typedef struct s_playList Playlist;
 
 typedef enum e_playlistElementType  { TYPE_PLAYLIST, TYPE_MEDIA, TYPE_UNKNOWN } PlaylistElementType;
 
+typedef enum e_playlistElementDRMMethod { DRM_NONE, DRM_AES_128 } PlaylistElementDRMMethod;
 /**
  * The Structure containing the playlist element
  */
@@ -67,6 +68,9 @@ struct s_playlistElement {
 	char *audio_group;
 	char *video_group;
 	char *url;
+	PlaylistElementDRMMethod drm_method;
+	char *key_uri;
+	unsigned char key_iv[16];
 	GF_Err load_error;
 	PlaylistElementType element_type;
 	union {

--- a/include/gpac/internal/mpd.h
+++ b/include/gpac/internal/mpd.h
@@ -149,6 +149,8 @@ typedef struct
 	char *index;
 	GF_MPD_ByteRange *index_range;
 	u64 duration;
+	char *key_url;
+	unsigned char key_iv[16];
 } GF_MPD_SegmentURL;
 
 typedef struct
@@ -224,6 +226,8 @@ typedef struct
 	u32 probe_switch_count;
 	char *init_segment_data;
 	u32 init_segment_size;
+	char *key_url;
+	unsigned char key_iv[16];
 } GF_DASH_RepresentationPlayback;
 
 typedef struct {
@@ -403,7 +407,7 @@ typedef enum
 	item_index: current downloading index of the segment
 	nb_segments_removed: number of segments removed when pruging the MPD after updates (can be 0). The start number will be offset by this value
 */
-GF_Err gf_mpd_resolve_url(GF_MPD *mpd, GF_MPD_Representation *rep, GF_MPD_AdaptationSet *set, GF_MPD_Period *period, const char *mpd_url, GF_MPD_URLResolveType resolve_type, u32 item_index, u32 nb_segments_removed, char **out_url, u64 *out_range_start, u64 *out_range_end, u64 *segment_duration, Bool *is_in_base_url);
+GF_Err gf_mpd_resolve_url(GF_MPD *mpd, GF_MPD_Representation *rep, GF_MPD_AdaptationSet *set, GF_MPD_Period *period, const char *mpd_url, GF_MPD_URLResolveType resolve_type, u32 item_index, u32 nb_segments_removed, char **out_url, u64 *out_range_start, u64 *out_range_end, u64 *segment_duration, Bool *is_in_base_url, char **out_key_url, unsigned char *key_iv);
 
 
 

--- a/include/gpac/internal/mpd.h
+++ b/include/gpac/internal/mpd.h
@@ -122,7 +122,7 @@ typedef struct
 	Double availability_time_offset;	\
 	GF_MPD_URL *initialization_segment;	\
 	GF_MPD_URL *representation_index;	\
- 
+
 
 typedef struct
 {
@@ -136,7 +136,7 @@ typedef struct
 	u32 start_number;	\
 	GF_MPD_SegmentTimeline *segment_timeline;	\
 	GF_MPD_URL *bitstream_switching_url;	\
- 
+
 typedef struct
 {
 	GF_MPD_MULTIPLE_SEGMENT_BASE
@@ -149,7 +149,7 @@ typedef struct
 	char *index;
 	GF_MPD_ByteRange *index_range;
 	u64 duration;
-	char *key_url;
+	unsigned char *key_url;
 	unsigned char key_iv[16];
 } GF_MPD_SegmentURL;
 
@@ -204,7 +204,7 @@ typedef enum
 	GF_List *essential_properties;	\
 	GF_List *supplemental_properties;	\
 	GF_List *isobmf_tracks;	\
- 
+
 typedef struct {
 	GF_MPD_COMMON_ATTRIBUTES_ELEMENTS
 } GF_MPD_CommonAttributes;
@@ -226,8 +226,6 @@ typedef struct
 	u32 probe_switch_count;
 	char *init_segment_data;
 	u32 init_segment_size;
-	char *key_url;
-	unsigned char key_iv[16];
 } GF_DASH_RepresentationPlayback;
 
 typedef struct {
@@ -403,7 +401,7 @@ typedef enum
 	GF_MPD_RESOLVE_URL_MEDIA_TEMPLATE,
 } GF_MPD_URLResolveType;
 
-/*resolves a URL based for a given segment, based on the MPD url, the type of resolution 
+/*resolves a URL based for a given segment, based on the MPD url, the type of resolution
 	item_index: current downloading index of the segment
 	nb_segments_removed: number of segments removed when pruging the MPD after updates (can be 0). The start number will be offset by this value
 */
@@ -412,4 +410,3 @@ GF_Err gf_mpd_resolve_url(GF_MPD *mpd, GF_MPD_Representation *rep, GF_MPD_Adapta
 
 
 #endif // _MPD_H_
-

--- a/include/gpac/modules/service.h
+++ b/include/gpac/modules/service.h
@@ -450,6 +450,10 @@ typedef struct
 	/*indicates that end of period is being reached (no new segements returned until period activates)*/
 	Bool in_end_of_period;
 
+	/* a possible DRM key associated to the segment */
+	const char *key_url;
+	/* the initialization vector associated to the key */
+	unsigned char key_iv[16];
 } GF_NetURLQuery;
 
 /*GF_NET_SERVICE_QUALITY_SWITCH*/

--- a/src/media_tools/mpegts.c
+++ b/src/media_tools/mpegts.c
@@ -1321,7 +1321,7 @@ static u32 gf_m2ts_sync(GF_M2TS_Demuxer *ts, Bool simple_check)
 
 	while (i<ts->buffer_size) {
 		if (i+188>ts->buffer_size) return ts->buffer_size;
-		if ((ts->buffer[i]==0x47) && (ts->buffer[i+188]==0x47)) 
+		if ((ts->buffer[i]==0x47) && (ts->buffer[i+188]==0x47))
 			break;
 		if ((ts->buffer[i]==0x47) && (ts->buffer[i+192]==0x47)) {
 			ts->prefix_present = 1;
@@ -1633,7 +1633,7 @@ static void gf_m2ts_section_complete(GF_M2TS_Demuxer *ts, GF_M2TS_SectionFilter 
 
 			if (t->last_section_number == t->section_number) {
 				u32 table_size;
-				
+
 				status |= GF_M2TS_TABLE_END;
 
 				table_size = 0;
@@ -3129,7 +3129,7 @@ static void gf_m2ts_get_adaptation_field(GF_M2TS_Demuxer *ts, GF_M2TS_Adaptation
 				case GF_M2TS_AFDESC_TIMELINE_DESCRIPTOR:
 					if (ts->ess[pid] && (ts->ess[pid]->flags & GF_M2TS_ES_IS_PES)) {
 						GF_M2TS_PES *pes = (GF_M2TS_PES *) ts->ess[pid];
-				
+
 						if (pes->temi_tc_desc_len)
 							gf_m2ts_store_temi(ts, pes);
 
@@ -3246,7 +3246,7 @@ static GF_Err gf_m2ts_process_packet(GF_M2TS_Demuxer *ts, unsigned char *data)
 	} else if (hdr.pid == GF_M2TS_PID_CAT) {
 		gf_m2ts_gather_section(ts, ts->cat, NULL, &hdr, data, payload_size);
 		return GF_OK;
-	} 
+	}
 
 	es = ts->ess[hdr.pid];
 	if (paf && paf->PCR_flag) {
@@ -3262,7 +3262,7 @@ static GF_Err gf_m2ts_process_packet(GF_M2TS_Demuxer *ts, unsigned char *data)
 						ts->ess[hdr.pid] = (GF_M2TS_ES *) pes;
 						break;
 					}
-					if (pes->flags & GF_M2TS_ES_IS_PES) 
+					if (pes->flags & GF_M2TS_ES_IS_PES)
 						first_pes = pes;
 				}
 				//non found, use the first media stream as a PCR destination - Q: is it legal to have PCR only streams not declared in PMT ?
@@ -3271,7 +3271,7 @@ static GF_Err gf_m2ts_process_packet(GF_M2TS_Demuxer *ts, unsigned char *data)
 				}
 				break;
 			}
-			if (!es) 
+			if (!es)
 				es = ts->ess[hdr.pid];
 		}
 		if (es) {
@@ -3821,7 +3821,7 @@ GF_Err gf_m2ts_demux_file(GF_M2TS_Demuxer *ts, const char *fileName, u64 start_b
 			}
 			read += size;
 			if (done) break;
-			if (ts->abort_parsing) 
+			if (ts->abort_parsing)
 				break;
 		}
 
@@ -4482,7 +4482,7 @@ static void rewrite_pts_dts(unsigned char *ptr, u64 TS)
 	if (_TS < (u64) -ts_shift) _TS = pcr_mod + _TS + ts_shift; \
 	else _TS = _TS + ts_shift; \
 	while (_TS > pcr_mod) _TS -= pcr_mod; \
- 
+
 
 GF_Err gf_m2ts_restamp(char *buffer, u32 size, s64 ts_shift, u8 *is_pes)
 {
@@ -4573,4 +4573,3 @@ GF_Err gf_m2ts_restamp(char *buffer, u32 size, s64 ts_shift, u8 *is_pes)
 }
 
 #endif /*GPAC_DISABLE_MPEG2TS*/
-


### PR DESCRIPTION
Here is an ugly try at HLS decryption, but it might help to see what needs to be done in order to implement it.

The first part is adding key and iv extraction in the m3u8 code. It is not complete as the IV attribute is not extracted but I did not encounter a file with that attribute as of now so the IV is always the media sequence number.

Next I added code to export the key and iv in the mpd representation and code to the mpd parser to extract them. 

Finally I added code in the dash client to decrypt the downloaded segments. The decryption is done by the drm_decrypt function. It uses a proprietary solution which fetches the key using some SSL client certificate and do the decryption. It could be easily replaced by another one implementing the hls aes "standard" cbc 128 decryption.

It's working OK until some point where the image get stuck but this is another bug we have (see issue #53)

gpac/GF_LOG_CONTAINER [M2TSDemux] URLremoved-url, iv 0 0
gpac/GF_LOG_CONTAINER [M2TSDemux] URLremoved-url, iv 0 1                                                                
gpac/GF_LOG_CONTAINER [M2TSDemux] Error Corrupted Data in file/stream while demuxing /data/data/co.test.platform.test.app/cache/gpac_cache_951C2478B3ED488C3978D04DFE8D893B24CBFFE9.ts
gpac/GF_LOG_CONTAINER [M2TSDemux] Error Bad Parameter while demuxing /data/data/co.test.platform.test.app/cache/gpac_cache_951C2478B3ED488C3978D04DFE8D893B24CBFFE9.ts                
gpac/GF_LOG_CONTAINER [M2TSDemux] Error Corrupted Data in file/stream while demuxing /data/data/co.test.platform.test.app/cache/gpac_cache_951C2478B3ED488C3978D04DFE8D893B24CBFFE9.ts
gpac/GF_LOG_CONTAINER [M2TSDemux] Error Bad Parameter while demuxing /data/data/co.test.platform.test.app/cache/gpac_cache_951C2478B3ED488C3978D04DFE8D893B24CBFFE9.ts                
gpac/GF_LOG_CONTAINER [M2TSDemux] Error Bad Parameter while demuxing /data/data/co.test.platform.test.app/cache/gpac_cache_951C2478B3ED488C3978D04DFE8D893B24CBFFE9.ts                
gpac/GF_LOG_CONTAINER [M2TSDemux] Error Bad Parameter while demuxing /data/data/co.test.platform.test.app/cache/gpac_cache_951C2478B3ED488C3978D04DFE8D893B24CBFFE9.ts                
gpac/GF_LOG_CONTAINER [M2TSDemux] Error Bad Parameter while demuxing /data/data/co.test.platform.test.app/cache/gpac_cache_951C2478B3ED488C3978D04DFE8D893B24CBFFE9.ts                
gpac/GF_LOG_CONTAINER [M2TSDemux] Error Bad Parameter while demuxing /data/ydata/co.test.platform.test.app/cache/gpac_cache_951C2478B3ED488C3978D04DFE8D893B24CBFFE9.ts               
gpac/GF_LOG_CONTAINER [M2TSDemux] Error Bad Parameter while demuxing /data/data/co.test.platform.test.app/cache/gpac_cache_951C2478B3ED488C3978D04DFE8D893B24CBFFE9.ts                
gpac/GF_LOG_CONTAINER [M2TSDemux] URLremoved-url, iv 0 3                                                                      
gpac/GF_LOG_CONTAINER [M2TSDemux] Error Corrupted Data in file/stream while demuxing /data/data/co.test.platform.test.app/cache/gpac_cache_3B1CD399A30C3373274FBB30840459BEA004702F.ts
gpac/GF_LOG_CONTAINER [M2TSDemux] Error Corrupted Data in file/stream while demuxing /data/data/co.test.platform.test.app/cache/gpac_cache_3B1CD399A30C3373274FBB30840459BEA004702F.ts
gpac/GF_LOG_CONTAINER [M2TSDemux] Error Bad Parameter while demuxing /data/data/co.test.platform.test.app/cache/gpac_cache_3B1CD399A30C3373274FBB30840459BEA004702F.ts                
gpac/GF_LOG_CONTAINER [M2TSDemux] Error Bad Parameter while demuxing /data/data/co.test.platform.test.app/cache/gpac_cache_3B1CD399A30C3373274FBB30840459BEA004702F.ts                
gpac/GF_LOG_CONTAINER [MPEG-2 TS] PID 6064: Bad Adaptation Extension fopund                                                                                                            
gpac/GF_LOG_CONTAINER [M2TSDemux] Error Bad Parameter while demuxing /data/data/co.test.platform.test.app/cache/gpac_cache_3B1CD399A30C3373274FBB30840459BEA004702F.ts                
gpac/GF_LOG_CONTAINER [M2TSDemux] Error Bad Parameter while demuxing /data/data/co.test.platform.test.app/cache/gpac_cache_3B1CD399A30C3373274FBB30840459BEA004702F.ts                
gpac/GF_LOG_CONTAINER [M2TSDemux] Error Bad Parameter while demuxing /data/data/co.test.platform.test.app/cache/gpac_cache_3B1CD399A30C3373274FBB30840459BEA004702F.ts                
gpac/GF_LOG_CONTAINER [M2TSDemux] Error Bad Parameter while demuxing /data/data/co.test.platform.test.app/cache/gpac_cache_3B1CD399A30C3373274FBB30840459BEA004702F.ts                
gpac/GF_LOG_CONTAINER [M2TSDemux] Error Bad Parameter while demuxing /data/data/co.test.platform.test.app/cache/gpac_cache_3B1CD399A30C3373274FBB30840459BEA004702F.ts                
gpac/GF_LOG_CONTAINER [M2TSDemux] Error Bad Parameter while demuxing /data/data/co.test.platform.test.app/cache/gpac_cache_3B1CD399A30C3373274FBB30840459BEA004702F.ts                
gpac/GF_LOG_CONTAINER [M2TSDemux] Error Corrupted Data in file/stream while demuxing /data/data/co.test.platform.test.app/cache/gpac_cache_3B1CD399A30C3373274FBB30840459BEA004702F.ts
gpac/GF_LOG_CONTAINER [M2TSDemux] URLremoved-url, iv 0 4                                                                      
gpac/GF_LOG_CONTAINER [M2TSDemux] Error Bad Parameter while demuxing /data/data/co.test.platform.test.app/cache/gpac_cache_31C8FBA8DEB7DFCD6FEB7684641F52A5145BBA61.ts                
gpac/GF_LOG_CONTAINER [M2TSDemux] Error Bad Parameter while demuxing /data/data/co.test.platform.test.app/cache/gpac_cache_31C8FBA8DEB7DFCD6FEB7684641F52A5145BBA61.ts                
gpac/GF_LOG_CONTAINER [M2TSDemux] Error Bad Parameter while demuxing /data/data/co.test.platform.test.app/cache/gpac_cache_31C8FBA8DEB7DFCD6FEB7684641F52A5145BBA61.ts                
gpac/GF_LOG_CONTAINER [M2TSDemux] Error Corrupted Data in file/stream while demuxing /data/data/co.test.platform.test.app/cache/gpac_cache_31C8FBA8DEB7DFCD6FEB7684641F52A5145BBA61.ts
gpac/GF_LOG_CONTAINER [M2TSDemux] Error Bad Parameter while demuxing /data/data/co.test.platform.test.app/cache/gpac_cache_31C8FBA8DEB7DFCD6FEB7684641F52A5145BBA61.ts                
gpac/GF_LOG_CONTAINER [M2TSDemux] Error Bad Parameter while demuxing /data/data/co.test.platform.test.app/cache/gpac_cache_31C8FBA8DEB7DFCD6FEB7684641F52A5145BBA61.ts                
gpac/GF_LOG_CONTAINER [M2TSDemux] Error Corrupted Data in file/stream while demuxing /data/data/co.test.platform.test.app/cache/gpac_cache_31C8FBA8DEB7DFCD6FEB7684641F52A5145BBA61.ts