### PR TITLE
small things for mobile builds

### DIFF
--- a/build/xcode/generate_ios.sh
+++ b/build/xcode/generate_ios.sh
@@ -32,6 +32,9 @@ fi
 echo "*** Generate IPA ***"
 mkdir -p Payload
 mv osmo4ios.xcarchive/Products/Applications/osmo4ios.app Payload/
+if [ ! -d "../../bin/iOS" ]; then
+	mkdir -p "../../bin/iOS"
+fi
 zip -r "../../bin/iOS/osmo4-$full_version-ios.ipa" Payload
 rm -rf Payload
 rm -rf osmo4ios.xcarchive

--- a/build/xcode/gpac4ios.xcodeproj/xcshareddata/xcschemes/libgpac_static.xcscheme
+++ b/build/xcode/gpac4ios.xcodeproj/xcshareddata/xcschemes/libgpac_static.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0820"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "71CCF1301277037A00339E12"
+               BuildableName = "libgpac_static.a"
+               BlueprintName = "libgpac_static"
+               ReferencedContainer = "container:gpac4ios.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "71CCF1301277037A00339E12"
+            BuildableName = "libgpac_static.a"
+            BlueprintName = "libgpac_static"
+            ReferencedContainer = "container:gpac4ios.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "71CCF1301277037A00339E12"
+            BuildableName = "libgpac_static.a"
+            BlueprintName = "libgpac_static"
+            ReferencedContainer = "container:gpac4ios.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/build/xcode/gpac4ios.xcodeproj/xcshareddata/xcschemes/osmo4ios.xcscheme
+++ b/build/xcode/gpac4ios.xcodeproj/xcshareddata/xcschemes/osmo4ios.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0820"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "71A19B1912796B5600ACFF58"
+               BuildableName = "osmo4ios.app"
+               BlueprintName = "osmo4ios"
+               ReferencedContainer = "container:gpac4ios.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "71A19B1912796B5600ACFF58"
+            BuildableName = "osmo4ios.app"
+            BlueprintName = "osmo4ios"
+            ReferencedContainer = "container:gpac4ios.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "71A19B1912796B5600ACFF58"
+            BuildableName = "osmo4ios.app"
+            BlueprintName = "osmo4ios"
+            ReferencedContainer = "container:gpac4ios.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "71A19B1912796B5600ACFF58"
+            BuildableName = "osmo4ios.app"
+            BlueprintName = "osmo4ios"
+            ReferencedContainer = "container:gpac4ios.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/modules/droid_mpegv/droid_mpegv.c
+++ b/modules/droid_mpegv/droid_mpegv.c
@@ -386,7 +386,7 @@ u32 ThreadRun(void* param)
 	loadSensorControler(rc);
 
 	if (!rc->env || !rc->sensCtrlObj)
-		return;
+		return GF_OK;
 
 	(*rc->env)->CallNonvirtualVoidMethod(rc->env, rc->sensCtrlObj, rc->sensCtrlClass, rc->startSensor, (s32)dr, rc->sensorAndroidType);
 
@@ -396,7 +396,7 @@ u32 ThreadRun(void* param)
 	GF_LOG(GF_LOG_ERROR, GF_LOG_CORE, ("[MPEG-V_IN] Stop: %d\n", gf_th_id()));
 
 	if (!rc->env)
-		return;
+		return GF_OK;
 
 	if ( rc->sensCtrlObj )
 	{
@@ -406,6 +406,7 @@ u32 ThreadRun(void* param)
 	}
 
 	unloadSensorController(rc);
+	return GF_OK;
 }
 
 void MPEGVS_Start(struct __input_device * dr)


### PR DESCRIPTION
two things I came across while rebuilding the project on new machines: 

android: a return type warning seem to give an error (Werror is probably defined somewhere)

ios: when ran for the first time, the xcodebuild archive command complains that no schemes exists in the project

schemes can be auto-generated in the xcode gui, but for the project to be buildable from scratch from the command line, it's better to include the schemes in the repo