### PR TITLE
Check SSL alternative names as well in downloader

### DIFF
--- a/src/utils/downloader.c
+++ b/src/utils/downloader.c
@@ -38,6 +38,7 @@
 #ifdef GPAC_HAS_SSL
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
+#include <openssl/x509v3.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
 
@@ -1387,12 +1388,47 @@ static void gf_dm_connect(GF_DownloadSession *sess)
 				}
 
 				if (vresult == X509_V_OK) {
+					STACK_OF(GENERAL_NAME) *altnames;
+					GF_List* valid_names;
+					int i;
+
+					valid_names = gf_list_new();
+
 					common_name[0] = 0;
 					X509_NAME_get_text_by_NID(X509_get_subject_name(cert), NID_commonName, common_name, sizeof (common_name));
-					if (!rfc2818_match(common_name, sess->server_name)) {
-						success = GF_FALSE;
-						GF_LOG(GF_LOG_ERROR, GF_LOG_NETWORK, ("[SSL] Mismatch in certificate names: got %s expected %s\n", common_name, sess->server_name));
+					gf_list_add(valid_names, common_name);
+
+					altnames = X509_get_ext_d2i(cert, NID_subject_alt_name, NULL, NULL);
+					if (altnames) {
+						for (i = 0; i < sk_GENERAL_NAME_num(altnames); ++i) {
+							const GENERAL_NAME *altname = sk_GENERAL_NAME_value(altnames, i);
+							if (altname->type == GEN_DNS)
+							{
+								char *altname_str = ASN1_STRING_data(altname->d.ia5);
+								gf_list_add(valid_names, altname_str);
+							}
+						}
 					}
+
+					success = GF_FALSE;
+					for (i = 0; i < gf_list_count(valid_names); ++i) {
+						const char *valid_name = (const char*) gf_list_get(valid_names, i);
+						if (rfc2818_match(valid_name, sess->server_name)) {
+						success = GF_TRUE;
+							GF_LOG(GF_LOG_INFO, GF_LOG_NETWORK, ("[SSL] Hostname %s matches %s\n", sess->server_name, valid_name));
+							break;
+						}
+					}
+					if (!success) {
+						GF_LOG(GF_LOG_ERROR, GF_LOG_NETWORK, ("[SSL] Mismatch in certificate names: expected %s\n", sess->server_name));
+						for (i = 0; i < gf_list_count(valid_names); ++i) {
+							const char *valid_name = (const char*) gf_list_get(valid_names, i);
+							GF_LOG(GF_LOG_ERROR, GF_LOG_NETWORK, ("[SSL] Tried name: %s\n", valid_name));
+						}
+					}
+
+					gf_list_del(valid_names);
+					GENERAL_NAMES_free(altnames);
 				} else {
 					success = GF_FALSE;
 					GF_LOG(GF_LOG_ERROR, GF_LOG_NETWORK, ("[SSL] Error verifying certificate %x\n", vresult));


### PR DESCRIPTION
I'm trying to play DASH manifests from youtube. The dash manifest I use is fetched with the following command:
```Shell
curl $(youtube-dl -j "https://www.youtube.com/watch?v=sc03SlMY3vA" | jq --raw-output '.dash_manifest_url') > dash.mpd
```
Note: you need [my fork](https://github.com/yan12125/youtube-dl/tree/expose-dash-manifest-url) of youtube-dl for the command above.

I encounter the following error in playing dash.mpd:
```
$ MP4Client dash.mpd       
Using config file in /home/yen/.gpac directory
System info: 7972 MB RAM - 4 cores
Modules Found : 34 
Loading GPAC Terminal
[Thread MediaManager] Couldn't set priority(2) for thread ID 0x11ee1700
[Thread MediaManager] Couldn't set priority(2) for thread ID 0x11ee1700
[PulseAudio] Set volume to 75: not yet implemented.
Terminal Loaded in 67 ms
Opening URL dash.mpd
[SSL] Mismatch in certificate names: got google.com expected manifest.googlevideo.com
[DASH] FAILED to download https://manifest.googlevideo.com/api/manifest/init_segment/id/sc03SlMY3vA.2/itag/140/source/yt_live_broadcast/requiressl/yes/playlist_type/LIVE/pmbypass/yes/gcr/tw/ratebypass/yes/cmbypass/yes/mime/audio%2Fmp4/live/1/gir/yes/upn/ifJ-55w5_J8/fexp/938628,9405185,9406775,9406838,9408093,9408142,9408416,9408710,9408787,9408806,9410660,9412859,945137,948124,952612,952642/sver/3/signature/82491208C20B93A32892566CB4C173C45417E219.2142FF961FEA651B4CBB520BC565907D9C8563B7/key/cms1/ip/140.112.247.145/ipbits/0/expire/1432257053/sparams/cmbypass,expire,gcr,gir,id,ip,ipbits,itag,live,mime,mm,mn,ms,mv,pl,playlist_type,pmbypass,ratebypass,requiressl,source/mm/32/mn/sn-u5oxu-un5e/ms/lv/mt/1432235403/mv/m/pl/17/sq/0 = Authentication failure...
 Cannot open dash.mpd: Authentication failure
```

manifest.googlevideo.com uses subject alternative name in its certificate. In this PR I managed to check for both common name and all alternative names.

Note: my implementation is based on verifyhost() function of [openssl.c](https://github.com/bagder/curl/blob/master/lib/vtls/openssl.c) from curl. I'm not sure whether there's a licensing issues or not.