### PR TITLE
Split Dash tests cases

### DIFF
--- a/tests/scripts/dash-if-live.sh
+++ b/tests/scripts/dash-if-live.sh
@@ -4,7 +4,7 @@ test_begin "dash-if-live"
 
 do_test "$MP4BOX -add $EXTERNAL_MEDIA_DIR/counter/counter_30s_I25_baseline_1280x720_512kbps.264 -add $EXTERNAL_MEDIA_DIR/counter/counter_30s_audio.aac -new $TEMP_DIR/file.mp4" "dash-input-preparation"
 
-do_test "$MP4BOX -dash 1000 -profile dashavc264:live $TEMP_DIR/file.mp4 -out $TEMP_DIR/file.mpd" "dash-if-live"
+do_test "$MP4BOX -dash 1000 -profile dashavc264:live $TEMP_DIR/file.mp4#video $TEMP_DIR/file.mp4#audio -out $TEMP_DIR/file.mpd" "dash-if-live"
 
 do_playback_test "$TEMP_DIR/file.mpd" "play-dash-if-live"
 

--- a/tests/scripts/dash-if-live.sh
+++ b/tests/scripts/dash-if-live.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-test_begin "dash-live"
+test_begin "dash-if-live"
 
 do_test "$MP4BOX -add $EXTERNAL_MEDIA_DIR/counter/counter_30s_I25_baseline_1280x720_512kbps.264 -add $EXTERNAL_MEDIA_DIR/counter/counter_30s_audio.aac -new $TEMP_DIR/file.mp4" "dash-input-preparation"
 
-do_test "$MP4BOX -dash 1000 -profile live $TEMP_DIR/file.mp4 -out $TEMP_DIR/file.mpd" "dash-live"
+do_test "$MP4BOX -dash 1000 -profile dashavc264:live $TEMP_DIR/file.mp4 -out $TEMP_DIR/file.mpd" "dash-if-live"
 
-do_playback_test "$TEMP_DIR/file.mpd" "play-dash-live"
+do_playback_test "$TEMP_DIR/file.mpd" "play-dash-if-live"
 
 test_end

--- a/tests/scripts/dash-if-ondemand.sh
+++ b/tests/scripts/dash-if-ondemand.sh
@@ -4,7 +4,7 @@ test_begin "dash-if-ondemand"
 
 do_test "$MP4BOX -add $EXTERNAL_MEDIA_DIR/counter/counter_30s_I25_baseline_1280x720_512kbps.264 -add $EXTERNAL_MEDIA_DIR/counter/counter_30s_audio.aac -new $TEMP_DIR/file.mp4" "dash-input-preparation"
 
-do_test "$MP4BOX -dash 1000 -profile dashavc264:onDemand $TEMP_DIR/file.mp4 -out $TEMP_DIR/file.mpd" "basic-dash-if-ondemand"
+do_test "$MP4BOX -dash 1000 -profile dashavc264:onDemand $TEMP_DIR/file.mp4#video $TEMP_DIR/file.mp4#audio -out $TEMP_DIR/file.mpd" "basic-dash-if-ondemand"
 
 do_playback_test "$TEMP_DIR/file.mpd" "play-dash-if-ondemand"
 

--- a/tests/scripts/dash-if-ondemand.sh
+++ b/tests/scripts/dash-if-ondemand.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-test_begin "dash-live"
+test_begin "dash-if-ondemand"
 
 do_test "$MP4BOX -add $EXTERNAL_MEDIA_DIR/counter/counter_30s_I25_baseline_1280x720_512kbps.264 -add $EXTERNAL_MEDIA_DIR/counter/counter_30s_audio.aac -new $TEMP_DIR/file.mp4" "dash-input-preparation"
 
-do_test "$MP4BOX -dash 1000 -profile live $TEMP_DIR/file.mp4 -out $TEMP_DIR/file.mpd" "dash-live"
+do_test "$MP4BOX -dash 1000 -profile dashavc264:onDemand $TEMP_DIR/file.mp4 -out $TEMP_DIR/file.mpd" "basic-dash-if-ondemand"
 
-do_playback_test "$TEMP_DIR/file.mpd" "play-dash-live"
+do_playback_test "$TEMP_DIR/file.mpd" "play-dash-if-ondemand"
 
 test_end

--- a/tests/scripts/dash-live-generation.sh
+++ b/tests/scripts/dash-live-generation.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+test_begin "dash-live-generation"
+
+do_test "$MP4BOX -add $EXTERNAL_MEDIA_DIR/counter/counter_30s_I25_baseline_1280x720_512kbps.264:dur=5 -add $EXTERNAL_MEDIA_DIR/counter/counter_30s_audio.aac:dur=5 -new $TEMP_DIR/file.mp4" "dash-input-preparation"
+
+do_test "$MP4BOX -bs-switching single -mpd-refresh 10 -dash-ctx $TEMP_DIR/dash_ctx -dash-run-for 10000 -dynamic -profile live -dash-live 40  $TEMP_DIR/file.mp4 -out $TEMP_DIR/file.mpd" "dash-live" &
+
+sleep 1
+
+do_playback_test "$TEMP_DIR/file.mpd" "play-basic-dash"
+
+test_end
+

