### PR TITLE
Fix disable flag build

### DIFF
--- a/include/gpac/isomedia.h
+++ b/include/gpac/isomedia.h
@@ -332,6 +332,14 @@ typedef struct
 	SAPType IsRAP;
 } GF_ISOSample;
 
+/*Flags for gf_isom_open_segment*/
+enum
+{
+	/*FLAT: the MediaData (MPEG4 ESs) is stored at the begining of the file*/
+	GF_ISOM_SEGMENT_NO_ORDER_FLAG = 1,
+	GF_ISOM_SEGMENT_SCALABLE_FLAG = 1<<1,
+};
+
 
 /*creates a new empty sample*/
 GF_ISOSample *gf_isom_sample_new();
@@ -1220,14 +1228,6 @@ footprint low when playing segments. Note however that seeking in the file is th
 WARNING - the sample count is not reset after the release of tables. This means you need to keep counting samples.*/
 GF_Err gf_isom_release_segment(GF_ISOFile *movie, Bool reset_tables);
 
-/*Flags for gf_isom_open_segment*/
-enum
-{
-	/*FLAT: the MediaData (MPEG4 ESs) is stored at the beginning of the file*/
-	GF_ISOM_SEGMENT_NO_ORDER_FLAG = 1,
-	GF_ISOM_SEGMENT_SCALABLE_FLAG = 1<<1,
-};
-
 /*opens a new segment file. Access to samples in previous segments is no longer possible
 if end_range>start_range, restricts the URL to the given byterange when parsing*/
 GF_Err gf_isom_open_segment(GF_ISOFile *movie, const char *fileName, u64 start_range, u64 end_range, u32 flags);
