### PR TITLE
[Android] Do not call glDisable when it is not needed.

### DIFF
--- a/modules/droid_out/droid_vout.c
+++ b/modules/droid_out/droid_vout.c
@@ -126,8 +126,6 @@ void initGL(AndroidContext *rc)
 
 	/* Really Nice Perspective Calculations */
 	glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_NICEST);
-
-	glDisable(GL_CULL_FACE | GL_NORMALIZE | GL_LIGHTING | GL_BLEND | GL_FOG | GL_COLOR_MATERIAL | GL_TEXTURE_2D);
 }
 
 void gluPerspective(GLfloat fovy, GLfloat aspect,
@@ -199,7 +197,6 @@ void drawGLScene(AndroidContext *rc)
 	glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, rgba);
 	glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, rgba);
 	glMaterialfv(GL_FRONT_AND_BACK, GL_EMISSION, rgba);
-	glDisable(GL_CULL_FACE | GL_NORMALIZE | GL_LIGHTING | GL_BLEND | GL_FOG | GL_COLOR_MATERIAL | GL_TEXTURE_2D);
 
 	/* Clear The Screen And The Depth Buffer */
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);


### PR DESCRIPTION
In the Android video out driver, glDisable is called at init and then
for each rendering step. As per the glEnable man pages, the capability
flags that are disabled in the driver are disabled by default:

    The initial value for each capability with the exception of
    GL_DITHER and GL_MULTISAMPLE is GL_FALSE.

So there is no need to call glDisable for those. Besides, it causes
spurious log messages on some Android devices:

    W/Adreno-ES20(24368): <process_gl_state_enables:519>: GL_INVALID_ENUM

which slows down the rendering process.
