### PR TITLE
microsoft smooth streaming mux missing boxes

### DIFF
--- a/include/gpac/base_coding.h
+++ b/include/gpac/base_coding.h
@@ -59,7 +59,7 @@ extern "C" {
  *\return size of the encoded Base64 buffer
  *\note the encoded data buffer is not NULL-terminated.
  */
-u32 gf_base64_encode(char *in_buffer, u32 in_buffer_size, char *out_buffer, u32 out_buffer_size);
+u32 gf_base64_encode(const char *in_buffer, u32 in_buffer_size, char *out_buffer, u32 out_buffer_size);
 /*!
  *\brief base64 decoder
  *

--- a/include/gpac/internal/isomedia_dev.h
+++ b/include/gpac/internal/isomedia_dev.h
@@ -2477,8 +2477,8 @@ typedef struct __traf_mss_timeext_box
 	u8 version;
 	u32 flags;
 
-	u64 absolute_time_in_10mhz;
-	u64 fragment_duration_in_10mhz;
+	u64 absolute_time_in_track_timescale;
+	u64 fragment_duration_in_track_timescale;
 } GF_MSSTimeExtBox;
 
 GF_PIFFSampleEncryptionBox *gf_isom_create_piff_psec_box(u8 version, u32 flags, u32 AlgorithmID, u8 IV_size, bin128 KID);

--- a/include/gpac/internal/isomedia_dev.h
+++ b/include/gpac/internal/isomedia_dev.h
@@ -430,6 +430,7 @@ enum
 
 	/*MS Smooth - these are actually UUID boxes*/
 	GF_ISOM_BOX_UUID_PSSH	= GF_4CC( 'P', 'S', 'S', 'H' ),
+	GF_ISOM_BOX_UUID_MSSM   = GF_4CC( 'M', 'S', 'S', 'M' ), /*Stream Manifest box*/
 	GF_ISOM_BOX_UUID_TENC	= GF_4CC( 'T', 'E', 'N', 'C' ),
 	GF_ISOM_BOX_UUID_TFRF	= GF_4CC( 'T', 'F', 'R', 'F' ),
 	GF_ISOM_BOX_UUID_TFXD	= GF_4CC( 'T', 'F', 'X', 'D' ),
@@ -485,6 +486,8 @@ typedef struct
 	char *data;
 	u32 dataSize;
 } GF_UnknownUUIDBox;
+
+u32 gf_isom_solve_uuid_box(char *UUID);
 
 typedef struct
 {
@@ -1800,6 +1803,7 @@ typedef struct
 
 	struct __piff_sample_enc_box *piff_sample_encryption;
 	struct __sample_encryption_box *sample_encryption;
+	struct __traf_mss_timeext_box *tfxd; /*similar to PRFT but for Smooth Streaming*/
 
 	/*when data caching is on*/
 	u32 DataCache;
@@ -2466,6 +2470,16 @@ typedef struct __sample_encryption_box
 	GF_SampleAuxiliaryInfoOffsetBox *cenc_saio;
 
 } GF_SampleEncryptionBox;
+
+typedef struct __traf_mss_timeext_box
+{
+	GF_ISOM_UUID_BOX
+	u8 version;
+	u32 flags;
+
+	u64 absolute_time_in_10mhz;
+	u64 fragment_duration_in_10mhz;
+} GF_MSSTimeExtBox;
 
 GF_PIFFSampleEncryptionBox *gf_isom_create_piff_psec_box(u8 version, u32 flags, u32 AlgorithmID, u8 IV_size, bin128 KID);
 GF_SampleEncryptionBox * gf_isom_create_samp_enc_box(u8 version, u32 flags);
@@ -3655,9 +3669,15 @@ GF_Err styp_Size(GF_Box *s);
 
 GF_Box *mehd_New();
 void mehd_del(GF_Box *s);
-GF_Err mehd_Read(GF_Box *s, GF_BitStream *bs);
 GF_Err mehd_Write(GF_Box *s, GF_BitStream *bs);
 GF_Err mehd_Size(GF_Box *s);
