### PR TITLE
Fixed UTF8 memory size calculation

### DIFF
--- a/applications/mp4box/main.c
+++ b/applications/mp4box/main.c
@@ -5004,7 +5004,7 @@ int wmain( int argc, wchar_t** wargv )
 	argv = (char **)malloc(argc*sizeof(wchar_t *));
 	for (i = 0; i < argc; i++) {
 		wchar_t *src_str = wargv[i];
-		len = 2*gf_utf8_wcslen(wargv[i]);
+		len = UTF8_MAX_BYTES_PER_CHAR*gf_utf8_wcslen(wargv[i]);
 		argv[i] = (char *)malloc(len + 1);
 		res_len = gf_utf8_wcstombs(argv[i], len, &src_str);
 		argv[i][res_len] = 0;

--- a/applications/mp4client/main.c
+++ b/applications/mp4client/main.c
@@ -2248,7 +2248,7 @@ int wmain(int argc, wchar_t** wargv)
 	argv = (char **)malloc(argc*sizeof(wchar_t *));
 	for (i = 0; i < argc; i++) {
 		wchar_t *src_str = wargv[i];
-		len = 2 * gf_utf8_wcslen(wargv[i]);
+		len = UTF8_MAX_BYTES_PER_CHAR * gf_utf8_wcslen(wargv[i]);
 		argv[i] = (char *)malloc(len + 1);
 		res_len = gf_utf8_wcstombs(argv[i], len, &src_str);
 		argv[i][res_len] = 0;

--- a/include/gpac/utf.h
+++ b/include/gpac/utf.h
@@ -89,6 +89,8 @@ size_t gf_utf8_wcslen(const unsigned short *s);
  */
 Bool gf_utf8_reorder_bidi(u16 *utf_string, u32 len);
 
+static const size_t UTF8_MAX_BYTES_PER_CHAR = 4;
+
 /*! @} */
 
 #ifdef __cplusplus


### PR DESCRIPTION
In 108b820(master, 2016/2/19) nightly build binary.

```
> mp4box.exe -info 日本語漢字.mp4
Length allocated for conversion of wide char to UTF-8 not sufficient
```

many cjk charactors encoded to three bytes in utf8 encoding.
But current implementation, allocate 2 * len bytes.

[RFC3629: UTF-8, a transformation format of ISO 10646](https://tools.ietf.org/html/rfc3629) defines UTF8 max octet sequence size is 4.

This patch fixed utf8 memory size calculation.