### PR TITLE
DASH-IF IOP profiles require ContentProtection only in AdaptationSet.

### DIFF
--- a/applications/mp4box/main.c
+++ b/applications/mp4box/main.c
@@ -386,6 +386,8 @@ void PrintDASHUsage()
 	        " -single-traf         uses a single track fragment per moof (smooth streaming and derived specs may require this)\n"
 	        " -dash-ts-prog N      program_number to be considered in case of an MPTS input file.\n"
 	        " -frag-rt             when using fragments in live mode, flush fragments according to their timing (only supported with a single input).\n"
+	        " -cp-in-as            if media is protected, adds the ContentProtection element to the AdaptationSet element.\n"
+	        " -cp-in-rep           if media is protected, adds the ContentProtection element to the Representation element.\n"
 	        "\n");
 }
 
@@ -1774,6 +1776,8 @@ u32 MTUSize = 1450;
 #endif
 GF_ISOFile *file;
 Bool frag_real_time = GF_FALSE;
+Bool content_protection_in_adaptation_set = GF_FALSE;
+Bool content_protection_in_representation = GF_FALSE;
 Double mpd_update_time = GF_FALSE;
 Bool stream_rtp = GF_FALSE;
 Bool force_co64 = GF_FALSE;
@@ -3114,6 +3118,12 @@ Bool mp4box_parse_args(int argc, char **argv)
 		else if (!stricmp(arg, "-frag-rt")) {
 			frag_real_time = GF_TRUE;
 		}