+
+/*smooth streaming timing*/
+GF_Box *tfxd_New();
+void tfxd_del(GF_Box *s);
+GF_Err tfxd_Read(GF_Box *s, GF_BitStream *bs);
+GF_Err tfxd_Write(GF_Box *s, GF_BitStream *bs);
+GF_Err tfxd_Size(GF_Box *s);
 
 #endif
 
@@ -4039,6 +4059,9 @@ GF_Err traf_dump(GF_Box *a, FILE * trace);
 GF_Err tfhd_dump(GF_Box *a, FILE * trace);
 GF_Err trun_dump(GF_Box *a, FILE * trace);
 GF_Err styp_dump(GF_Box *a, FILE * trace);
+
+//Smooth Streaming specific
+GF_Err tfxd_dump(GF_Box *a, FILE * trace);
 #endif
 
 GF_Err avcc_dump(GF_Box *a, FILE * trace);

--- a/include/gpac/isomedia.h
+++ b/include/gpac/isomedia.h
@@ -1081,7 +1081,7 @@ GF_Err gf_isom_remove_user_data_item(GF_ISOFile *the_file, u32 trackNumber, u32 
 /*remove track, moov (trackNumber=0) or file-level (trackNumber=0xFFFFFFFF) UUID box of matching type*/
 GF_Err gf_isom_remove_uuid(GF_ISOFile *movie, u32 trackNumber, bin128 UUID);
 /*adds track, moov (trackNumber=0) or file-level (trackNumber=0xFFFFFFFF) UUID box of given type*/
-GF_Err gf_isom_add_uuid(GF_ISOFile *movie, u32 trackNumber, bin128 UUID, char *data, u32 data_size);
+GF_Err gf_isom_add_uuid(GF_ISOFile *movie, u32 trackNumber, bin128 UUID, const char *data, u32 data_size);
 
 /*Add a user data item in the desired track or in the movie if TrackNumber is 0, using a serialzed buffer of ISOBMFF boxes*/
 GF_Err gf_isom_add_user_data_boxes(GF_ISOFile *the_file, u32 trackNumber, char *data, u32 DataLength);
@@ -1351,6 +1351,9 @@ GF_Err gf_isom_start_segment(GF_ISOFile *movie, const char *SegName, Bool memory
 
 /*sets the baseMediaDecodeTime of the first sample of the given track*/
 GF_Err gf_isom_set_traf_base_media_decode_time(GF_ISOFile *movie, u32 TrackID, u64 decode_time);
+
+/*sets Microsoft Smooth Streaming traf 'tfxd' box info, written at the end of each traf*/
+GF_Err gf_isom_set_traf_mss_timeext(GF_ISOFile *movie, u32 reference_track_ID, u64 ntp_in_10mhz, u64 traf_duration_in_10mhz);
 
 /*closes current segment - if fragments_per_sidx is <0, no sidx is used - if fragments_per_sidx is ==0, a single sidx is used
 timestamp_shift is the constant difference between media time and presentation time (derived from edit list)*/

--- a/include/gpac/version.h
+++ b/include/gpac/version.h
@@ -49,7 +49,7 @@
  */
 #define GPAC_VERSION          "0.6.2-DEV"
 #define GPAC_VERSION_MAJOR 7
-#define GPAC_VERSION_MINOR 2
+#define GPAC_VERSION_MINOR 3
 #define GPAC_VERSION_MICRO 0
 
 #include <gpac/revision.h>

--- a/src/export.cpp
+++ b/src/export.cpp
@@ -914,6 +914,7 @@
 #pragma comment (linker, EXPORT_SYMBOL(gf_isom_add_user_data_boxes) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_isom_remove_user_data) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_isom_remove_user_data_item) )
+#pragma comment (linker, EXPORT_SYMBOL(gf_isom_add_uuid) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_isom_use_compact_size) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_isom_set_brand_info) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_isom_modify_alternate_brand) )
@@ -1052,6 +1053,7 @@
 #pragma comment (linker, EXPORT_SYMBOL(gf_isom_start_fragment) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_isom_flush_fragments) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_isom_set_fragment_reference_time) )
+#pragma comment (linker, EXPORT_SYMBOL(gf_isom_set_traf_mss_timeext) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_isom_set_fragment_option) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_isom_set_single_moof_mode) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_isom_fragment_add_sample) )
@@ -1061,6 +1063,8 @@
 #pragma comment (linker, EXPORT_SYMBOL(gf_isom_start_segment) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_isom_close_segment) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_isom_set_traf_base_media_decode_time) )
+#pragma comment (linker, EXPORT_SYMBOL(gf_isom_set_next_moof_number) )
+#pragma comment (linker, EXPORT_SYMBOL(gf_isom_get_next_moof_number) )
 #endif
 
 #endif /*GPAC_DISABLE_ISOM_WRITE*/

--- a/src/isomedia/box_code_base.c
+++ b/src/isomedia/box_code_base.c
@@ -6327,6 +6327,62 @@ GF_Box *traf_New()
 
 #ifndef GPAC_DISABLE_ISOM_WRITE
 
+
+GF_Box *tfxd_New()
+{
+	ISOM_DECL_BOX_ALLOC(GF_MSSTimeExtBox, GF_ISOM_BOX_TYPE_UUID);
+	tmp->internal_4cc = GF_ISOM_BOX_UUID_TFXD;
+	return (GF_Box *)tmp;
+}
+
+void tfxd_del(GF_Box *s)
+{
+	gf_free(s);
+}
+
+
+GF_Err tfxd_Read(GF_Box *s, GF_BitStream *bs)
+{
+	GF_MSSTimeExtBox *ptr = (GF_MSSTimeExtBox *)s;
+	if (ptr->size<4) return GF_ISOM_INVALID_FILE;
+	ptr->version = gf_bs_read_u8(bs);
+	ptr->flags = gf_bs_read_u24(bs);
+	ptr->size -= 4;
+
+	if (ptr->version == 0x01) {
+		ptr->absolute_time_in_10mhz = gf_bs_read_u64(bs);
+		ptr->fragment_duration_in_10mhz = gf_bs_read_u64(bs);
+	} else {
+		ptr->absolute_time_in_10mhz = gf_bs_read_u32(bs);
+		ptr->fragment_duration_in_10mhz = gf_bs_read_u32(bs);
+	}
+
+	return GF_OK;
+}
+
+GF_Err tfxd_Write(GF_Box *s, GF_BitStream *bs)
+{
+	GF_Err e = GF_OK;
+	GF_MSSTimeExtBox *uuid = (GF_MSSTimeExtBox*)s;
+	e = gf_isom_box_write_header(s, bs);
+	if (e) return e;
+
+	gf_bs_write_u8(bs, 1);
+	gf_bs_write_u24(bs, 0);
+	gf_bs_write_u64(bs, uuid->absolute_time_in_10mhz);
+	gf_bs_write_u64(bs, uuid->fragment_duration_in_10mhz);
+
+	return GF_OK;
+}
+
+GF_Err tfxd_Size(GF_Box *s)
+{
+	GF_Err e = gf_isom_box_get_size(s);
+	if (e) return e;
+	s->size += 20;
+	return GF_OK;
+}
+
 GF_Err traf_Write(GF_Box *s, GF_BitStream *bs)
 {
 	GF_Err e;
@@ -6374,6 +6430,10 @@ GF_Err traf_Write(GF_Box *s, GF_BitStream *bs)
 
 	if (ptr->piff_sample_encryption) {
 		e = gf_isom_box_write((GF_Box *) ptr->piff_sample_encryption, bs);
+		if (e) return e;
+	}
+	if (ptr->tfxd) {
+		e = gf_isom_box_write((GF_Box *) ptr->tfxd, bs);
 		if (e) return e;
 	}
 
@@ -6438,10 +6498,13 @@ GF_Err traf_Size(GF_Box *s)
 		if (e) return e;
 		ptr->size += ptr->sample_encryption->size;
 	}
+	if (ptr->tfxd) {
+		e = gf_isom_box_size((GF_Box *)ptr->tfxd);
+		if (e) return e;
+		s->size += ptr->tfxd->size;
+	}
 	return gf_isom_box_array_size(s, ptr->TrackRuns);
 }
-
-
 
 #endif /*GPAC_DISABLE_ISOM_WRITE*/
 

--- a/src/isomedia/box_code_base.c
+++ b/src/isomedia/box_code_base.c
@@ -6350,11 +6350,11 @@ GF_Err tfxd_Read(GF_Box *s, GF_BitStream *bs)
 	ptr->size -= 4;
 
 	if (ptr->version == 0x01) {
-		ptr->absolute_time_in_10mhz = gf_bs_read_u64(bs);
-		ptr->fragment_duration_in_10mhz = gf_bs_read_u64(bs);
+		ptr->absolute_time_in_track_timescale = gf_bs_read_u64(bs);
+		ptr->fragment_duration_in_track_timescale = gf_bs_read_u64(bs);
 	} else {
-		ptr->absolute_time_in_10mhz = gf_bs_read_u32(bs);
-		ptr->fragment_duration_in_10mhz = gf_bs_read_u32(bs);
+		ptr->absolute_time_in_track_timescale = gf_bs_read_u32(bs);
+		ptr->fragment_duration_in_track_timescale = gf_bs_read_u32(bs);
 	}
 
 	return GF_OK;
@@ -6369,8 +6369,8 @@ GF_Err tfxd_Write(GF_Box *s, GF_BitStream *bs)
 
 	gf_bs_write_u8(bs, 1);
 	gf_bs_write_u24(bs, 0);
-	gf_bs_write_u64(bs, uuid->absolute_time_in_10mhz);
-	gf_bs_write_u64(bs, uuid->fragment_duration_in_10mhz);
+	gf_bs_write_u64(bs, uuid->absolute_time_in_track_timescale);
+	gf_bs_write_u64(bs, uuid->fragment_duration_in_track_timescale);
 
 	return GF_OK;
 }

