### PR TITLE
Make configure script compatible with Homebrew on MacOS

### DIFF
--- a/configure
+++ b/configure
@@ -542,13 +542,15 @@ EOF
     Darwin)
         js_flags=-DXP_MAC
         xul_flags=-DXP_MAC
+        CFLAGS_DIR="-I$prefix/include"
+        LDFLAGS="-L$prefix/lib"
         if test -d /sw/bin ; then
             alt_macosx_dir="/sw"
-            CFLAGS_DIR="-I/sw/include"
+            CFLAGS_DIR="-I/sw/include $CFLAGS_DIR"
             LDFLAGS="-L/sw/lib $LDFLAGS"
         elif test -d /opt/local/bin ; then
             alt_macosx_dir="/opt/local"
-            CFLAGS_DIR="-I/opt/local/include"
+            CFLAGS_DIR="-I/opt/local/include $CFLAGS_DIR"
             LDFLAGS="-L/opt/local/lib $LDFLAGS"
         fi
         cc="cc"


### PR DESCRIPTION
The configure script seems to be compatible with Macports which installs
its stuff into /opt/local.

However, Homebrew doesn't have the same behavior. It installs its stuff
into a Cellar folder, then, links it into /usr/local/{include,lib,bin}.

However, for example, the png detection uses -Iprefix/include (line
1225), but this include path is not used afterwards.

So, if you have installed libpng with Homebrew, configure detects a
"system" png, but fails to compile since $prefix/include isn't used as
include path at compile time.