### PR TITLE
Fix relative paths

### DIFF
--- a/src/odf/odf_dump.c
+++ b/src/odf/odf_dump.c
@@ -1697,11 +1697,7 @@ GF_Err gf_odf_dump_muxinfo(GF_MuxInfo *mi, FILE *trace, u32 indent, Bool XMTDump
 {
 	char *full_path = NULL;
 
-	if (mi->file_name && mi->src_url) {
-		if (strchr(mi->src_url, '/') || strchr(mi->src_url, '\\')) {
-			full_path = gf_url_concatenate(mi->src_url, mi->file_name);
-		}
-	}
+	full_path = gf_url_get_absolute_path( mi->file_name, mi->src_url );
 
 	if (!XMTDump) {
 		StartDescDump(trace, "MuxInfo", indent, GF_FALSE);

--- a/src/utils/url.c
+++ b/src/utils/url.c
@@ -60,17 +60,17 @@ static u32 URL_GetProtocolType(const char *pathName)
 	//conditions for a file path to be absolute:
 	// - on posix: absolute iif starts with '/'
 	// - on windows: absolute if
-	// 		* starts with \ or / (current drive)
-	//		* OR starts with <LETTER>: and then \ or /
-	//		* OR starts with \\host\share\<path> [NOT HANDLED HERE]
+	//	* starts with \ or / (current drive)
+	//	* OR starts with <LETTER>: and then \ or /
+	//	* OR starts with \\host\share\<path> [NOT HANDLED HERE]
 #ifndef WIN32
 	if (pathName[0] == '/')
 #else
 	if ( (pathName[0] == '/') || (pathName[0] == '\\')
-			|| ( strlen(pathName)>2 && pathName[1]==':'
-					&& ((pathName[2] == '/') || (pathName[2] == '\\'))
-				)
-		)
+		|| ( strlen(pathName)>2 && pathName[1]==':'
+			&& ((pathName[2] == '/') || (pathName[2] == '\\'))
+		   )
+	   )
 #endif
 		return GF_URL_TYPE_FILE_PATH;
 
@@ -115,14 +115,17 @@ char *gf_url_get_absolute_path(const char *pathName, const char *parentPath)
 			pathName += 6; // keep a slash in case it's forgotten
 
 			/* Windows file URIs SHOULD BE in the form "file:///C:\..."
-			/* Unix file URIs SHOULD BE in the form "file:///home..."
+			 * Unix file URIs SHOULD BE in the form "file:///home..."
 			 * anything before the 3rd '/' is a hostname
 			*/
 			sep = strchr(pathName+1, '/');
 			if (sep) {
 				pathName = sep;
-				if (strlen(pathName) > 2 && pathName[2]==':')	// dirty way to say if windows
-					pathName++;									// consume the third / in that case
+
+				// dirty way to say if windows
+				// consume the third / in that case
+				if (strlen(pathName) > 2 && pathName[2]==':')
+					pathName++;
 			}
 			res = gf_strdup(pathName);
 			break;


### PR DESCRIPTION
This PR does some dusting in the handling of relative paths. 

Most notably, it fixes the following scenario: 

the test file `tests/media/bifs/bifs-2D-background-background2D-movie.bt` contains 

```
      muxInfo MuxInfo {
       fileName "../auxiliary_files/enst_video.h264"
      }
```

if we export it to xmt with 

`mp4box -xmt media/bifs/bifs-2D-background-background2D-movie.bt`

it will wrongly try to "resolve" the relative path, resulting in 

`        <StreamSource url="media/auxiliary_files/enst_video.h264" >`

After that, doing

` MP4Box -mp4 media/bifs/bifs-2D-background-background2D-movie.xmt`

will fail because it's trying to open `media/bifs/media/auxiliary_files/enst_video.h264` instead of  `media/auxiliary_files/enst_video.h264`


With this PR, the same command outputs: 

`        <StreamSource url="../auxiliary_files/enst_video.h264" >`

and the next command can run. 