### PR TITLE
[Osmo4] Some improvement on the Android menu and 360 navigation

### DIFF
--- a/applications/osmo4_android_studio/app/src/main/java/com/gpac/Osmo4/Osmo4.java
+++ b/applications/osmo4_android_studio/app/src/main/java/com/gpac/Osmo4/Osmo4.java
@@ -243,9 +243,7 @@ public class Osmo4 extends Activity implements GpacCallback {
 		new GestureDetector.SimpleOnGestureListener() {
 			@Override
 			public boolean onSingleTapUp(MotionEvent e) {
-				boolean visible = (mDecorView.getSystemUiVisibility()
-								   & View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) == 0;
-				if (visible) {
+				if (uivisible) {
 					hideSystemUI();
 				} 
 				return true;

--- a/applications/osmo4_android_studio/app/src/main/java/com/gpac/Osmo4/Osmo4.java
+++ b/applications/osmo4_android_studio/app/src/main/java/com/gpac/Osmo4/Osmo4.java
@@ -258,7 +258,6 @@ public class Osmo4 extends Activity implements GpacCallback {
             }
         });
 
-       showSystemUI();
 		mGLView = new Osmo4GLSurfaceView(this);
 		
 		gl_view = (LinearLayout)findViewById(R.id.surface_gl);
@@ -1326,18 +1325,11 @@ public class Osmo4 extends Activity implements GpacCallback {
 
     private void hideSystemUI() {
         mDecorView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-										 | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
 										 | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
 										 | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
 										 | View.SYSTEM_UI_FLAG_FULLSCREEN
 										 | View.SYSTEM_UI_FLAG_LOW_PROFILE
 										 | View.SYSTEM_UI_FLAG_IMMERSIVE);
-    }
-
-    private void showSystemUI() {
-        mDecorView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-										 | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-										 | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
     }
 
     private final Handler mHideHandler = new Handler() {

--- a/applications/osmo4_android_studio/app/src/main/java/com/gpac/Osmo4/Osmo4.java
+++ b/applications/osmo4_android_studio/app/src/main/java/com/gpac/Osmo4/Osmo4.java
@@ -131,6 +131,8 @@ public class Osmo4 extends Activity implements GpacCallback {
 
     private final static int DEFAULT_BUFFER_SIZE = 8192;
 
+    private static boolean uivisible;
+
     private GpacConfig gpacConfig;
 
     /**
@@ -223,6 +225,19 @@ public class Osmo4 extends Activity implements GpacCallback {
 		
 		final View contentView = (LinearLayout)findViewById(R.id.surface_gl);
 		mDecorView =  getWindow().getDecorView();
+
+	mDecorView.setOnSystemUiVisibilityChangeListener
+		(new View.OnSystemUiVisibilityChangeListener() {
+	    @Override
+	    public void onSystemUiVisibilityChange(int visibility) {
+		if ((visibility & View.SYSTEM_UI_FLAG_FULLSCREEN) == 0) {
+			uivisible = true;
+		} else {
+			uivisible = false;
+		}
+	    }
+	});
+
 		contentView.setClickable(true);
         final GestureDetector clickDetector = new GestureDetector(this,
 		new GestureDetector.SimpleOnGestureListener() {
@@ -462,6 +477,10 @@ public class Osmo4 extends Activity implements GpacCallback {
 		}
 
     // ---------------------------------------
+
+    public static boolean isUIvisible(){
+	return uivisible;
+    }
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {

--- a/applications/osmo4_android_studio/app/src/main/java/com/gpac/Osmo4/Osmo4GLSurfaceView.java
+++ b/applications/osmo4_android_studio/app/src/main/java/com/gpac/Osmo4/Osmo4GLSurfaceView.java
@@ -59,16 +59,19 @@ public class Osmo4GLSurfaceView extends GLSurfaceView implements GPACInstanceInt
     // ------------------------------------
     @Override
     public boolean onTouchEvent(final MotionEvent event) {
-        queueEvent(new Runnable() {
+	if(!Osmo4.isUIvisible()){
+		queueEvent(new Runnable() {
 
-            @Override
-            public void run() {
-                GPACInstance instance = getInstance();
-                if (instance != null)
-                    instance.motionEvent(event);
-            }
-        });
-        return true;
+		    @Override
+		    public void run() {
+		        GPACInstance instance = getInstance();
+		        if (instance != null)
+		            instance.motionEvent(event);
+		    }
+		});
+		return true;
+	}
+    return false;
     }
 
     /**

--- a/include/gpac/options.h
+++ b/include/gpac/options.h
@@ -322,6 +322,8 @@ enum
 	GF_OPT_NUM_STEREO_VIEWS,
 	/*set the mode of display of HEVC multiview videos, 0 to display the two views/layers and 1 to display just the first view/layer*/
 	GF_OPT_MULTIVIEW_MODE,
+	/*get orientation sensors flag, true if sensors are activated false if not*/
+	GF_OPT_ORIENTATION_SENSORS_ACTIVE,
 };
 
 /*! @} */

--- a/src/compositor/navigate.c
+++ b/src/compositor/navigate.c
@@ -384,6 +384,7 @@ static Bool compositor_handle_navigation_3d(GF_Compositor *compositor, GF_Event 
 
 	/* note: shortcuts are mostly the same as blaxxun contact, I don't feel like remembering 2 sets...*/
 	case GF_EVENT_MOUSEMOVE:
+		if (gf_term_get_option(compositor->term, GF_OPT_ORIENTATION_SENSORS_ACTIVE)) return 0;
 		if (!compositor->navigation_state) {
 			if (cam->navigate_mode==GF_NAVIGATE_GAME) {
 				/*init mode*/

--- a/src/terminal/terminal.c
+++ b/src/terminal/terminal.c
@@ -1101,7 +1101,8 @@ u32 gf_term_get_option(GF_Terminal * term, u32 type)
 		return gf_dm_get_data_rate(term->downloader);
 	case GF_OPT_VIDEO_BENCH:
 		return term->bench_mode ? GF_TRUE : GF_FALSE;
-
+	case GF_OPT_ORIENTATION_SENSORS_ACTIVE:
+		return term->orientation_sensors_active;
 	default:
 		return gf_sc_get_option(term->compositor, type);
 	}


### PR DESCRIPTION
- On the touch event hide the android menu first if it is visible, otherwise hide/show the GUI.
- Disable 360 mouse/touch navigation if orientation sensors are enabled.
- Make content (Video and GUI) appear above the navigation bar.