### PR TITLE
Fixmpegtsdash

### DIFF
--- a/src/media_tools/dash_segmenter.c
+++ b/src/media_tools/dash_segmenter.c
@@ -4412,8 +4412,7 @@ static GF_Err dasher_mp2t_segment_file(GF_DashSegInput *dash_input, const char *
 		FILE *in, *out;
 		u64 fsize, done;
 		char buf[NB_TSPCK_IO_BYTES];
-
-		gf_media_mpd_format_segment_name(GF_DASH_TEMPLATE_SEGMENT, GF_TRUE, SegName, dash_cfg->seg_rad_name ? basename : szOutName, dash_input->representationID, dash_input->baseURL ? dash_input->baseURL[0] : NULL, gf_dasher_strip_output_dir(dash_cfg->mpd_name, dash_cfg->seg_rad_name), "ts", 0, bandwidth, segment_index, dash_cfg->use_segment_timeline);
+		gf_media_mpd_format_segment_name(GF_DASH_TEMPLATE_SEGMENT, GF_TRUE, SegName, szOutName, dash_input->representationID, dash_input->baseURL ? dash_input->baseURL[0] : NULL, dash_cfg->seg_rad_name, "ts", 0, bandwidth, segment_index, dash_cfg->use_segment_timeline);
 		out = gf_fopen(SegName, "wb");
 		if (!out) {
 			GF_LOG(GF_LOG_ERROR, GF_LOG_DASH, ("[DASH] Cannot create segment file %s\n", SegName));

--- a/tests/scripts/dash-ts.sh
+++ b/tests/scripts/dash-ts.sh
@@ -6,8 +6,12 @@ do_test "$MP4BOX -add $EXTERNAL_MEDIA_DIR/counter/counter_30s_I25_baseline_1280x
 
 do_test "$MP42TS -src $TEMP_DIR/file.mp4 -dst-file=$TEMP_DIR/file.ts" "ts-for-dash-input-preparation-2"
 
-do_test "$MP4BOX -dash 1000 $TEMP_DIR/file.ts -out $TEMP_DIR/file.mpd" "ts-dash"
+do_test "$MP4BOX -dash 1000 -rap -single-file -segment-name myrep/ts-segment-single-f-\$RepresentationID\$ $TEMP_DIR/file.ts -out $TEMP_DIR/file1.mpd" "ts-dash-single-file"
 
-do_playback_test "$TEMP_DIR/file.mpd" "play-ts-dash"
+do_playback_test "$TEMP_DIR/file1.mpd" "play-ts-dash-single-file"
+
+do_test "$MP4BOX -dash 1000 -rap -segment-name myrep/ts-segment-multiple-f-\$RepresentationID\$ $TEMP_DIR/file.ts -out $TEMP_DIR/file2.mpd" "ts-dash-multiple-file"
+
+do_playback_test "$TEMP_DIR/file2.mpd" "play-ts-dash-multisegment"
 
 test_end


### PR DESCRIPTION
This PR increases the code coverage by testing relative path in segment name and testing singlefile mode in MPEGTS Dashing.

Moreover, it seems to fix the issue #736.