### PR TITLE
invalid cast in swf parser decompress

### DIFF
--- a/src/scene_manager/swf_parse.c
+++ b/src/scene_manager/swf_parse.c
@@ -95,6 +95,7 @@ enum
 static void swf_init_decompress(SWFReader *read)
 {
 	u32 size, dst_size;
+	uLongf destLen;
 	char *src, *dst;
 
 	assert(gf_bs_get_size(read->bs)-8 < 1<<31); /*must fit within 32 bits*/
@@ -105,7 +106,8 @@ static void swf_init_decompress(SWFReader *read)
 	memset(dst, 0, sizeof(char)*8);
 	gf_bs_read_data(read->bs, src, size);
 	dst_size -= 8;
-	uncompress((Bytef *) dst+8, (uLongf *)&dst_size, (Bytef *) src, size);
+	destLen = (uLongf)dst_size;
+	uncompress((Bytef *) dst+8, &destLen, (Bytef *) src, size);
 	dst_size += 8;
 	gf_free(src);
 	read->mem = dst;


### PR DESCRIPTION
### test case

when trying to run the following test

`MP4Box -add tests/media/xmlin4/anim.swf:fmt=svg -new ./results/temp/text-stxt-svg.mp4`

on linux, we get 

```
SWF import (as text - type: svg)
SWF Import - Scene Size 0x0 - 0 frames @ 0 FPS
```

and nothing is done - on windows we rightly get 

```
SWF import (as text - type: svg)
SWF Import - Scene Size 170x170 - 30 frames @ 25 FPS
```

### cause

the problem comes from the call to zlib for unpacking a compressed swf : 

we read the length of the data on 4 bytes (`u32`) in `dst_size`, and (weirdly) zlib expects a `uLongf*` as its size argument (`uLongf` being 8 bytes long)

passing `(uLongf *)&dst_size` is incorrect because the extra bytes aren't necessarily initialized to 0 so the numeric value becomes garbage

### resolution

by copying the `u32` to a `uLongf` first and then passing that address, we get the intended result

```
$ MP4Box -add tests/media/xmlin4/anim.swf:fmt=svg -new ./results/temp/text-stxt-svg.mp4
SWF import (as text - type: svg)
SWF Import - Scene Size 0x0 - 0 frames @ 0 FPS
```


