### PR TITLE
invalid use of fputwc on already non-wide stream

### DIFF
--- a/src/scene_manager/scene_dump.c
+++ b/src/scene_manager/scene_dump.c
@@ -153,7 +153,7 @@ GF_SceneDumper *gf_sm_dumper_new(GF_SceneGraph *graph, char *_rad_name, Bool is_
 				ext_name = ".bt";
 				break;
 			}
-			
+
 			tmp->filename = (char *)gf_malloc(strlen(_rad_name ? _rad_name : "") + strlen(ext_name) + 1);
 			strcpy(tmp->filename, _rad_name ? _rad_name : "");
 			if (!is_final_name) strcat(tmp->filename, ext_name);
@@ -589,20 +589,20 @@ static void gf_dump_vrml_sffield(GF_SceneDumper *sdump, u32 type, void *ptr, Boo
 		u16 *uniLine;
 		str = (char*)((SFScript *)ptr)->script_text;
 		len = (u32)strlen(str);
-		uniLine = (u16*)gf_malloc(sizeof(short) * (len+1));
-		_len = gf_utf8_mbstowcs(uniLine, len, (const char **) &str);
-		if (_len != (size_t) -1) {
-			len = (u32) _len;
-			if (!sdump->XMLDump) fputc('\"', sdump->trace);
 
-			for (i=0; i<len; i++) {
-				if (!sdump->XMLDump) {
-#ifndef __SYMBIAN32__
-					fputwc(uniLine[i], sdump->trace);
-#else
-					fputc(uniLine[i], sdump->trace);
-#endif
-				} else {
+		if (!sdump->XMLDump) {
+			fprintf(sdump->trace, "\"%s\"", str);
+		}
+		else {
+
+			uniLine = (u16*)gf_malloc(sizeof(short) * (len + 1));
+			_len = gf_utf8_mbstowcs(uniLine, len, (const char **)&str);
+
+			if (_len != (size_t)-1) {
+				len = (u32)_len;
+
+				for (i = 0; i<len; i++) {
+
 					switch (uniLine[i]) {
 					case '&':
 						fprintf(sdump->trace, "&amp;");
@@ -619,21 +619,21 @@ static void gf_dump_vrml_sffield(GF_SceneDumper *sdump, u32 type, void *ptr, Boo
 						break;
 					case 0:
 						break;
-					/*FIXME: how the heck can we preserve newlines and spaces of JavaScript in
-					an XML attribute in any viewer ? */
+						/*FIXME: how the heck can we preserve newlines and spaces of JavaScript in
+						an XML attribute in any viewer ? */
 					default:
 						if (uniLine[i]<128) {
-							fprintf(sdump->trace, "%c", (u8) uniLine[i]);
-						} else {
+							fprintf(sdump->trace, "%c", (u8)uniLine[i]);
+						}
+						else {
 							fprintf(sdump->trace, "&#%d;", uniLine[i]);
 						}
 						break;
 					}
-				}
 			}
-			if (!sdump->XMLDump) fprintf(sdump->trace, "\"\n");
 		}
-		gf_free(uniLine);
+			gf_free(uniLine);
+	}
 		DUMP_IND(sdump);
 	}
 	break;


### PR DESCRIPTION
### test_case:

the test file `tests/media/bifs/bifs-2D-interactivity-mousesensor.bt` contains a script block with a `url` element containing some javascript 

if we export it to xmt the script contents is copied properly, however if we export that xmt back to bt, the script content has disappeared and the url element is empty

_this happens on linux only, it works on both windows and macos_

### cause: 

when trying to dump the content of the `url` element, we first try to convert it to UTF16 and write it, one wide-character at a time, with `fputwc()`

however, the standard says that a `FILE*` stream can be either:
 - _byte-oriented_: when using functions such as `fprintf`, `fputc`, etc.
 - _wide-oriented_: when using functions such as `fwprintf`, `fputwc`, etc. 

once its orientation is set, either by the first i/o function used on it or by `fwide()`, **it cannot be changed and all ill-orientated functions will fail**

here is a simple example : https://ideone.com/vwfHZc (if we remove the 'before' part, the middle will print but not the 'after')

in our case, the `sdump->trace` stream has been used as byte-oriented previously (we've `fprintf` in it a bunch), so we can't use `fputwc` 

as to why it works on windows and macos I don't know but it shouldn't, it's a deviation from the standard

### resolution:

in this particular case, the `fputwc` loop didn't seem necessary, copying the raw string directly is faster and preserve the encoding of the input (so unicode characters will be properly copied is they were properly encoded in the input) so I removed it

