### PR TITLE
Attempt to support saio version 1 and 2

### DIFF
--- a/src/isomedia/box_code_drm.c
+++ b/src/isomedia/box_code_drm.c
@@ -1198,33 +1198,20 @@ GF_Err store_senc_info(GF_SampleEncryptionBox *ptr, GF_BitStream *bs)
 	if (!ptr->cenc_saio) return GF_OK;
 
 	pos = gf_bs_get_position(bs);
-
+	if (pos>0xFFFFFFFFULL) {
+		GF_LOG(GF_LOG_DEBUG, GF_LOG_CONTAINER, ("[iso file] \"senc\" offset larger than 32-bits , \"saio\" box version must be 1 .\n"));
+	}
 	e = gf_bs_seek(bs, ptr->cenc_saio->offset_first_offset_field);
 	if (e) return e;
-
-  // BOOM
-  if (pos>0xFFFFFFFFULL) {
-    GF_LOG(GF_LOG_INFO, GF_LOG_CONTAINER, ("[iso file] BOOM writing 64\n"));
+	//force using version 1 for saio box i.e offset has 64 bits
 #ifndef GPAC_DISABLE_ISOM_FRAGMENTS
-    if (ptr->traf) {
-  		gf_bs_write_u64(bs, pos - ptr->traf->moof_start_in_bs );
-  	} else
+	if (ptr->traf) {
+		gf_bs_write_u64(bs, pos - ptr->traf->moof_start_in_bs );
+	} else
 #endif
-    {
-      gf_bs_write_u64(bs, pos);
-    }
-  } else {
-    GF_LOG(GF_LOG_INFO, GF_LOG_CONTAINER, ("[iso file] BOOM writing 32\n"));
-#ifndef GPAC_DISABLE_ISOM_FRAGMENTS
-    if (ptr->traf) {
-  		gf_bs_write_u32(bs, (u32) ( pos - ptr->traf->moof_start_in_bs) );
-  	} else
-#endif
-    {
-  		gf_bs_write_u32(bs, (u32) pos);
-    }
-  }
-
+	{
+		gf_bs_write_u64(bs, pos);
+	}
 	return gf_bs_seek(bs, pos);
 }
 