--- a/tests/scripts/dash-live-generation.sh
+++ b/tests/scripts/dash-live-generation.sh
@@ -4,7 +4,7 @@ test_begin "dash-live-generation"
 
 do_test "$MP4BOX -add $EXTERNAL_MEDIA_DIR/counter/counter_30s_I25_baseline_1280x720_512kbps.264:dur=5 -add $EXTERNAL_MEDIA_DIR/counter/counter_30s_audio.aac:dur=5 -new $TEMP_DIR/file.mp4" "dash-input-preparation"
 
-do_test "$MP4BOX -bs-switching single -mpd-refresh 10 -dash-ctx $TEMP_DIR/dash_ctx -dash-run-for 10000 -dynamic -profile live -dash-live 40  $TEMP_DIR/file.mp4 -out $TEMP_DIR/file.mpd" "dash-live" &
+do_test "$MP4BOX -bs-switching single -mpd-refresh 10 -dash-ctx $TEMP_DIR/dash_ctx -dash-run-for 10000 -dynamic -profile live -dash-live 40  $TEMP_DIR/file.mp4#video $TEMP_DIR/file.mp4#audio -out $TEMP_DIR/file.mpd" "dash-live" &
 
 sleep 1
 

--- a/tests/scripts/dash-live.sh
+++ b/tests/scripts/dash-live.sh
@@ -4,7 +4,7 @@ test_begin "dash-live"
 
 do_test "$MP4BOX -add $EXTERNAL_MEDIA_DIR/counter/counter_30s_I25_baseline_1280x720_512kbps.264 -add $EXTERNAL_MEDIA_DIR/counter/counter_30s_audio.aac -new $TEMP_DIR/file.mp4" "dash-input-preparation"
 
-do_test "$MP4BOX -dash 1000 -profile live $TEMP_DIR/file.mp4 -out $TEMP_DIR/file.mpd" "dash-live"
+do_test "$MP4BOX -dash 1000 -profile live $TEMP_DIR/file.mp4#video $TEMP_DIR/file.mp4#audio -out $TEMP_DIR/file.mpd" "dash-live"
 
 do_playback_test "$TEMP_DIR/file.mpd" "play-dash-live"
 

--- a/tests/scripts/dash.sh
+++ b/tests/scripts/dash.sh
@@ -4,7 +4,7 @@ test_begin "dash"
 
 do_test "$MP4BOX -add $EXTERNAL_MEDIA_DIR/counter/counter_30s_I25_baseline_1280x720_512kbps.264 -add $EXTERNAL_MEDIA_DIR/counter/counter_30s_audio.aac -new $TEMP_DIR/file.mp4" "dash-input-preparation"
 
-do_test "$MP4BOX -dash 1000 $TEMP_DIR/file.mp4 -out $TEMP_DIR/file.mpd" "basic-dash"
+do_test "$MP4BOX -dash 1000 $TEMP_DIR/file.mp4#video $TEMP_DIR/file.mp4#audio -out $TEMP_DIR/file.mpd" "basic-dash"
 
 do_playback_test "$TEMP_DIR/file.mpd" "play-basic-dash"
 

--- a/tests/scripts/dash.sh
+++ b/tests/scripts/dash.sh
@@ -4,7 +4,7 @@ test_begin "dash"
 
 do_test "$MP4BOX -add $EXTERNAL_MEDIA_DIR/counter/counter_30s_I25_baseline_1280x720_512kbps.264 -add $EXTERNAL_MEDIA_DIR/counter/counter_30s_audio.aac -new $TEMP_DIR/file.mp4" "dash-input-preparation"
 
-do_test "$MP4BOX -dash 1000 -profile live $TEMP_DIR/file.mp4 -out $TEMP_DIR/file.mpd" "basic-dash"
+do_test "$MP4BOX -dash 1000 $TEMP_DIR/file.mp4 -out $TEMP_DIR/file.mpd" "basic-dash"
 
 do_playback_test "$TEMP_DIR/file.mpd" "play-basic-dash"
 


### PR DESCRIPTION
This PR is splitting dash tests in 5 tests cases:
dash.sh: Using Dash OnDemand profile
dash-live.sh: Using Dash Live profile
dash-live-generation.sh: live DASH session (with Dash Live profile)
dash-if-ondemand.sh: Using Dash-if on demand profile
dash-if-live.sh: Using dash-if live profile

The previous tests were producing adaptation sets with multiplexed media streams. Considering the rare usage, tests are now producing adaptation sets with non multiplexed media streams.
