### PR TITLE
Add test for mpeg-ts dash

### DIFF
--- a/tests/scripts/dash.sh
+++ b/tests/scripts/dash.sh
@@ -4,9 +4,13 @@ test_begin "dash"
 
 do_test "$MP4BOX -add $MEDIA_DIR/auxiliary_files/enst_video.h264 -add $MEDIA_DIR/auxiliary_files/enst_audio.aac -new $TEMP_DIR/file.mp4" "dash-input-preparation"
 
+do_test "$MP42TS -src $TEMP_DIR/file.mp4 -dst-file=$TEMP_DIR/file.ts" "ts-for-dash-input-preparation"
+
 do_test "$MP4BOX -dash 1000 $TEMP_DIR/file.mp4 -out $TEMP_DIR/file.mpd" "basic-dash"
 
-do_test "$MP4BOX -mpd-refresh 1000 -dash-ctx $TEMP_DIR/dash_ctx -dash-run-for 20000 -subdur 100 -dynamic -profile live -dash-live 100 $TEMP_DIR/file.mp4 -out $TEMP_DIR/file2.mpd" "dash-live"
+do_test "$MP4BOX -dash 1000 $TEMP_DIR/file.ts -out $TEMP_DIR/file2.mpd" "ts-dash"
+
+do_test "$MP4BOX -mpd-refresh 1000 -dash-ctx $TEMP_DIR/dash_ctx -dash-run-for 20000 -subdur 100 -dynamic -profile live -dash-live 100 $TEMP_DIR/file.mp4 -out $TEMP_DIR/file3.mpd" "dash-live"
 
 do_playback_test "$TEMP_DIR/file.mpd" "play"
 

--- a/tests/scripts/dash.sh
+++ b/tests/scripts/dash.sh
@@ -10,7 +10,7 @@ do_test "$MP4BOX -dash 1000 $TEMP_DIR/file.mp4 -out $TEMP_DIR/file.mpd" "basic-d
 
 do_test "$MP4BOX -dash 1000 $TEMP_DIR/file.ts -out $TEMP_DIR/file2.mpd" "ts-dash"
 
-do_test "$MP4BOX -mpd-refresh 1000 -dash-ctx $TEMP_DIR/dash_ctx -dash-run-for 20000 -subdur 100 -dynamic -profile live -dash-live 100 $TEMP_DIR/file.mp4 -out $TEMP_DIR/file3.mpd" "dash-live"
+do_test "$MP4BOX -bs-switching single -mpd-refresh 1000 -dash-ctx $TEMP_DIR/dash_ctx -dash-run-for 20000 -subdur 100 -dynamic -profile live -dash-live 100 $TEMP_DIR/file.mp4 -out $TEMP_DIR/file3.mpd" "dash-live"
 
 do_playback_test "$TEMP_DIR/file.mpd" "play"
 


### PR DESCRIPTION
This commit enhance code coverage in dash segmenter:

Line coverage goes from 43.5 % to 58.7 %
Function coverage goes from 66.7 % to 84.7 %