### PR TITLE
Tests improvement

### DIFF
--- a/tests/scripts/dash-live.sh
+++ b/tests/scripts/dash-live.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+test_begin "dash-live"
+
+do_test "$MP4BOX -add $EXTERNAL_MEDIA_DIR/counter/counter-10mn_I25_baseline_1280x720_512kbps.264:dur=5 -add $EXTERNAL_MEDIA_DIR/counter/counter-10mn_audio.aac:dur=5 -new $TEMP_DIR/file.mp4" "dash-input-preparation"
+
+do_test "$MP4BOX -bs-switching single -mpd-refresh 10 -dash-ctx $TEMP_DIR/dash_ctx -dash-run-for 10000 -dynamic -profile live -dash-live 40  $TEMP_DIR/file.mp4 -out $TEMP_DIR/file.mpd" "dash-live" &
+
+sleep 1
+
+do_playback_test "$TEMP_DIR/file.mpd" "play-basic-dash"
+
+test_end
+

--- a/tests/scripts/dash-ts.sh
+++ b/tests/scripts/dash-ts.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+test_begin "dash-ts"
+
+do_test "$MP4BOX -add $EXTERNAL_MEDIA_DIR/counter/counter-10mn_I25_baseline_1280x720_512kbps.264 -add $EXTERNAL_MEDIA_DIR/counter/counter-10mn_audio.aac -new $TEMP_DIR/file.mp4" "ts-for-dash-input-preparation"
+
+do_test "$MP42TS -src $TEMP_DIR/file.mp4 -dst-file=$TEMP_DIR/file.ts" "ts-for-dash-input-preparation-2"
+
+do_test "$MP4BOX -dash 1000 $TEMP_DIR/file.ts -out $TEMP_DIR/file.mpd" "ts-dash"
+
+do_playback_test "$TEMP_DIR/file.mpd" "play-ts-dash"
+
+test_end

--- a/tests/scripts/dash.sh
+++ b/tests/scripts/dash.sh
@@ -2,15 +2,9 @@
 
 test_begin "dash"
 
-do_test "$MP4BOX -add $MEDIA_DIR/auxiliary_files/enst_video.h264 -add $MEDIA_DIR/auxiliary_files/enst_audio.aac -new $TEMP_DIR/file.mp4" "dash-input-preparation"
+do_test "$MP4BOX -add $EXTERNAL_MEDIA_DIR/counter/counter-10mn_I25_baseline_1280x720_512kbps.264 -add $EXTERNAL_MEDIA_DIR/counter/counter-10mn_audio.aac -new $TEMP_DIR/file.mp4" "dash-input-preparation"
 
-do_test "$MP42TS -src $TEMP_DIR/file.mp4 -dst-file=$TEMP_DIR/file.ts" "ts-for-dash-input-preparation"
-
-do_test "$MP4BOX -dash 1000 $TEMP_DIR/file.mp4 -out $TEMP_DIR/file.mpd" "basic-dash"
-
-do_test "$MP4BOX -dash 1000 $TEMP_DIR/file.ts -out $TEMP_DIR/file2.mpd" "ts-dash"
-
-do_test "$MP4BOX -bs-switching single -mpd-refresh 1000 -dash-ctx $TEMP_DIR/dash_ctx -dash-run-for 20000 -subdur 100 -dynamic -profile live -dash-live 100 $TEMP_DIR/file.mp4 -out $TEMP_DIR/file3.mpd" "dash-live"
+do_test "$MP4BOX -dash 1000 -profile live $TEMP_DIR/file.mp4 -out $TEMP_DIR/file.mpd" "basic-dash"
 
 do_playback_test "$TEMP_DIR/file.mpd" "play-basic-dash"
 


### PR DESCRIPTION
This commit splits the previous dash tests in several files and use files with regular GoP.
The dash-live test is also more accurate (using a forked process).

The following tests are ok on my debian machine:

./make_test.sh -v scripts/dash.sh
./make_test.sh -v scripts/dash-live.sh
./make_test.sh -v scripts/dash-ts.sh
 