### PR TITLE
Win32 config h define

### DIFF
--- a/include/gpac/configuration.h
+++ b/include/gpac/configuration.h
@@ -33,7 +33,7 @@
   except for symbian32 which uses .mmp directives ... */
 
 /*Configuration for visual studio, 32/64 bits */
-#if defined(WIN32) && !defined(_WIN32_WCE)
+#if defined(_WIN32) && !defined(_WIN32_WCE)
 
 #ifndef GPAC_MP4BOX_MINI
 

--- a/src/utils/os_thread.c
+++ b/src/utils/os_thread.c
@@ -231,7 +231,7 @@ GF_Err gf_th_run(GF_Thread *t, u32 (*Run)(void *param), void *param)
 	t->_signal = gf_sema_new(1, 0);
 
 #ifdef WIN32
-	t->threadH = CreateThread(NULL,  t->stackSize, &(RunThread), (void *)t, 0, &id);
+	t->threadH = CreateThread(NULL, t->stackSize, &(RunThread), (void *)t, 0, &id);
 	if (t->threadH != NULL) {
 #ifdef _MSC_VER
 		/*add thread name for the msvc debugger*/


### PR DESCRIPTION
configuration.h should check for _WIN32, not the GPAC defined WIN32. …
…Otherwise external applications using GPAC also have to define WIN32.