### PR TITLE
terminal/scene: replace non-breaking spaces added in f5d1997

### DIFF
--- a/src/terminal/scene.c
+++ b/src/terminal/scene.c
@@ -1297,7 +1297,7 @@ static void create_movie(GF_Scene *scene, GF_Node *root, const char *tr_name, co
 		
 		if (scene->vr_type) {
 			n2 = load_vr_proto_node(scene->graph, name_geo);
-		} else {
+		} else {
 			n2 = is_create_node(scene->graph, TAG_MPEG4_Rectangle, name_geo);
 		}
 		
@@ -1513,7 +1513,7 @@ void gf_scene_regenerate(GF_Scene *scene)
 				if (scene->vr_type) {
 					n2 = gf_sg_find_node_by_name(scene->graph, szGeom);
 					gf_node_changed(n2, NULL);
-				} else {
+				} else {
 					tw = INT2FIX( sw * a_odm->mo->srd_w) /  (max_x - min_x);
 					th = INT2FIX(sh * a_odm->mo->srd_h) / (max_y - min_y);
 
@@ -2538,7 +2538,7 @@ void gf_scene_register_associated_media(GF_Scene *scene, GF_AssociatedContentLoc
 	if (!addon) {
 		GF_SAFEALLOC(addon, GF_AddonMedia);
 		if (!addon) {
-			GF_LOG(GF_LOG_ERROR, GF_LOG_MEDIA, ("[Terminal] Failed to allocate media addon\n"));
+			GF_LOG(GF_LOG_ERROR, GF_LOG_MEDIA, ("[Terminal] Failed to allocate media addon\n"));
 			return;
 		}
 		addon->timeline_id = addon_info->timeline_id;


### PR DESCRIPTION
They broke at least MinGW builds.