### PR TITLE
Enlarge test coverage for dash segmenter

### DIFF
--- a/tests/scripts/dash.sh
+++ b/tests/scripts/dash.sh
@@ -6,6 +6,8 @@ do_test "$MP4BOX -add $MEDIA_DIR/auxiliary_files/enst_video.h264 -add $MEDIA_DIR
 
 do_test "$MP4BOX -dash 1000 $TEMP_DIR/file.mp4 -out $TEMP_DIR/file.mpd" "basic-dash"
 
+do_test "$MP4BOX -mpd-refresh 1000 -dash-ctx $TEMP_DIR/dash_ctx -dash-run-for 20000 -subdur 100 -dynamic -profile live -dash-live 100 $TEMP_DIR/file.mp4 -out $TEMP_DIR/file2.mpd" "dash-live"
+
 do_playback_test "$TEMP_DIR/file.mpd" "play"
 
 test_end


### PR DESCRIPTION
This commit improves the test coverage for the Dash Segmenter (src/media_tools/dash_segmenter.c).

Line coverage goes from 33.1% to 43.5%
Function coverage goes from 59.7 % to 66.7 %