### PR TITLE
Fix crash in mediacodec

### DIFF
--- a/modules/mediacodec_dec/mediacodec_dec.c
+++ b/modules/mediacodec_dec/mediacodec_dec.c
@@ -755,7 +755,7 @@ void DeleteMCDec(GF_BaseDecoder *ifcg)
         LOGE("AMediaFormat_delete failed");
     }
     
-    if(AMediaCodec_delete(ctx->codec) != AMEDIA_OK) {
+    if(ctx->codec && AMediaCodec_delete(ctx->codec) != AMEDIA_OK) {
         LOGE("AMediaCodec_delete failed");
     }
 


### PR DESCRIPTION
This commit fixes the crash in https://android.googlesource.com/platform/frameworks/av/+/0c3be87/media/ndk/NdkMediaCodec.cpp#104 when we pass NULL pointer to AMediaCodec_delete