--- a/src/isomedia/box_dump.c
+++ b/src/isomedia/box_dump.c
@@ -2740,7 +2740,7 @@ GF_Err tfxd_dump(GF_Box *a, FILE * trace)
 	GF_MSSTimeExtBox *ptr = (GF_MSSTimeExtBox*)a;
 	if (!a) return GF_BAD_PARAM;
 
-	fprintf(trace, "<MSSTimeExtensionBox AbsoluteTime=\""LLU"\" FragmentDuration=\""LLU"\">\n", ptr->absolute_time_in_10mhz, ptr->fragment_duration_in_10mhz);
+	fprintf(trace, "<MSSTimeExtensionBox AbsoluteTime=\""LLU"\" FragmentDuration=\""LLU"\">\n", ptr->absolute_time_in_track_timescale, ptr->fragment_duration_in_track_timescale);
 	DumpBox(a, trace);
 	fprintf(trace, "<FullBoxInfo Version=\"%d\" Flags=\"%d\"/>\n", ptr->version, ptr->flags);
 	gf_box_dump_done("MSSTimeExtensionBox", a, trace);

--- a/src/isomedia/box_dump.c
+++ b/src/isomedia/box_dump.c
@@ -534,8 +534,10 @@ GF_Err gf_box_dump_ex(void *ptr, FILE * trace, u32 box_4cc)
 			return piff_psec_dump(a, trace);
 		case GF_ISOM_BOX_UUID_PSSH:
 			return piff_pssh_dump(a, trace);
