### PR TITLE
fix bug in ctts unpack mode when removing sample

### DIFF
--- a/include/gpac/internal/isomedia_dev.h
+++ b/include/gpac/internal/isomedia_dev.h
@@ -2680,6 +2680,7 @@ GF_Err stbl_GetSampleDepType(GF_SampleDependencyTypeBox *stbl, u32 SampleNumber,
 
 /*unpack sample2chunk and chunk offset so that we have 1 sample per chunk (edition mode only)*/
 GF_Err stbl_UnpackOffsets(GF_SampleTableBox *stbl);
+GF_Err stbl_unpackCTS(GF_SampleTableBox *stbl);
 GF_Err SetTrackDuration(GF_TrackBox *trak);
 GF_Err Media_SetDuration(GF_TrackBox *trak);
 

--- a/src/isomedia/isom_write.c
+++ b/src/isomedia/isom_write.c
@@ -43,6 +43,8 @@ static GF_Err unpack_track(GF_TrackBox *trak)
 	GF_Err e = GF_OK;
 	if (!trak->is_unpacked) {
 		e = stbl_UnpackOffsets(trak->Media->information->sampleTable);
+		if (e) return e;
+		e = stbl_unpackCTS(trak->Media->information->sampleTable);
 		trak->is_unpacked = 1;
 	}
 	return e;


### PR DESCRIPTION
I think that we need unpack also CompositionOffsetBox before editing/removing the entries (cf. #147 )