+		else if (!stricmp(arg, "-cp-in-as")) {
+			content_protection_in_adaptation_set = GF_TRUE;
+		}
+		else if (!stricmp(arg, "-cp-in-rep")) {
+			content_protection_in_representation = GF_TRUE;
+		}
 		else if (!strnicmp(arg, "-dash-live", 10) || !strnicmp(arg, "-ddbg-live", 10)) {
 			dash_mode = !strnicmp(arg, "-ddbg-live", 10) ? GF_DASH_DYNAMIC_DEBUG : GF_DASH_DYNAMIC;
 			dash_live = 1;
@@ -3808,6 +3818,8 @@ int mp4boxMain(int argc, char **argv)
 		if (!e) e = gf_dasher_configure_isobmf_default(dasher, no_fragments_defaults, pssh_in_moof, samplegroups_in_traf, single_traf_per_moof);
 		if (!e) e = gf_dasher_enable_utc_ref(dasher, insert_utc);
 		if (!e) e = gf_dasher_enable_real_time(dasher, frag_real_time);
+		if (!e) e = gf_dasher_set_content_protection_in_adaptation_set(dasher, content_protection_in_adaptation_set);
+		if (!e) e = gf_dasher_set_content_protection_in_representation(dasher, content_protection_in_representation);
 		if (!e) e = gf_dasher_set_profile_extension(dasher, dash_profile_extension);
 
 		for (i=0; i < nb_dash_inputs; i++) {

--- a/include/gpac/media_tools.h
+++ b/include/gpac/media_tools.h
@@ -508,6 +508,18 @@ GF_Err gf_dasher_enable_utc_ref(GF_DASHSegmenter *dasher, Bool insert_utc);
  *	\return error code if any
 */
 GF_Err gf_dasher_enable_real_time(GF_DASHSegmenter *dasher, Bool real_time);
+/*Sets whether the ContentProtection element must be added to the AdapatationSet element or not.
+*	\param dasher the DASH segmenter object
+*	\param value if true, the ContentProtection element will be added to the AdaptationSet element.
+*	\return error code if any
+*/
+GF_Err gf_dasher_set_content_protection_in_adaptation_set(GF_DASHSegmenter *dasher, Bool value);
+/*Sets whether the ContentProtection element must be added to the Representation element or not.
+*	\param dasher the DASH segmenter object
+*	\param value if true, the ContentProtection element will be added to the Representation element.
+*	\return error code if any
+*/
+GF_Err gf_dasher_set_content_protection_in_representation(GF_DASHSegmenter *dasher, Bool value);
 /*Sets profile extension as used by DASH-IF and DVB.
  *	\param dasher the DASH segmenter object
  *	\param dash_profile_extension specifies a string of profile extensions, as used by DASH-IF and DVB.

--- a/src/export.cpp
+++ b/src/export.cpp
@@ -2005,6 +2005,8 @@
 #pragma comment (linker, EXPORT_SYMBOL(gf_dasher_configure_isobmf_default) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_dasher_enable_utc_ref) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_dasher_enable_real_time) )
+#pragma comment (linker, EXPORT_SYMBOL(gf_dasher_set_content_protection_in_adaptation_set) )
+#pragma comment (linker, EXPORT_SYMBOL(gf_dasher_set_content_protection_in_representation) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_dasher_set_profile_extension) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_dasher_add_input) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_dasher_process) )

--- a/src/media_tools/dash_segmenter.c
+++ b/src/media_tools/dash_segmenter.c
@@ -126,8 +126,14 @@ struct __gf_dash_segmenter
 	/*set if seg_rad_name depends on input file name (had %s in it). In this case, SegmentTemplate cannot be used at adaptation set level*/
 	Bool variable_seg_rad_name;
 
-	/*duplicate ContentProtection elemnt in adaptation set for DRM and profiles compatibility*/
+	// According to the DASH standard, the ContentProtection element can be
+	// present in different locations, including multiple locations at the
+	// same time. But different profiles or interoperability points
+	// may require ContentProtection elements to to be present only
+	// in a specific location. So, we need additional flexibility
+	// in order to know where exactly ContentProtection must be present.
 	Bool content_protection_in_adaptation_set;
+	Bool content_protection_in_representation;
 
 	Double max_segment_duration;
 
@@ -2168,7 +2174,7 @@ restart_fragmentation_pass:
 		fprintf(dash_cfg->mpd, "    <AudioChannelConfiguration schemeIdUri=\"urn:mpeg:dash:23003:3:audio_channel_configuration:2011\" value=\"%d\"/>\n", nb_channels);
 
 	/* Write content protection element in representation */
-	if (protected_track && !dash_cfg->content_protection_in_adaptation_set) {
+	if (protected_track && dash_cfg->content_protection_in_representation) {
 		gf_isom_write_content_protection(input, dash_cfg->mpd, protected_track, 4);
 	}
 
@@ -5349,6 +5355,75 @@ GF_Err gf_dasher_enable_real_time(GF_DASHSegmenter *dasher, Bool real_time)
 }
 
 GF_EXPORT
+GF_Err gf_dasher_set_content_protection_in_adaptation_set(GF_DASHSegmenter *dasher, Bool value)
+{
+	if (!dasher) return GF_BAD_PARAM;
+	dasher->content_protection_in_adaptation_set = value;
+	return GF_OK;
+}
+
+GF_EXPORT
+GF_Err gf_dasher_set_content_protection_in_representation(GF_DASHSegmenter *dasher, Bool value)
+{
+	if (!dasher) return GF_BAD_PARAM;
+	dasher->content_protection_in_representation = value;
+	return GF_OK;
+}
+
+/**
+ * Sets proper locations of the ContentProtection element for protected media.
+ * According to the DASH standard, this element can be located in different
+ * places, including multiple places at the same time. But some profiles or
+ * interoperability points may require this element to be present only in
+ * specific location.
+ */
+static GF_Err gf_dasher_set_content_protection_locations(GF_DASHSegmenter *dasher)
+{
+	if (!dasher) return GF_BAD_PARAM;
+
+	// If the user didn't specify explicitly desired locations, let's use proper defaults.
+	if (!dasher->content_protection_in_adaptation_set && !dasher->content_protection_in_representation) {
+		switch (dasher->profile) {
+			// According to DASH-IF IOP, the ContentProtection element shall be in the AdaptationSet element.
+			// Other locations are not explicitly prohibited.
+			case GF_DASH_PROFILE_AVC264_LIVE:
+			case GF_DASH_PROFILE_AVC264_ONDEMAND:
+				dasher->content_protection_in_adaptation_set = GF_TRUE;
+				break;
+
+			default:
+				dasher->content_protection_in_representation = GF_TRUE;
+				break;
+		}
+
+		return GF_OK;
+	}
+
+	// The user explicitly specified desired locations, so we can't use defaults anymore.
+	// Let's check whether the user's choices make sense.
+	switch (dasher->profile) {
+		case GF_DASH_PROFILE_AVC264_LIVE:
+		case GF_DASH_PROFILE_AVC264_ONDEMAND: {
+			if (!dasher->content_protection_in_adaptation_set) {
+				GF_LOG(GF_LOG_ERROR, GF_LOG_DASH, (
+					"[DASH] ERROR! The selected DASH profile (DASH-IF IOP) requires the ContentProtection element to be present in the AdaptationSet element. "
+					"Use advanced options to explicitly specify that ContentProtection must be in AdaptationSet. See help for details.\n"
+				));
+
+				return GF_BAD_PARAM;
+			}
+
+			break;
+		}
+
+		default:
+			break;
+	}
+
+	return GF_OK;
+}
+
+GF_EXPORT
 GF_Err gf_dasher_set_profile_extension(GF_DASHSegmenter *dasher, const char *dash_profile_extension)
 {
 	if (!dasher) return GF_BAD_PARAM;
@@ -5451,7 +5526,6 @@ GF_Err gf_dasher_process(GF_DASHSegmenter *dasher, Double sub_duration)
 	GF_LOG(GF_LOG_DEBUG, GF_LOG_DASH, ("[DASH] Dashing starting\n"));
 
 	dasher->force_period_end = GF_FALSE;
-	dasher->content_protection_in_adaptation_set = GF_FALSE;
 
 	if (dasher->dash_mode && !dasher->mpd_update_time && !dasher->mpd_live_duration) {
 		if (dasher->dash_mode == GF_DASH_DYNAMIC_LAST) {
@@ -5611,6 +5685,7 @@ GF_Err gf_dasher_process(GF_DASHSegmenter *dasher, Double sub_duration)
 		dasher->profile = GF_DASH_PROFILE_FULL;
 	}
 
+	if (e = gf_dasher_set_content_protection_locations(dasher)) goto exit;
 
 	/*adjust params based on profiles*/
 	switch (dasher->profile) {
@@ -5636,12 +5711,10 @@ GF_Err gf_dasher_process(GF_DASHSegmenter *dasher, Double sub_duration)
 		dasher->no_fragments_defaults = GF_TRUE;
 		dasher->use_url_template = 1;
 		dasher->single_segment = dasher->single_file = GF_FALSE;
-		dasher->content_protection_in_adaptation_set = GF_TRUE;
 		break;
 	case GF_DASH_PROFILE_AVC264_ONDEMAND:
 		dasher->segments_start_with_rap = GF_TRUE;
 		dasher->no_fragments_defaults = GF_TRUE;
-		dasher->content_protection_in_adaptation_set = GF_TRUE;
 		if (dasher->seg_rad_name) {
 			GF_LOG(GF_LOG_ERROR, GF_LOG_DASH, ("[DASH] Segment-name not allowed in DASH-AVC/264 onDemand profile.\n"));
 			return GF_BAD_PARAM;

--- a/src/media_tools/dash_segmenter.c
+++ b/src/media_tools/dash_segmenter.c
@@ -2168,7 +2168,7 @@ restart_fragmentation_pass:
 		fprintf(dash_cfg->mpd, "    <AudioChannelConfiguration schemeIdUri=\"urn:mpeg:dash:23003:3:audio_channel_configuration:2011\" value=\"%d\"/>\n", nb_channels);
 
 	/* Write content protection element in representation */
-	if (protected_track) {
+	if (protected_track && !dash_cfg->content_protection_in_adaptation_set) {
 		gf_isom_write_content_protection(input, dash_cfg->mpd, protected_track, 4);
 	}
 


### PR DESCRIPTION
DASH-IF IOP 3.1 says in 7.5.2 that:

> ContentProtection Descriptors SHALL always be present in the AdaptationSet element, and apply to all contained Representations

The same is related to previous IOP versions. ContentProtection was never allowed to be in Representation.