-		case GF_ISOM_BOX_UUID_TFRF:
 		case GF_ISOM_BOX_UUID_TFXD:
+			return tfxd_dump(a, trace);
+		case GF_ISOM_BOX_UUID_MSSM:
+		case GF_ISOM_BOX_UUID_TFRF:
 		default:
 			return defa_dump(a, trace);
 		}
@@ -2730,6 +2732,18 @@ GF_Err tfhd_dump(GF_Box *a, FILE * trace)
 	DumpBox(a, trace);
 	gf_full_box_dump(a, trace);
 	gf_box_dump_done("TrackFragmentHeaderBox", a, trace);
+	return GF_OK;
+}
+
+GF_Err tfxd_dump(GF_Box *a, FILE * trace)
+{
+	GF_MSSTimeExtBox *ptr = (GF_MSSTimeExtBox*)a;
+	if (!a) return GF_BAD_PARAM;
+
+	fprintf(trace, "<MSSTimeExtensionBox AbsoluteTime=\""LLU"\" FragmentDuration=\""LLU"\">\n", ptr->absolute_time_in_10mhz, ptr->fragment_duration_in_10mhz);
+	DumpBox(a, trace);
+	fprintf(trace, "<FullBoxInfo Version=\"%d\" Flags=\"%d\"/>\n", ptr->version, ptr->flags);
+	gf_box_dump_done("MSSTimeExtensionBox", a, trace);
 	return GF_OK;
 }
 

