### PR TITLE
Colorizing the log of libgpac #14

### DIFF
--- a/src/utils/error.c
+++ b/src/utils/error.c
@@ -333,23 +333,34 @@ Bool gf_log_tool_level_on(u32 log_tool, u32 log_level)
 	return GF_FALSE;
 }
 
-#define ANSI_COLOR_RED     "\x1b[31m"
-#define ANSI_COLOR_GREEN   "\x1b[32m"
-#define ANSI_COLOR_YELLOW  "\x1b[33m"
-#define ANSI_COLOR_BLUE    "\x1b[34m"
-#define ANSI_COLOR_MAGENTA "\x1b[35m"
-#define ANSI_COLOR_CYAN    "\x1b[36m"
-#define ANSI_COLOR_RESET   "\x1b[0m"
+#define RED     "\x1b[31m"
+#define YELLOW  "\x1b[33m"
+#define WHITE   "\x1b[37m"
+#define RESET   "\x1b[0m"
 
 void default_log_callback(void *cbck, u32 level, u32 tool, const char* fmt, va_list vlist)
 {
 #ifndef _WIN32_WCE
-  char * fmtColored = malloc((strlen(fmt) + strlen(ANSI_COLOR_RED) + strlen(ANSI_COLOR_RESET))*sizeof(char));
-	strcat(fmtColored , ANSI_COLOR_RED);
-	strcat(fmtColored , fmt);
-	strcat(fmtColored , ANSI_COLOR_RESET);
+  /*! RED, GREEN, YELLOW, and so on have the same size, RESET is one byte shorter */
+  char * fmtColored = malloc((strlen(fmt) + strlen(RED))*sizeof(char));
+	switch(level) {
+    case GF_LOG_ERROR:
+      strcat(fmtColored , RED);
+      break;
+    case GF_LOG_WARNING:
+      strcat(fmtColored , YELLOW);
+      break;
+    case GF_LOG_INFO:
+      strcat(fmtColored, WHITE);
+      break;
+    default:
+      strcat(fmtColored , RESET);
+      break;
+  }
 
-  vfprintf(stderr, fmt, vlist);
+  strcat(fmtColored , fmt);
+
+  vfprintf(stderr, fmtColored, vlist);
   free(fmtColored);
 #endif
 }

--- a/src/utils/error.c
+++ b/src/utils/error.c
@@ -333,10 +333,24 @@ Bool gf_log_tool_level_on(u32 log_tool, u32 log_level)
 	return GF_FALSE;
 }
 
+#define ANSI_COLOR_RED     "\x1b[31m"
+#define ANSI_COLOR_GREEN   "\x1b[32m"
+#define ANSI_COLOR_YELLOW  "\x1b[33m"
+#define ANSI_COLOR_BLUE    "\x1b[34m"
+#define ANSI_COLOR_MAGENTA "\x1b[35m"
+#define ANSI_COLOR_CYAN    "\x1b[36m"
+#define ANSI_COLOR_RESET   "\x1b[0m"
+
 void default_log_callback(void *cbck, u32 level, u32 tool, const char* fmt, va_list vlist)
 {
 #ifndef _WIN32_WCE
-	vfprintf(stderr, fmt, vlist);
+  char * fmtColored = malloc((strlen(fmt) + strlen(ANSI_COLOR_RED) + strlen(ANSI_COLOR_RESET))*sizeof(char));
+	strcat(fmtColored , ANSI_COLOR_RED);
+	strcat(fmtColored , fmt);
+	strcat(fmtColored , ANSI_COLOR_RESET);
+
+  vfprintf(stderr, fmt, vlist);
+  free(fmtColored);
 #endif
 }
 


### PR DESCRIPTION
By playing with the ANSI color codes and prepending the color code before the log message, I add some red to the errors and yellow to the warnings.


