### PR TITLE
Fix broken compilations with MSYS MinGW since 5b14f8328

### DIFF
--- a/configure
+++ b/configure
@@ -583,18 +583,17 @@ EOF
         win32="yes"
         want_pic="no"
         #ugly patch for msys2 mingw32/mingw64 where toolchain is not properly setup
-        if [ -e /mingw64 ]; then
+        if [ x"$MSYSTEM" = x"MSYS" ] && [ -e /mingw64 ]; then
           extralibs="$extralibs -lws2_32 -lwinmm -limagehlp"
           CFLAGS="$CFLAGS -I/mingw64/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
           LDFLAGS="$LDFLAGS -L/mingw64/lib"
-        elif [ -e /mingw32 ]; then
+        elif [ x"$MSYSTEM" = x"MSYS" ] && [ -e /mingw32 ]; then
           extralibs="-L/mingw32/lib $extralibs -lws2_32 -lwinmm -limagehlp"
           CFLAGS="$CFLAGS -I/mingw32/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
           LDFLAGS="$LDFLAGS -L/mingw32/lib"
         else
           extralibs="$extralibs -lws2_32 -lwinmm -limagehlp"
           CFLAGS="$CFLAGS -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
-          echo "titi"
         fi
 		LDFLAGS="$LDFLAGS"
         if test "$cross_prefix" != "" ; then


### PR DESCRIPTION
The referenced commit broke compilations when both /mingw32 and
/mingw64 paths exist and people tried to compile 32-bit.