--- a/src/isomedia/box_funcs.c
+++ b/src/isomedia/box_funcs.c
@@ -64,6 +64,8 @@ u32 gf_isom_solve_uuid_box(char *UUID)
 	}
 	if (!strnicmp(strUUID, "8974dbce7be74c5184f97148f9882554", 32))
 		return GF_ISOM_BOX_UUID_TENC;
+	if (!strnicmp(strUUID, "A5D40B30E81411DDBA2F0800200C9A66", 32))
+		return GF_ISOM_BOX_UUID_MSSM;
 	if (!strnicmp(strUUID, "D4807EF2CA3946958E5426CB9E46A79F", 32))
 		return GF_ISOM_BOX_UUID_TFRF;
 	if (!strnicmp(strUUID, "6D1D9B0542D544E680E2141DAFF757B2", 32))
@@ -72,6 +74,7 @@ u32 gf_isom_solve_uuid_box(char *UUID)
 		return GF_ISOM_BOX_UUID_PSEC;
 	if (!strnicmp(strUUID, "D08A4F1810F34A82B6C832D8ABA183D3", 32))
 		return GF_ISOM_BOX_UUID_PSSH;
+
 	return 0;
 }
 
@@ -305,8 +308,14 @@ GF_Err gf_isom_box_write_header(GF_Box *ptr, GF_BitStream *bs)
 		case GF_ISOM_BOX_UUID_PSEC:
 			memcpy(strUUID, "A2394F525A9B4F14A2446C427C648DF4", 32);
 			break;
+		case GF_ISOM_BOX_UUID_MSSM:
+			memcpy(strUUID, "A5D40B30E81411DDBA2F0800200C9A66", 32);
+			break;
 		case GF_ISOM_BOX_UUID_PSSH:
 			memcpy(strUUID, "D08A4F1810F34A82B6C832D8ABA183D3", 32);
+			break;
+		case GF_ISOM_BOX_UUID_TFXD:
+			memcpy(strUUID, "6D1D9B0542D544E680E2141DAFF757B2", 32);
 			break;
 		default:
 			memset(strUUID, 0, 32);
@@ -723,8 +732,10 @@ GF_Box *gf_isom_box_new(u32 boxType)
 		return piff_psec_New();
 	case GF_ISOM_BOX_UUID_PSSH:
 		return piff_pssh_New();
-	case GF_ISOM_BOX_UUID_TFRF:
 	case GF_ISOM_BOX_UUID_TFXD:
+		return tfxd_New();
+	case GF_ISOM_BOX_UUID_MSSM:
+	case GF_ISOM_BOX_UUID_TFRF:
 	case GF_ISOM_BOX_TYPE_UUID:
 		return uuid_New();
 
@@ -1383,8 +1394,11 @@ void gf_isom_box_del(GF_Box *a)
 		case GF_ISOM_BOX_UUID_PSSH:
 			piff_pssh_del(a);
 			return;
-		case GF_ISOM_BOX_UUID_TFRF:
 		case GF_ISOM_BOX_UUID_TFXD:
+			tfxd_del(a);
+			return;
+		case GF_ISOM_BOX_UUID_MSSM:
+		case GF_ISOM_BOX_UUID_TFRF:
 		default:
 			uuid_del(a);
 			return;
@@ -1925,8 +1939,10 @@ GF_Err gf_isom_box_read(GF_Box *a, GF_BitStream *bs)
 			return piff_psec_Read(a, bs);
 		case GF_ISOM_BOX_UUID_PSSH:
 			return piff_pssh_Read(a, bs);
-		case GF_ISOM_BOX_UUID_TFRF:
 		case GF_ISOM_BOX_UUID_TFXD:
+			return tfxd_Read(a, bs);
+		case GF_ISOM_BOX_UUID_MSSM:
+		case GF_ISOM_BOX_UUID_TFRF:
 		default:
 			return uuid_Read(a, bs);
 		}
