### PR TITLE
fix some bugs with file/path extensions

### DIFF
--- a/applications/mp4box/main.c
+++ b/applications/mp4box/main.c
@@ -4211,19 +4211,22 @@ int mp4boxMain(int argc, char **argv)
 
 
 	strcpy(outfile, outName ? outName : inName);
-	if (strrchr(outfile, '.')) {
-		char *szExt = strrchr(outfile, '.');
+	if (outfile) {
 
-		/*turn on 3GP saving*/
-		if (!stricmp(szExt, ".3gp") || !stricmp(szExt, ".3gpp") || !stricmp(szExt, ".3g2"))
-			conv_type = GF_ISOM_CONV_TYPE_3GPP;
-		else if (!stricmp(szExt, ".m4a") || !stricmp(szExt, ".m4v"))
-			conv_type = GF_ISOM_CONV_TYPE_IPOD;
-		else if (!stricmp(szExt, ".psp"))
-			conv_type = GF_ISOM_CONV_TYPE_PSP;
+		char *szExt = gf_file_ext_start(outfile);
 
-		while (outfile[strlen(outfile)-1] != '.') outfile[strlen(outfile)-1] = 0;
-		outfile[strlen(outfile)-1] = 0;
+		if (szExt)
+		{
+			/*turn on 3GP saving*/
+			if (!stricmp(szExt, ".3gp") || !stricmp(szExt, ".3gpp") || !stricmp(szExt, ".3g2"))
+				conv_type = GF_ISOM_CONV_TYPE_3GPP;
+			else if (!stricmp(szExt, ".m4a") || !stricmp(szExt, ".m4v"))
+				conv_type = GF_ISOM_CONV_TYPE_IPOD;
+			else if (!stricmp(szExt, ".psp"))
+				conv_type = GF_ISOM_CONV_TYPE_PSP;
+
+			*szExt = 0;
+		}
 	}
 
 #ifndef GPAC_DISABLE_MEDIA_EXPORT

--- a/include/gpac/tools.h
+++ b/include/gpac/tools.h
@@ -43,7 +43,7 @@ extern "C" {
 
 /*! \defgroup utils_grp Core Tools
  *	\brief Core definitions and tools of GPAC.
- *	
+ *
  * You will find in this module the documentation of the core tools used in GPAC.
 */
 
@@ -164,6 +164,15 @@ u64 gf_ftell(FILE *f);
  *	\note You only need to call this function if you're suspecting the file to be a large one (usually only media files), otherwise use regular stdio.
 */
 u64 gf_fseek(FILE *f, s64 pos, s32 whence);
+
+/*!
+ *	\brief get extension from filename
+ *
+ *	Returns a pointer to the start of a filepath extension or null
+ *	\param filename Path of the file, can be an absolute path
+*/
+char* gf_file_ext_start(const char* filename);
+
 
 /*! @} */
 

--- a/src/export.cpp
+++ b/src/export.cpp
@@ -88,6 +88,7 @@
 #pragma comment (linker, EXPORT_SYMBOL(gf_fseek) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_ftell) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_file_exists) )
+#pragma comment (linker, EXPORT_SYMBOL(gf_file_ext_start) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_prompt_has_input) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_prompt_get_char) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_prompt_set_echo_off) )

--- a/src/media_tools/media_export.c
+++ b/src/media_tools/media_export.c
@@ -468,10 +468,12 @@ GF_Err gf_media_export_samples(GF_MediaExporter *dumper)
 	}
 	if (dumper->flags & GF_EXPORT_PROBE_ONLY) return GF_OK;
 
-	ext_start = strrchr(dumper->out_name, '.');
-
-	if (dumper->out_name && !strcmp(dumper->out_name, "std"))
+	if (!strcmp(dumper->out_name, "std"))
 		is_stdout = 1;
+	else
+		ext_start = gf_file_ext_start(dumper->out_name);
+
+
 
 	gf_isom_set_nalu_extract_mode(dumper->file, track, GF_ISOM_NALU_EXTRACT_TILE_ONLY | GF_ISOM_NALU_EXTRACT_ANNEXB_FLAG);
 
@@ -731,7 +733,7 @@ static const char *QCP_SMV_GUID = "\x75\x2B\x7C\x8D\x97\xA7\x46\xED\x98\x5E\xD5\
 			gf_bs_write_u32(bs, 1); \
 			gf_bs_write_data(bs, sl->data, sl->size); \
 		} \
- 
+
 #define DUMP_HEVCPARAM(_params) \
 	count = gf_list_count(_params->param_array); \
 	for (i=0;i<count;i++) { \
@@ -743,7 +745,7 @@ static const char *QCP_SMV_GUID = "\x75\x2B\x7C\x8D\x97\xA7\x46\xED\x98\x5E\xD5\
 			gf_bs_write_data(bs, sl->data, sl->size); \
 		} \
 	} \
- 
+
 
 GF_Err gf_media_export_native(GF_MediaExporter *dumper)
 {
@@ -3146,4 +3148,3 @@ GF_Err gf_media_export(GF_MediaExporter *dumper)
 }
 
 #endif /*GPAC_DISABLE_MEDIA_EXPORT*/
-

--- a/src/utils/os_file.c
+++ b/src/utils/os_file.c
@@ -253,7 +253,7 @@ GF_Err gf_move_file(const char *fileName, const char *newFileName)
 #else
 	e = (system(cmd) == 0) ? GF_OK : GF_IO_ERR;
 #endif
-	
+
 error:
 	gf_free(arg1);
 	gf_free(arg2);
@@ -769,3 +769,24 @@ size_t gf_fwrite(const void *ptr, size_t size, size_t nmemb,
 	return result;
 }
 
+
+/**
+  * Returns a pointer to the start of a filepath extension or null
+ **/
+GF_EXPORT
+char* gf_file_ext_start(const char* filename)
+{
+	char* res = NULL;
+	if (filename) {
+
+		const char* lastPathPart = strrchr(filename , GF_PATH_SEPARATOR);
+		if (!lastPathPart)
+			lastPathPart = filename;
+		else
+			lastPathPart++;
+
+		res = strrchr(lastPathPart, '.');
+
+	}
+	return res;
+}

--- a/src/utils/os_file.c
+++ b/src/utils/os_file.c
@@ -780,6 +780,17 @@ char* gf_file_ext_start(const char* filename)
 	if (filename) {
 
 		const char* lastPathPart = strrchr(filename , GF_PATH_SEPARATOR);
+		if (GF_PATH_SEPARATOR != '/')
+		{
+			// windows paths can mix slashes and backslashes
+			// so we search for the last slash that occurs after the last backslash
+			// if it occurs before it's not relevant
+			// if there's no backslashes we search in the whole file path
+
+			const char* trailingSlash = strrchr(lastPathPart?lastPathPart:filename, '/');
+			if (trailingSlash)
+				lastPathPart = trailingSlash;
+		}
 		if (!lastPathPart)
 			lastPathPart = filename;
 		else

--- a/tests/make_tests.sh
+++ b/tests/make_tests.sh
@@ -18,7 +18,7 @@ EXTERNAL_MEDIA_AVAILABLE=1
 platform=`uname -s`
 main_dir=`pwd`
 # May be needed in some particular mingw cases
-#case $platform in MINGW*) 
+#case $platform in MINGW*)
 #  main_dir=`pwd -W | sed 's|/|\\\\|g'`
 #  echo $main_dir
 #esac
@@ -351,7 +351,7 @@ else
 fi
 
 #test for GNU time
-$GNU_TIME ls 2> /dev/null  
+$GNU_TIME ls 2> /dev/null
 res=$?
 if [ $res != 0 ] ; then
 log $L_ERR "GNU time not found (ret $res) - exiting"
@@ -416,7 +416,7 @@ if [ $res != 0 ] ; then
 MP4CLIENT_NOT_FOUND=1
 echo ""
 log $L_WAR "WARNING: MP4Client not found (ret $res) - disabling all playback tests - launch results:"
-MP4Client -run-for 0 
+MP4Client -run-for 0
 res=$?
 echo ""
 echo "** MP4Client returned $res - dumping GPAC config file **"
@@ -449,7 +449,7 @@ else
 fi
 
 #end check_only
-fi 
+fi
 
 #check for afl-fuzz
 if [ $enable_fuzzing != 0 ] ; then
@@ -466,7 +466,7 @@ if [ $enable_fuzzing != 0 ] ; then
   $GNU_TIMEOUT 3.0 afl-fuzz -d -i tmpafi -o tmpafo MP4Box -h > /dev/null
   if [ $? != 0 ] ; then
    log $L_WAR "afl-fuzz not properly configure:"
-   afl-fuzz -d -i tmpafi -o tmpafo MP4Box -h 
+   afl-fuzz -d -i tmpafi -o tmpafo MP4Box -h
    exit
   else
    log $L_INF "afl-fuzz found and OK - enabling fuzzing with duration $fuzz_duration"
@@ -815,16 +815,16 @@ do_fuzz()
    if [ $no_fuzz_cleanup = 0 ] ; then
     #rename all crashes and hangs
     cd out/crashes
-    ls | cat -n | while read n f; do mv "$f" "$fuzz_res_dir/crash_$n.$file_ext"; done 
+    ls | cat -n | while read n f; do mv "$f" "$fuzz_res_dir/crash_$n.$file_ext"; done
     cd ../hangs
-    ls | cat -n | while read n f; do mv "$f" "$fuzz_res_dir/hang_$n.$file_ext"; done 
+    ls | cat -n | while read n f; do mv "$f" "$fuzz_res_dir/hang_$n.$file_ext"; done
     cd ../..
     rm -f "$fuzz_res_dir/readme.txt"
    fi
   fi
 
   cd $orig_path
- 
+
   if [ $no_fuzz_cleanup = 0 ] ; then
    rm -rf $fuzz_temp_dir
 
@@ -883,11 +883,11 @@ do_test ()
  #so each successfull afl-fuzz test (not call!) will modify the input...
  if [ $fuzz_test != 0 ] ; then
   fuzz_dir="$LOCAL_OUT_DIR/fuzzing/$TEST_NAME_$SUBTEST_NAME/"
-  mkdir -p fuzz_dir 
+  mkdir -p fuzz_dir
   fuzz_sub_idx=1
   for word in $1 ; do
    is_file_arg=0
-   case "$word" in 
+   case "$word" in
      $main_dir/*)
       is_file_arg=1;;
    esac
@@ -900,7 +900,7 @@ do_test ()
     fi
    fi
   done
-  
+
   if [ $no_fuzz_cleanup = 0 ] ; then
    crashes=`ls $fuzz_dir | wc -w`
    if [ $crashes = 0 ] ; then


### PR DESCRIPTION
at several places in the code, when checking for a file extension, we only do something like `strrchr(outfile, '.');`

however this doesn't work with a full path that contains directory names with a dot and a file without it

e.g.: 

`mp4box -logs all@debug -raws 1 test.extension\noext`

will write to the wrong path

and

`mp4box -logs all@debug -raws 1 test.extension\meta-metx.mp4`

will fail when trying to check the extension for `test.extension\meta-metx_track1`

I added a `gf_file_ext_start()` function to get the extension while taking the path into account, and fixed the 2 cases above. There are other places that can use this function that I haven't tested yet. 