@@ -1835,7 +1835,7 @@ GF_Err gf_isom_stxt_get_description(GF_ISOFile *the_file, u32 trackNumber, u32 S
 GF_Err gf_isom_new_stxt_description(GF_ISOFile *movie, u32 trackNumber, u32 type, const char *mime, const char *encoding, const char *config, u32 *outDescriptionIndex);
 GF_Err gf_isom_update_stxt_description(GF_ISOFile *movie, u32 trackNumber, const char *encoding, const char *config, u32 DescriptionIndex);
 
-GF_Err gf_isom_xml_subtitle_get_description(GF_ISOFile *the_file, u32 trackNumber, u32 StreamDescriptionIndex, 
+GF_Err gf_isom_xml_subtitle_get_description(GF_ISOFile *the_file, u32 trackNumber, u32 StreamDescriptionIndex,
 											const char **xmlnamespace, const char **xml_schema_loc, const char **mimes);
 GF_Err gf_isom_new_xml_subtitle_description(GF_ISOFile  *movie, u32 trackNumber,
 											const char *xmlnamespace, const char *xml_schema_loc, const char *auxiliary_mimes,

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -2431,9 +2431,11 @@ void gf_sc_simulation_tick(GF_Compositor *compositor)
 
 	gf_sg_activate_routes(compositor->scene);
 	i = 0;
+#ifndef GPAC_DISABLE_SCENEGRAPH
 	while ((sg = (GF_SceneGraph*)gf_list_enum(compositor->extra_scenes, &i))) {
 		gf_sg_activate_routes(sg);
 	}
+#endif
 
 #ifndef GPAC_DISABLE_LOG
 	route_time = gf_sys_clock() - route_time;

--- a/src/compositor/compositor_2d.c
+++ b/src/compositor/compositor_2d.c
@@ -298,6 +298,7 @@ Bool c2d_gl_draw_bitmap(GF_VisualManager *visual, GF_TraverseState *tr_state, Dr
 
 Bool compositor_2d_hybgl_draw_bitmap(GF_VisualManager *visual, GF_TraverseState *tr_state, DrawableContext *ctx)
 {
+#ifndef GPAC_DISABLE_VRML
 	//for anything but background use regular routines
 	if (!(ctx->flags & CTX_IS_BACKGROUND)) return GF_FALSE;
 
@@ -316,6 +317,9 @@ Bool compositor_2d_hybgl_draw_bitmap(GF_VisualManager *visual, GF_TraverseState 
 		tr_state->mesh_num_textures = 0;
 	}
 	return GF_TRUE;
+#else
+	return GF_FALSE;;
+#endif
 }
 #endif
 
@@ -568,7 +572,7 @@ Bool compositor_2d_check_attached(GF_VisualManager *visual)
 	if (!visual->is_attached) {
 		c2d_get_video_access_normal(visual);
 	}
-	
+
 	return visual->is_attached;
 }
 
@@ -1352,7 +1356,7 @@ GF_Err compositor_2d_set_aspect_ratio(GF_Compositor *compositor)
 		compositor->traverse_state->vp_size.y = INT2FIX(compositor->output_height);
 	}
 	GF_LOG(GF_LOG_DEBUG, GF_LOG_COMPOSE, ("[Compositor2D] Reconfigured display size %d x %d done\n", evt.setup.width, evt.setup.height));
-	
+
 	/*set scale factor*/
 	compositor_set_ar_scale(compositor, scaleX, scaleY);
 	return GF_OK;

--- a/src/compositor/font_engine.c
+++ b/src/compositor/font_engine.c
@@ -1435,8 +1435,10 @@ void gf_font_spans_pick(GF_Node *node, GF_List *spans, GF_TraverseState *tr_stat
 			}
 
 			if (use_dom_events && !compositor->sel_buffer) {
+#ifndef GPAC_DISABLE_SVG
 				if (svg_drawable_is_over(drawable, loc_x, loc_y, &asp, tr_state, &rc))
 					goto picked;
+#endif
 			} else {
 				if ( (loc_x >= rc.x) && (loc_y <= rc.y) && (loc_x <= rc.x + rc.width) && (loc_y >= rc.y - rc.height) ) {
 					goto picked;

--- a/src/compositor/mpeg4_grouping_3d.c
+++ b/src/compositor/mpeg4_grouping_3d.c
@@ -339,11 +339,13 @@ static void TraverseLOD(GF_Node *node, void *rs, Bool is_destroy)
 		children = ((M_LOD *) node)->level;
 		ranges = &((M_LOD *) node)->range;
 		center = ((M_LOD *) node)->center;
-#ifndef GPAC_DISABLE_X3D
 	} else {
+#ifndef GPAC_DISABLE_X3D
 		children = ((X_LOD *) node)->children;
 		ranges = &((X_LOD *) node)->range;
 		center = ((X_LOD *) node)->center;
+#else
+		return;
 #endif
 	}
 

--- a/src/compositor/texturing_gl.c
+++ b/src/compositor/texturing_gl.c
@@ -1183,6 +1183,7 @@ Bool gf_sc_texture_get_transform(GF_TextureHandler *txh, GF_Node *tx_transform, 
 {
 	Bool ret = 0;
 	gf_mx_init(*mx);
+	(void) tx_transform;
 
 	/*flip image if requested*/
 	if (! (txh->flags & GF_SR_TEXTURE_NO_GL_FLIP) && !(txh->tx_io->flags & TX_IS_FLIPPED) && !for_picking) {

--- a/src/compositor/visual_manager_3d.c
+++ b/src/compositor/visual_manager_3d.c
@@ -1510,6 +1510,7 @@ void visual_3d_set_2d_strike(GF_TraverseState *tr_state, DrawAspect2D *asp)
 {
 	if (asp->line_texture) {
 		GF_Node *txtrans = NULL;
+#ifndef GPAC_DISABLE_VRML
 		if (tr_state->appear
 		        && (gf_node_get_tag( ((M_Appearance *)tr_state->appear)->material) == TAG_MPEG4_Material2D)
 		        && (gf_node_get_tag(((M_Material2D *) ((M_Appearance *)tr_state->appear)->material)->lineProps) == TAG_MPEG4_XLineProperties)
@@ -1530,6 +1531,7 @@ void visual_3d_set_2d_strike(GF_TraverseState *tr_state, DrawAspect2D *asp)
 #endif
 		tr_state->mesh_num_textures = gf_sc_texture_enable(asp->line_texture, txtrans);
 		if (tr_state->mesh_num_textures) return;
+#endif
 	}
 	/*no texture or not ready, use color*/
 	if (asp->line_color)
@@ -2049,4 +2051,3 @@ void visual_3d_set_fog(GF_VisualManager *visual, const char *type, SFColor color
 }
 
 #endif
-

--- a/src/isomedia/track.c
+++ b/src/isomedia/track.c
@@ -548,7 +548,9 @@ GF_Err MergeTrack(GF_TrackBox *trak, GF_TrackFragmentBox *traf, u64 moof_offset,
 			degr = GF_ISOM_GET_FRAG_DEG(flags);
 			if (degr) stbl_AppendDegradation(trak->Media->information->sampleTable, degr);
 
+#ifndef GPAC_DISABLE_ISOM_WRITE
 			stbl_AppendDependencyType(trak->Media->information->sampleTable, GF_ISOM_GET_FRAG_LEAD(flags), GF_ISOM_GET_FRAG_DEPENDS(flags), GF_ISOM_GET_FRAG_DEPENDED(flags), GF_ISOM_GET_FRAG_REDUNDANT(flags));
+#endif
 		}
 	}
 	/*merge sample groups*/

--- a/src/terminal/media_control.c
+++ b/src/terminal/media_control.c
@@ -125,7 +125,7 @@ Bool MC_URLChanged(MFURL *old_url, MFURL *new_url)
 	}
 	return 0;
 }
-
+#endif
 
 
 
@@ -210,7 +210,7 @@ void mediacontrol_pause(GF_ObjectManager *odm)
 	}
 }
 
-
+#ifndef GPAC_DISABLE_VRML
 /*pause all objects*/
 void mediacontrol_set_speed(GF_ObjectManager *odm, Fixed speed)
 {


### PR DESCRIPTION
To reduce the size of my Android builds, I'm using the various GPAC_DISABLE_* flags, but for some of those, it breaks the build.