@@ -2415,8 +2431,10 @@ GF_Err gf_isom_box_write_listing(GF_Box *a, GF_BitStream *bs)
 			return piff_psec_Write(a, bs);
 		case GF_ISOM_BOX_UUID_PSSH:
 			return piff_pssh_Write(a, bs);
-		case GF_ISOM_BOX_UUID_TFRF:
 		case GF_ISOM_BOX_UUID_TFXD:
+			return tfxd_Write(a, bs);
+		case GF_ISOM_BOX_UUID_MSSM:
+		case GF_ISOM_BOX_UUID_TFRF:
 		default:
 			return uuid_Write(a, bs);
 		}
@@ -2908,8 +2926,10 @@ static GF_Err gf_isom_box_size_listing(GF_Box *a)
 			return piff_psec_Size(a);
 		case GF_ISOM_BOX_UUID_PSSH:
 			return piff_pssh_Size(a);
-		case GF_ISOM_BOX_UUID_TFRF:
 		case GF_ISOM_BOX_UUID_TFXD:
+			return tfxd_Size(a);
+		case GF_ISOM_BOX_UUID_MSSM:
+		case GF_ISOM_BOX_UUID_TFRF:
 		default:
 			return uuid_Size(a);
 		}

--- a/src/isomedia/isom_write.c
+++ b/src/isomedia/isom_write.c
@@ -4256,8 +4256,8 @@ GF_Err gf_isom_remove_uuid(GF_ISOFile *movie, u32 trackNumber, bin128 UUID)
 	return GF_OK;
 }
 