--- a/src/isomedia/box_code_drm.c
+++ b/src/isomedia/box_code_drm.c
@@ -1204,7 +1204,7 @@ GF_Err store_senc_info(GF_SampleEncryptionBox *ptr, GF_BitStream *bs)
 
   // BOOM
   if (pos>0xFFFFFFFFULL) {
-    GF_LOG(GF_LOG_INFO, GF_LOG_CONTAINER, ("[iso file] BOOM writing 64\n"));
+    // GF_LOG(GF_LOG_INFO, GF_LOG_CONTAINER, ("[iso file] BOOM writing 64\n"));
 #ifndef GPAC_DISABLE_ISOM_FRAGMENTS
     if (ptr->traf) {
   		gf_bs_write_u64(bs, pos - ptr->traf->moof_start_in_bs );
@@ -1214,7 +1214,7 @@ GF_Err store_senc_info(GF_SampleEncryptionBox *ptr, GF_BitStream *bs)
       gf_bs_write_u64(bs, pos);
     }
   } else {
-    GF_LOG(GF_LOG_INFO, GF_LOG_CONTAINER, ("[iso file] BOOM writing 32\n"));
+    // GF_LOG(GF_LOG_INFO, GF_LOG_CONTAINER, ("[iso file] BOOM writing 32\n"));
 #ifndef GPAC_DISABLE_ISOM_FRAGMENTS
     if (ptr->traf) {
   		gf_bs_write_u32(bs, (u32) ( pos - ptr->traf->moof_start_in_bs) );

--- a/src/isomedia/drm_sample.c
+++ b/src/isomedia/drm_sample.c
@@ -604,7 +604,7 @@ GF_Err gf_isom_get_cenc_info(GF_ISOFile *the_file, u32 trackNumber, u32 sampleDe
 #ifndef GPAC_DISABLE_ISOM_WRITE
 
 GF_Err gf_isom_set_cenc_protection(GF_ISOFile *the_file, u32 trackNumber, u32 desc_index, u32 scheme_type,
-                                   u32 scheme_version, u32 default_IsEncrypted, u8 default_IV_size,	bin128 default_KID,
+                                   u32 scheme_version, u32 default_IsEncrypted, u8 default_IV_size,	bin128 default_KID, 
 								   u8 default_crypt_byte_block, u8 default_skip_byte_block,
 								    u8 default_constant_IV_size, bin128 default_constant_IV)
 {
@@ -905,11 +905,8 @@ void gf_isom_cenc_set_saiz_saio(GF_SampleEncryptionBox *senc, GF_SampleTableBox 
 	}
 	if (!senc->cenc_saio) {
 		senc->cenc_saio = (GF_SampleAuxiliaryInfoOffsetBox *) gf_isom_box_new(GF_ISOM_BOX_TYPE_SAIO);
-    // BOOM free
-    //if (senc->cenc_saio->offsets_large) {
-    // this appears to make all the difference with the larger files... I think I need a larger file
-    //senc->cenc_saio->version = 1;
-    //}
+		//force using version 1 for saio box, it could be redundant when we use 64 bits for offset
+		senc->cenc_saio->version = 1;
 		senc->cenc_saio->aux_info_type = GF_4CC('c', 'e', 'n', 'c');
 		senc->cenc_saio->aux_info_type_parameter = 0;
 		senc->cenc_saio->entry_count = 1;
@@ -947,11 +944,8 @@ void gf_isom_cenc_merge_saiz_saio(GF_SampleEncryptionBox *senc, GF_SampleTableBo
 	}
 	if (!senc->cenc_saio) {
 		senc->cenc_saio = (GF_SampleAuxiliaryInfoOffsetBox *) gf_isom_box_new(GF_ISOM_BOX_TYPE_SAIO);
-    // BOOM
-    //if (senc->cenc_saio->offsets_large) {
-    // setting here makes no difference
-    //senc->cenc_saio->version = 1;
-    //}
+		//force using version 1 for saio box, it could be redundant when we use 64 bits for offset
+		senc->cenc_saio->version = 1;
 		senc->cenc_saio->aux_info_type = GF_4CC('c', 'e', 'n', 'c');
 		senc->cenc_saio->aux_info_type_parameter = 0;
 		if (stbl)
@@ -973,32 +967,14 @@ void gf_isom_cenc_merge_saiz_saio(GF_SampleEncryptionBox *senc, GF_SampleTableBo
 		senc->cenc_saiz->sample_count++;
 	}
 
-  // BOOM
 	if (!senc->cenc_saio->entry_count) {
-    if (offset>0xFFFFFFFFULL) {
-      senc->cenc_saio->version = 1;
-      senc->cenc_saio->offsets_large = (u64 *)gf_malloc(sizeof(u64));
-      senc->cenc_saio->offsets_large[0] = offset;
-      senc->cenc_saio->entry_count ++;
-    } else {
-      senc->cenc_saio->version = 0;
-  		senc->cenc_saio->offsets = (u32 *)gf_malloc(sizeof(u32));
-  		senc->cenc_saio->offsets[0] = offset;
-  		senc->cenc_saio->entry_count ++;
-    }
+		senc->cenc_saio->offsets_large = (u64 *)gf_malloc(sizeof(u64));
+		senc->cenc_saio->offsets_large[0] = offset;
+		senc->cenc_saio->entry_count ++;
 	} else {
-    if (offset>0xFFFFFFFFULL) {
-      GF_LOG(GF_LOG_ERROR, GF_LOG_CONTAINER, ("[iso file] BOOM setting 64\n"));
-      senc->cenc_saio->version = 1;
-      senc->cenc_saio->offsets_large = (u64*)gf_realloc(senc->cenc_saio->offsets_large, sizeof(u64)*(senc->cenc_saio->entry_count+1));
-  		senc->cenc_saio->offsets_large[senc->cenc_saio->entry_count] = offset;
-    } else {
-      GF_LOG(GF_LOG_ERROR, GF_LOG_CONTAINER, ("[iso file] BOOM setting 32\n"));
-      senc->cenc_saio->version = 0;
-    	senc->cenc_saio->offsets = (u32*)gf_realloc(senc->cenc_saio->offsets, sizeof(u32)*(senc->cenc_saio->entry_count+1));
-  		senc->cenc_saio->offsets[senc->cenc_saio->entry_count] = offset;
-    }
-    senc->cenc_saio->entry_count++;
+		senc->cenc_saio->offsets_large = (u64*)gf_realloc(senc->cenc_saio->offsets_large, sizeof(u64)*(senc->cenc_saio->entry_count+1));
+		senc->cenc_saio->offsets_large[senc->cenc_saio->entry_count] = offset;
+		senc->cenc_saio->entry_count++;
 	}
 }
 #endif /* GPAC_DISABLE_ISOM_FRAGMENTS */


### PR DESCRIPTION
Work in progress on #564, opening this for comment.

This contains logging for testing purposes.

Currently streams are able to be parsed via the the Google universal transmuxer.

I have not been able to recreate the >4GB error. I have a 4.5GB version of big buck bunny generated by repeated concatenation but it fails to encrypt. Have verified this issue on master.

``` bash
MP4Box -v  -crypt encrypt.xml \
./test_input/bigbuck_4gb.mp4 \
-out output.mp4

MP4Box(89476,0x7fff789f2000) malloc: *** error for object 0x7fa1b5005008: incorrect checksum for freed object - object was probably modified after being freed.
*** set a breakpoint in malloc_error_break to debug
```

So I am not sure if files of this size are commonly used as others must be seeing this issue if they are.

Currently testing by 

``` bash
mp4dump output_dashinit.mp4 | grep saio
    [saio] size=12+16, flags=1
    [saio] size=12+16, flags=1
    [saio] size=12+16, flags=1
    [saio] size=12+16, flags=1
    [saio] size=12+16, flags=1
    [saio] size=12+16, flags=1
```

And verifying playback on iOS simulator.

Actions:
a) fix encryption for large files
b) clean up and support files < 4GB as they currently don't appear to be working

Cheers
