### PR TITLE
Don't override $cc on Darwin

### DIFF
--- a/configure
+++ b/configure
@@ -555,7 +555,6 @@ EOF
             CFLAGS_DIR="-I/opt/local/include $CFLAGS_DIR"
             LDFLAGS="-L/opt/local/lib $LDFLAGS"
         fi
-        cc="cc"
         Mac_Applications="/Applications"
         SHFLAGS="-dynamiclib"
         DYN_LIB_SUFFIX=".dylib"


### PR DESCRIPTION
The `--cc` configure argument doesn't work on Darwin (OS X) because the configure script overwrites the value of `cc` later. This PR fixes that bug by not overwriting `cc`.