-
-GF_Err gf_isom_add_uuid(GF_ISOFile *movie, u32 trackNumber, bin128 UUID, char *data, u32 data_size)
+GF_EXPORT
+GF_Err gf_isom_add_uuid(GF_ISOFile *movie, u32 trackNumber, bin128 UUID, const char *data, u32 data_size)
 {
 	GF_List *list;
 	GF_UnknownUUIDBox *uuid;
@@ -4281,6 +4281,7 @@ GF_Err gf_isom_add_uuid(GF_ISOFile *movie, u32 trackNumber, bin128 UUID, char *d
 	GF_SAFEALLOC(uuid, GF_UnknownUUIDBox);
 	if (!uuid) return GF_OUT_OF_MEM;
 	uuid->type = GF_ISOM_BOX_TYPE_UUID;
+	uuid->internal_4cc = gf_isom_solve_uuid_box(UUID);
 	memcpy(uuid->uuid, UUID, sizeof(bin128));
 	uuid->dataSize = data_size;
 	uuid->data = (char*)gf_malloc(sizeof(char)*data_size);

--- a/src/isomedia/movie_fragments.c
+++ b/src/isomedia/movie_fragments.c
@@ -1608,6 +1608,25 @@ GF_Err gf_isom_set_fragment_reference_time(GF_ISOFile *movie, u32 reference_trac
 }
 
 GF_EXPORT
+GF_Err gf_isom_set_traf_mss_timeext(GF_ISOFile *movie, u32 reference_track_ID, u64 ntp_in_10mhz, u64 traf_duration_in_10mhz)
+{
+	u32 i;
+	if (!movie || !movie->moof)
+		return GF_BAD_PARAM;
+	for (i=0; i<gf_list_count(movie->moof->TrackList); i++) {
+		GF_TrackFragmentBox *traf = (GF_TrackFragmentBox*)gf_list_get(movie->moof->TrackList, i);
+		if (!traf)
+			return GF_BAD_PARAM;
+		if (traf->tfxd)
+			gf_isom_box_del(traf->tfxd);
+		traf->tfxd = (GF_MSSTimeExtBox *)gf_isom_box_new(GF_ISOM_BOX_UUID_TFXD);
+		traf->tfxd->absolute_time_in_10mhz = ntp_in_10mhz;
+		traf->tfxd->fragment_duration_in_10mhz = traf_duration_in_10mhz;
+	}
+	return GF_OK;
+}
+
+GF_EXPORT
 GF_Err gf_isom_start_fragment(GF_ISOFile *movie, Bool moof_first)
 {
 	u32 i, count;
@@ -2132,9 +2151,15 @@ GF_Err gf_isom_set_traf_base_media_decode_time(GF_ISOFile *movie, u32 TrackID, u
 	return GF_NOT_SUPPORTED;
 }
 
+GF_Err gf_isom_set_traf_mss_timeext(GF_ISOFile *movie, u32 reference_track_ID, u64 ntp_in_10mhz, u64 traf_duration_in_10mhz)
+{
+	return GF_NOT_SUPPORTED;
+}
+
 #endif /*GPAC_DISABLE_ISOM_FRAGMENTS)*/
 
 
+GF_EXPORT
 void gf_isom_set_next_moof_number(GF_ISOFile *movie, u32 value)
 {
 #ifndef GPAC_DISABLE_ISOM_FRAGMENTS
@@ -2142,6 +2167,7 @@ void gf_isom_set_next_moof_number(GF_ISOFile *movie, u32 value)
 #endif
 }
 
+GF_EXPORT
 u32 gf_isom_get_next_moof_number(GF_ISOFile *movie)
 {
 #ifndef GPAC_DISABLE_ISOM_FRAGMENTS

--- a/src/isomedia/movie_fragments.c
+++ b/src/isomedia/movie_fragments.c
@@ -1608,7 +1608,7 @@ GF_Err gf_isom_set_fragment_reference_time(GF_ISOFile *movie, u32 reference_trac
 }
 
 GF_EXPORT
-GF_Err gf_isom_set_traf_mss_timeext(GF_ISOFile *movie, u32 reference_track_ID, u64 ntp_in_10mhz, u64 traf_duration_in_10mhz)
+GF_Err gf_isom_set_traf_mss_timeext(GF_ISOFile *movie, u32 reference_track_ID, u64 ntp_in_track_timescale, u64 traf_duration_in_track_timescale)
 {
 	u32 i;
 	if (!movie || !movie->moof)
@@ -1618,10 +1618,10 @@ GF_Err gf_isom_set_traf_mss_timeext(GF_ISOFile *movie, u32 reference_track_ID, u
 		if (!traf)
 			return GF_BAD_PARAM;
 		if (traf->tfxd)
-			gf_isom_box_del(traf->tfxd);
+			gf_isom_box_del((GF_Box*)traf->tfxd);
 		traf->tfxd = (GF_MSSTimeExtBox *)gf_isom_box_new(GF_ISOM_BOX_UUID_TFXD);
-		traf->tfxd->absolute_time_in_10mhz = ntp_in_10mhz;
-		traf->tfxd->fragment_duration_in_10mhz = traf_duration_in_10mhz;
+		traf->tfxd->absolute_time_in_track_timescale = ntp_in_track_timescale;
+		traf->tfxd->fragment_duration_in_track_timescale = traf_duration_in_track_timescale;
 	}
 	return GF_OK;
 }

--- a/src/media_tools/isom_tools.c
+++ b/src/media_tools/isom_tools.c
@@ -3005,7 +3005,7 @@ GF_Err gf_media_fragment_file(GF_ISOFile *input, const char *output_file, Double
 
 				//end of track fragment or track
 				if ((tf->SampleNum==tf->SampleCount) ||
-				        /* TODO: should probably test the time position (not only duratino) to avoid drift */
+				        /* TODO: should probably test the time position (not only duration) to avoid drift */
 				        (tf->FragmentLength*1000 >= MaxFragmentDuration*tf->TimeScale)) {
 					gf_isom_sample_del(&next);
 					sample = next = NULL;

--- a/src/utils/base_encoding.c
+++ b/src/utils/base_encoding.c
@@ -31,7 +31,7 @@
 static const char base_64[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
 GF_EXPORT
-u32 gf_base64_encode(char *_in, u32 inSize, char *_out, u32 outSize)
+u32 gf_base64_encode(const char *_in, u32 inSize, char *_out, u32 outSize)
 {
 	s32 padding;
 	u32 i = 0, j = 0;


### PR DESCRIPTION
- add full tfxd support
- add mss manifest box (invented 'mssm' name)
- constify api (gf_base64_encode()) => bump minor api