### PR TITLE
Add a Travis CI build status image to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/gpac/gpac.svg?branch=master)](https://travis-ci.org/gpac/gpac)
+
 README for GPAC version 0.5.0, May 2012.
 
 GPAC is a multimedia framework oriented towards rich media and distributed under the LGPL license (see COPYING).


### PR DESCRIPTION
- This will display an image showing the current build status of the
  master branch. To make this work according to
  http://docs.travis-ci.com/user/status-images/ I had to change the
  README's file extension from plain text to Markdown. I've not
  touched anything else to make it more Markdown-like, though.
- This fixes #117 and was found through http://issuehub.io/.