### PR TITLE
fixes for using hash verification in test suite

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,3 +17,6 @@ configure text eol=lf
 *.vcxproj text eol=crlf
 *.dsp text eol=crlf
 *.dsw text eol=crlf
+
+#tests
+tests/media/xmlin4/input.txt text eol=crlf

--- a/applications/mp4client/main.c
+++ b/applications/mp4client/main.c
@@ -1135,11 +1135,11 @@ Bool revert_cache_file(void *cbck, char *item_name, char *item_path, GF_FileEnum
 		sep = strstr(item_path, "gpac_cache_");
 		if (sep) {
 			sep[0] = 0;
-			dir_len = strlen(item_path);
+			dir_len = (u32) strlen(item_path);
 			sep[0] = 'g';
 		}
 		url+=3;
-		len = strlen(url);
+		len = (u32) strlen(url);
 		dst_name = gf_malloc(len+dir_len+1);
 		memset(dst_name, 0, len+dir_len+1);
 

--- a/build/msvc10/gpac.sln
+++ b/build/msvc10/gpac.sln
@@ -151,7 +151,6 @@ Global
 		{1F7CD37F-DC9A-4AC7-881B-36B263A644C7}.Debug|x64.Build.0 = Debug|x64
 		{1F7CD37F-DC9A-4AC7-881B-36B263A644C7}.Release - MP4Box_only|Win32.ActiveCfg = Release|Win32
 		{1F7CD37F-DC9A-4AC7-881B-36B263A644C7}.Release - MP4Box_only|x64.ActiveCfg = Release|x64
-		{1F7CD37F-DC9A-4AC7-881B-36B263A644C7}.Release - MP4Box_only|x64.Build.0 = Release|x64
 		{1F7CD37F-DC9A-4AC7-881B-36B263A644C7}.Release|Win32.ActiveCfg = Release|Win32
 		{1F7CD37F-DC9A-4AC7-881B-36B263A644C7}.Release|Win32.Build.0 = Release|Win32
 		{1F7CD37F-DC9A-4AC7-881B-36B263A644C7}.Release|x64.ActiveCfg = Release|x64
@@ -518,7 +517,6 @@ Global
 		{1DE72B1E-0DD6-4AFD-95E9-D23ACAB31812}.Debug|x64.Build.0 = Debug|x64
 		{1DE72B1E-0DD6-4AFD-95E9-D23ACAB31812}.Release - MP4Box_only|Win32.ActiveCfg = Release|Win32
 		{1DE72B1E-0DD6-4AFD-95E9-D23ACAB31812}.Release - MP4Box_only|x64.ActiveCfg = Release|x64
-		{1DE72B1E-0DD6-4AFD-95E9-D23ACAB31812}.Release - MP4Box_only|x64.Build.0 = Release|x64
 		{1DE72B1E-0DD6-4AFD-95E9-D23ACAB31812}.Release|Win32.ActiveCfg = Release|Win32
 		{1DE72B1E-0DD6-4AFD-95E9-D23ACAB31812}.Release|Win32.Build.0 = Release|Win32
 		{1DE72B1E-0DD6-4AFD-95E9-D23ACAB31812}.Release|x64.ActiveCfg = Release|x64
@@ -543,7 +541,6 @@ Global
 		{C993119B-29B1-49C8-8EA3-A9ABF633164E}.Debug|x64.Build.0 = Debug|x64
 		{C993119B-29B1-49C8-8EA3-A9ABF633164E}.Release - MP4Box_only|Win32.ActiveCfg = Release|Win32
 		{C993119B-29B1-49C8-8EA3-A9ABF633164E}.Release - MP4Box_only|x64.ActiveCfg = Release|x64
-		{C993119B-29B1-49C8-8EA3-A9ABF633164E}.Release - MP4Box_only|x64.Build.0 = Release|x64
 		{C993119B-29B1-49C8-8EA3-A9ABF633164E}.Release|Win32.ActiveCfg = Release|Win32
 		{C993119B-29B1-49C8-8EA3-A9ABF633164E}.Release|Win32.Build.0 = Release|Win32
 		{C993119B-29B1-49C8-8EA3-A9ABF633164E}.Release|x64.ActiveCfg = Release|x64
@@ -628,7 +625,6 @@ Global
 		{5ED5A1C8-DB34-4089-8E53-EFB225754D02}.Debug|x64.Build.0 = Debug|x64
 		{5ED5A1C8-DB34-4089-8E53-EFB225754D02}.Release - MP4Box_only|Win32.ActiveCfg = Release|Win32
 		{5ED5A1C8-DB34-4089-8E53-EFB225754D02}.Release - MP4Box_only|x64.ActiveCfg = Release|x64
-		{5ED5A1C8-DB34-4089-8E53-EFB225754D02}.Release - MP4Box_only|x64.Build.0 = Release|x64
 		{5ED5A1C8-DB34-4089-8E53-EFB225754D02}.Release|Win32.ActiveCfg = Release|Win32
 		{5ED5A1C8-DB34-4089-8E53-EFB225754D02}.Release|Win32.Build.0 = Release|Win32
 		{5ED5A1C8-DB34-4089-8E53-EFB225754D02}.Release|x64.ActiveCfg = Release|x64
@@ -641,7 +637,6 @@ Global
 		{5D3983BF-143F-49C3-9284-89778282AEFE}.Debug|x64.Build.0 = Debug|x64
 		{5D3983BF-143F-49C3-9284-89778282AEFE}.Release - MP4Box_only|Win32.ActiveCfg = Release|Win32
 		{5D3983BF-143F-49C3-9284-89778282AEFE}.Release - MP4Box_only|x64.ActiveCfg = Release|x64
-		{5D3983BF-143F-49C3-9284-89778282AEFE}.Release - MP4Box_only|x64.Build.0 = Release|x64
 		{5D3983BF-143F-49C3-9284-89778282AEFE}.Release|Win32.ActiveCfg = Release|Win32
 		{5D3983BF-143F-49C3-9284-89778282AEFE}.Release|Win32.Build.0 = Release|Win32
 		{5D3983BF-143F-49C3-9284-89778282AEFE}.Release|x64.ActiveCfg = Release|x64

--- a/build/msvc14/gpac.sln
+++ b/build/msvc14/gpac.sln
@@ -147,7 +147,6 @@ Global
 		{1F7CD37F-DC9A-4AC7-881B-36B263A644C7}.Debug|x64.Build.0 = Debug|x64
 		{1F7CD37F-DC9A-4AC7-881B-36B263A644C7}.Release - MP4Box_only|Win32.ActiveCfg = Release|Win32
 		{1F7CD37F-DC9A-4AC7-881B-36B263A644C7}.Release - MP4Box_only|x64.ActiveCfg = Release|x64
-		{1F7CD37F-DC9A-4AC7-881B-36B263A644C7}.Release - MP4Box_only|x64.Build.0 = Release|x64
 		{1F7CD37F-DC9A-4AC7-881B-36B263A644C7}.Release|Win32.ActiveCfg = Release|Win32
 		{1F7CD37F-DC9A-4AC7-881B-36B263A644C7}.Release|Win32.Build.0 = Release|Win32
 		{1F7CD37F-DC9A-4AC7-881B-36B263A644C7}.Release|x64.ActiveCfg = Release|x64
@@ -504,7 +503,6 @@ Global
 		{1DE72B1E-0DD6-4AFD-95E9-D23ACAB31812}.Debug|x64.Build.0 = Debug|x64
 		{1DE72B1E-0DD6-4AFD-95E9-D23ACAB31812}.Release - MP4Box_only|Win32.ActiveCfg = Release|Win32
 		{1DE72B1E-0DD6-4AFD-95E9-D23ACAB31812}.Release - MP4Box_only|x64.ActiveCfg = Release|x64
-		{1DE72B1E-0DD6-4AFD-95E9-D23ACAB31812}.Release - MP4Box_only|x64.Build.0 = Release|x64
 		{1DE72B1E-0DD6-4AFD-95E9-D23ACAB31812}.Release|Win32.ActiveCfg = Release|Win32
 		{1DE72B1E-0DD6-4AFD-95E9-D23ACAB31812}.Release|Win32.Build.0 = Release|Win32
 		{1DE72B1E-0DD6-4AFD-95E9-D23ACAB31812}.Release|x64.ActiveCfg = Release|x64
@@ -529,7 +527,6 @@ Global
 		{C993119B-29B1-49C8-8EA3-A9ABF633164E}.Debug|x64.Build.0 = Debug|x64
 		{C993119B-29B1-49C8-8EA3-A9ABF633164E}.Release - MP4Box_only|Win32.ActiveCfg = Release|Win32
 		{C993119B-29B1-49C8-8EA3-A9ABF633164E}.Release - MP4Box_only|x64.ActiveCfg = Release|x64
-		{C993119B-29B1-49C8-8EA3-A9ABF633164E}.Release - MP4Box_only|x64.Build.0 = Release|x64
 		{C993119B-29B1-49C8-8EA3-A9ABF633164E}.Release|Win32.ActiveCfg = Release|Win32
 		{C993119B-29B1-49C8-8EA3-A9ABF633164E}.Release|Win32.Build.0 = Release|Win32
 		{C993119B-29B1-49C8-8EA3-A9ABF633164E}.Release|x64.ActiveCfg = Release|x64
@@ -614,7 +611,6 @@ Global
 		{5ED5A1C8-DB34-4089-8E53-EFB225754D02}.Debug|x64.Build.0 = Debug|x64
 		{5ED5A1C8-DB34-4089-8E53-EFB225754D02}.Release - MP4Box_only|Win32.ActiveCfg = Release|Win32
 		{5ED5A1C8-DB34-4089-8E53-EFB225754D02}.Release - MP4Box_only|x64.ActiveCfg = Release|x64
-		{5ED5A1C8-DB34-4089-8E53-EFB225754D02}.Release - MP4Box_only|x64.Build.0 = Release|x64
 		{5ED5A1C8-DB34-4089-8E53-EFB225754D02}.Release|Win32.ActiveCfg = Release|Win32
 		{5ED5A1C8-DB34-4089-8E53-EFB225754D02}.Release|Win32.Build.0 = Release|Win32
 		{5ED5A1C8-DB34-4089-8E53-EFB225754D02}.Release|x64.ActiveCfg = Release|x64
@@ -627,7 +623,6 @@ Global
 		{5D3983BF-143F-49C3-9284-89778282AEFE}.Debug|x64.Build.0 = Debug|x64
 		{5D3983BF-143F-49C3-9284-89778282AEFE}.Release - MP4Box_only|Win32.ActiveCfg = Release|Win32
 		{5D3983BF-143F-49C3-9284-89778282AEFE}.Release - MP4Box_only|x64.ActiveCfg = Release|x64
-		{5D3983BF-143F-49C3-9284-89778282AEFE}.Release - MP4Box_only|x64.Build.0 = Release|x64
 		{5D3983BF-143F-49C3-9284-89778282AEFE}.Release|Win32.ActiveCfg = Release|Win32
 		{5D3983BF-143F-49C3-9284-89778282AEFE}.Release|Win32.Build.0 = Release|Win32
 		{5D3983BF-143F-49C3-9284-89778282AEFE}.Release|x64.ActiveCfg = Release|x64

--- a/include/gpac/mpegts.h
+++ b/include/gpac/mpegts.h
@@ -1177,7 +1177,7 @@ typedef struct __m2ts_mux_stream {
 	Bool start_pes_at_rap, prevent_two_au_start_in_pes;
 
 	struct __elementary_stream_ifce *ifce;
-	Double ts_scale;
+	GF_Fraction ts_scale;
 
 	/*packet fifo*/
 	GF_M2TS_Packet *pck_first, *pck_last;

--- a/include/gpac/setup.h
+++ b/include/gpac/setup.h
@@ -340,6 +340,10 @@ typedef enum {
 } Bool;
 #endif
 
+typedef struct {
+	s32 num;
+	u32 den;
+} GF_Fraction;
 
 /*GPAC memory tracking*/
 #if defined(GPAC_MEMORY_TRACKING)

--- a/include/gpac/tools.h
+++ b/include/gpac/tools.h
@@ -166,6 +166,14 @@ u64 gf_ftell(FILE *f);
 u64 gf_fseek(FILE *f, s64 pos, s32 whence);
 
 /*!
+ *	\brief get basename from filename/path
+ *
+ *	Returns a pointer to the start of a filepath basename or null
+ *	\param filename Path of the file, can be an absolute path
+*/
+char* gf_file_basename(const char* filename);
+
+/*!
  *	\brief get extension from filename
  *
  *	Returns a pointer to the start of a filepath extension or null

--- a/src/export.cpp
+++ b/src/export.cpp
@@ -88,6 +88,7 @@
 #pragma comment (linker, EXPORT_SYMBOL(gf_fseek) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_ftell) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_file_exists) )
+#pragma comment (linker, EXPORT_SYMBOL(gf_file_basename) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_file_ext_start) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_prompt_has_input) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_prompt_get_char) )

--- a/src/isomedia/track.c
+++ b/src/isomedia/track.c
@@ -723,7 +723,7 @@ GF_Err MergeTrack(GF_TrackBox *trak, GF_TrackFragmentBox *traf, u64 moof_offset,
 
 					GF_SAFEALLOC(sai, GF_CENCSampleAuxInfo);
 
-					e = gf_isom_get_sample_cenc_info_ex(trak, traf, senc, i+1, &is_encrypted, &sai->IV_size, NULL, NULL, NULL, NULL, NULL);
+					e = gf_isom_get_sample_cenc_info_ex(trak, traf, senc, i+1, (u32*)&is_encrypted, &sai->IV_size, NULL, NULL, NULL, NULL, NULL);
 					if (e) {
 						GF_LOG(GF_LOG_ERROR, GF_LOG_CONTAINER, ("[isobmf] could not get cenc info for sample %d: %s\n", i+1, gf_error_to_string(e) ));
 						return e;

--- a/src/media_tools/av_parsers.c
+++ b/src/media_tools/av_parsers.c
@@ -3771,7 +3771,7 @@ s32 hevc_parse_slice_segment(GF_BitStream *bs, HEVCState *hevc, HEVCSliceInfo *s
 	}
 //	if (!full_header_parse) return 0;
 
-	si->entry_point_start_bits = (gf_bs_get_position(bs)-1)*8 + gf_bs_get_bit_position(bs);
+	si->entry_point_start_bits = ((u32)gf_bs_get_position(bs)-1)*8 + gf_bs_get_bit_position(bs);
 
 	if (pps->tiles_enabled_flag || pps->entropy_coding_sync_enabled_flag ) {
 		u32 num_entry_point_offsets = bs_get_ue(bs);
@@ -3808,7 +3808,7 @@ s32 hevc_parse_slice_segment(GF_BitStream *bs, HEVCState *hevc, HEVCSliceInfo *s
 	}
 
 	gf_bs_align(bs);
-	si->payload_start_offset = gf_bs_get_position(bs);
+	si->payload_start_offset = (s32)gf_bs_get_position(bs);
 	return 0;
 }
 

--- a/src/media_tools/media_export.c
+++ b/src/media_tools/media_export.c
@@ -2308,7 +2308,7 @@ GF_Err gf_media_export_nhml(GF_MediaExporter *dumper, Bool dims_doc)
 		}
 		if (dims.content_script_types) fprintf(nhml, "content_script_types=\"%s\" ", dims.content_script_types);
 	} else if (szMedia[0]) {
-		fprintf(nhml, "baseMediaFile=\"%s\" ", szMedia);
+		fprintf(nhml, "baseMediaFile=\"%s\" ", gf_file_basename(szMedia));
 	}
 
 
@@ -2530,7 +2530,7 @@ GF_Err gf_media_export_webvtt_metadata(GF_MediaExporter *dumper)
 	if (gf_isom_is_track_in_root_od(dumper->file, track)) fprintf(vtt, "inRootOD: yes\n");
 	fprintf(vtt, "trackID: %d\n", dumper->trackID);
 	if (med) {
-		fprintf(vtt, "baseMediaFile: %s\n", szMedia);
+		fprintf(vtt, "baseMediaFile: %s\n", gf_file_basename(szMedia));
 	}
 	if (esd) {
 		/* TODO: export the MPEG-4 Stream type only if it is not a GPAC internal value */

--- a/src/utils/os_file.c
+++ b/src/utils/os_file.c
@@ -787,12 +787,12 @@ char* gf_file_basename(const char* filename)
 			// if it occurs before it's not relevant
 			// if there's no backslashes we search in the whole file path
 
-			const char* trailingSlash = strrchr(lastPathPart?lastPathPart:filename, '/');
+			char* trailingSlash = strrchr(lastPathPart?lastPathPart:filename, '/');
 			if (trailingSlash)
 				lastPathPart = trailingSlash;
 		}
 		if (!lastPathPart)
-			lastPathPart = filename;
+			lastPathPart = (char *)filename;
 		else
 			lastPathPart++;
 

--- a/src/utils/os_file.c
+++ b/src/utils/os_file.c
@@ -771,15 +771,15 @@ size_t gf_fwrite(const void *ptr, size_t size, size_t nmemb,
 
 
 /**
-  * Returns a pointer to the start of a filepath extension or null
+  * Returns a pointer to the start of a filepath basename
  **/
 GF_EXPORT
-char* gf_file_ext_start(const char* filename)
+char* gf_file_basename(const char* filename)
 {
-	char* res = NULL;
+	char* lastPathPart = NULL;
 	if (filename) {
 
-		const char* lastPathPart = strrchr(filename , GF_PATH_SEPARATOR);
+		lastPathPart = strrchr(filename , GF_PATH_SEPARATOR);
 		if (GF_PATH_SEPARATOR != '/')
 		{
 			// windows paths can mix slashes and backslashes
@@ -796,7 +796,23 @@ char* gf_file_ext_start(const char* filename)
 		else
 			lastPathPart++;
 
-		res = strrchr(lastPathPart, '.');
+
+
+	}
+	return lastPathPart;
+}
+
+/**
+  * Returns a pointer to the start of a filepath extension or null
+ **/
+GF_EXPORT
+char* gf_file_ext_start(const char* filename)
+{
+	char* res = NULL;
+	char* basename = gf_file_basename(filename);
+	if (basename) {
+
+		res = strrchr(basename, '.');
 
 	}
 	return res;

--- a/tests/make_tests.sh
+++ b/tests/make_tests.sh
@@ -440,27 +440,23 @@ fi
 MP4CLIENT="MP4Client"
 
 if [ $MP4CLIENT_NOT_FOUND = 0 ] && [ $do_clean = 0 ] ; then
-
-MP4Client -run-for 0 2> /dev/null
-res=$?
-if [ $res != 0 ] ; then
-MP4CLIENT_NOT_FOUND=1
-echo ""
-log $L_WAR "WARNING: MP4Client not found (ret $res) - launch results:"
-MP4Client -run-for 0
-res=$?
-if [ $res = 0 ] ; then
-log $L_INF "MP4Client returned $res on second run - enabling all playback tests"
-else
-echo "** MP4Client returned $res - disabling all playback tests - dumping GPAC config file **"
-cat $HOME/.gpac/GPAC.cfg
-echo "** End of dump **"
+  MP4Client -run-for 0 2> /dev/null
+  res=$?
+  if [ $res != 0 ] ; then
+    MP4CLIENT_NOT_FOUND=1
+    echo ""
+    log $L_WAR "WARNING: MP4Client not found (ret $res) - launch results:"
+    MP4Client -run-for 0
+    res=$?
+    if [ $res = 0 ] ; then
+      log $L_INF "MP4Client returned $res on second run - enabling all playback tests"
+    else
+      echo "** MP4Client returned $res - disabling all playback tests - dumping GPAC config file **"
+      cat $HOME/.gpac/GPAC.cfg
+      echo "** End of dump **"
+    fi
+  fi
 fi
-
-fi
-
-fi
-
 
 MP42TS -h 2> /dev/null
 res=$?
@@ -610,6 +606,10 @@ test_begin ()
   fi
  fi
 
+ if [ $MP4CLIENT_NOT_FOUND > 0 ] ; then
+  skip_play_hash=1
+ fi
+
  if [ $generate_hash = 1 ] ; then
   #skip test only if reference hash is marked as valid
   if [ -f "$reference_hash_valid" ] ; then
@@ -740,7 +740,7 @@ shopt -s nullglob
     result="$SUBTEST_NAME:Fail(ret code $RETURN_VALUE) $result"
    fi
    test_ok=0
-   test_exec_na=$((test_exec_na + 1))
+   test_fail=$((test_fail + 1))
   fi
 
   if [ $log_after_fail = 1 ] ; then
@@ -766,10 +766,12 @@ shopt -s nullglob
    if [ $HASH_NOT_FOUND -eq 1 ] ; then
     result="$HASH_TEST:HashNotFound $result"
     nb_hash_missing=$((nb_hash_missing + 1))
+    test_exec_na=$((test_exec_na + 1))
    elif [ $HASH_FAIL -eq 1 ] ; then
     result="$HASH_TEST:HashFail $result"
     test_ok=0
     nb_hash_fail=$((nb_hash_fail + 1))
+    test_exec_na=$((test_exec_na + 1))
    fi
   fi
   rm -f $i > /dev/null
@@ -1111,7 +1113,21 @@ do_hash_test ()
  echo "HASH_TEST=$2" > $STATHASH_SH
 
  echo "Computing $1  ($2) hash: " >> $log_subtest
- $MP4BOX -hash -std $1 > $test_hash 2>> $log_subtest
+ file_to_hash="$1"
+
+ # for text files, we remove potential CR chars
+ # to prevent having different hashes on different platforms
+ if [ -n "$(file -b $1 | grep text)" ] ; then
+  file_to_hash="to_hash_$(basename $1)"
+  sed $'s/\r//' "$1" > "$file_to_hash"
+ fi
+
+ $MP4BOX -hash -std $file_to_hash > $test_hash 2>> $log_subtest
+
+ if [ "$file_to_hash" != "$1" ]; then
+  rm "$file_to_hash"
+ fi
+
  if [ $generate_hash = 0 ] ; then
   if [ ! -f $ref_hash ] ; then
    echo "HASH_NOT_FOUND=1" >> $STATHASH_SH
@@ -1380,23 +1396,22 @@ else
  TESTS_SKIP=$((TESTS_SKIP + $TEST_SKIP))
 fi
 
-if [ $TEST_EXEC_NA != 0 ] ; then
- if [ $TEST_FAIL = 0 ] ; then
-  TEST_FAIL=1
- fi
- TESTS_EXEC_NA=$((TESTS_EXEC_NA + 1))
-fi
-
 if [ $TEST_FAIL = 0 ] ; then
- TESTS_PASSED=$((TESTS_PASSED + 1))
+  if [ $TEST_EXEC_NA = 0 ] && [ $SUBTESTS_LEAK = 0 ]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    rm -f $i > /dev/null
+    if [ $TEST_EXEC_NA != 0 ] ; then
+      TESTS_EXEC_NA=$((TESTS_EXEC_NA + 1))
+    else
+      TESTS_LEAK=$((TESTS_LEAK + 1))
+    fi
+  fi
 else
- TESTS_FAILED=$((TESTS_FAILED + 1))
- rm -f $i > /dev/null
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  rm -f $i > /dev/null
 fi
 
-if [ $SUBTESTS_LEAK != 0 ] ; then
-  TESTS_LEAK=$((TESTS_LEAK + 1))
-fi
 
 SUBTESTS_FAIL=$((SUBTESTS_FAIL + $TEST_FAIL))
 SUBTESTS_EXEC_NA=$((SUBTESTS_EXEC_NA + $TEST_EXEC_NA))
@@ -1485,12 +1500,12 @@ fi
 
  if [ $SUBTESTS_HASH_FAIL != 0 ] ; then
   pc=$((100*SUBTESTS_HASH_FAIL/SUBTESTS_DONE))
-  log $L_WAR "Tests HASH total $TESTS_HASH - fail $TESTS_HASH_FAIL ($pc % of subtests)"
+  log $L_WAR "Tests HASH total $SUBTESTS_HASH - fail $SUBTESTS_HASH_FAIL ($pc % of subtests)"
  fi
 
  if [ $SUBTESTS_HASH_MISSING != 0 ] ; then
   pc=$((100*SUBTESTS_HASH_MISSING/$SUBTESTS_HASH))
-  log $L_WAR "Missing hashes $SUBTESTS_HASH_MISSING / $SUBTESTS_HASH ($pc % )"
+  log $L_WAR "Missing hashes $SUBTESTS_HASH_MISSING / $SUBTESTS_HASH ($pc % hashed subtests)"
  fi
 
 

--- a/tests/make_tests.sh
+++ b/tests/make_tests.sh
@@ -1117,7 +1117,7 @@ do_hash_test ()
 
  # for text files, we remove potential CR chars
  # to prevent having different hashes on different platforms
- if [ -n "$(file -b $1 | grep text)" ] ; then
+ if [ -n "$(file -b $1 | grep text)" ] ||  [ ${1: -4} == ".lsr" ] ; then
   file_to_hash="to_hash_$(basename $1)"
   tr -d '\r' <  "$1" > "$file_to_hash"
  fi

--- a/tests/make_tests.sh
+++ b/tests/make_tests.sh
@@ -1119,7 +1119,7 @@ do_hash_test ()
  # to prevent having different hashes on different platforms
  if [ -n "$(file -b $1 | grep text)" ] ; then
   file_to_hash="to_hash_$(basename $1)"
-  sed $'s/\r//' "$1" > "$file_to_hash"
+  tr -d '\r' <  "$1" > "$file_to_hash"
  fi
 
  $MP4BOX -hash -std $file_to_hash > $test_hash 2>> $log_subtest

--- a/tests/media/xmlin4/first.xml
+++ b/tests/media/xmlin4/first.xml
@@ -1,3 +1,1 @@
-<gpac xmlns="http://www.gpac.io/xml">
-	This is some text in first.xml
-</gpac>
+<gpac xmlns="http://www.gpac.io/xml">This is some text in first.xml</gpac>

--- a/tests/media/xmlin4/last.xml
+++ b/tests/media/xmlin4/last.xml
@@ -1,3 +1,1 @@
-<gpac xmlns="http://www.gpac.io/xml">
-	This is some text in last.xml
-</gpac>
+<gpac xmlns="http://www.gpac.io/xml">This is some text in last.xml</gpac>

--- a/tests/media/xmlin4/meta-mett.nhml
+++ b/tests/media/xmlin4/meta-mett.nhml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <NHNTStream version="1.0" timeScale="1000" mediaType="meta" mediaSubType="mett" mime_type="text/plain" text_encoding="utf-8" baseMediaFile="input.txt" >
- <NHNTSample DTS="0" dataLength="43" isRAP="yes" />
- <NHNTSample DTS="1000" dataLength="817" />
- <NHNTSample DTS="2000" dataLength="446" />
- <NHNTSample DTS="3000" dataLength="484" isRAP="yes" />
- <NHNTSample DTS="4000" dataLength="540" />
+ <NHNTSample DTS="0" dataLength="45" isRAP="yes" />
+ <NHNTSample DTS="1000" dataLength="820" />
+ <NHNTSample DTS="2000" dataLength="449" />
+ <NHNTSample DTS="3000" dataLength="487" isRAP="yes" />
+ <NHNTSample DTS="4000" dataLength="542" />
 </NHNTStream>

--- a/tests/media/xmlin4/second.xml
+++ b/tests/media/xmlin4/second.xml
@@ -1,3 +1,1 @@
-<gpac xmlns="http://www.gpac.io/xml">
-	This is some text in second.xml
-</gpac>
+<gpac xmlns="http://www.gpac.io/xml">This is some text in second.xml</gpac>

--- a/tests/media/xmlin4/text-stxt.nhml
+++ b/tests/media/xmlin4/text-stxt.nhml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <NHNTStream version="1.0" timeScale="1000" mediaType="text" mediaSubType="stxt" mime_type="text/plain" text_encoding="utf-8" baseMediaFile="input.txt" >
- <NHNTSample DTS="0" dataLength="43" isRAP="yes" />
- <NHNTSample DTS="1000" dataLength="817" />
- <NHNTSample DTS="2000" dataLength="446" />
- <NHNTSample DTS="3000" dataLength="484" isRAP="yes" />
- <NHNTSample DTS="4000" dataLength="540" />
+ <NHNTSample DTS="0" dataLength="45" isRAP="yes" />
+ <NHNTSample DTS="1000" dataLength="820" />
+ <NHNTSample DTS="2000" dataLength="449" />
+ <NHNTSample DTS="3000" dataLength="487" isRAP="yes" />
+ <NHNTSample DTS="4000" dataLength="542" />
 </NHNTStream>

--- a/tests/scripts/mp42ts.sh
+++ b/tests/scripts/mp42ts.sh
@@ -30,15 +30,15 @@ mp4file="$TEMP_DIR/test.mp4"
 $MP4BOX -add $MEDIA_DIR/auxiliary_files/enst_video.h264 -add $MEDIA_DIR/auxiliary_files/enst_audio.aac -new $mp4file 2> /dev/null
 
 
-ts_test "simple" "-src $mp4file -dst-file=$tsfile"
+ts_test "simple" "-src $mp4file -dst-file=$tsfile -pcr-init 0"
 
-ts_test "rate" "-src $mp4file -dst-file=$tsfile -rate 10000"
+ts_test "rate" "-src $mp4file -dst-file=$tsfile -rate 10000 -pcr-init 0"
 
-ts_test "singleau" "-src $mp4file -dst-file=$tsfile -single-au"
+ts_test "singleau" "-src $mp4file -dst-file=$tsfile -single-au -pcr-init 0"
 
-ts_test "multiau" "-src $mp4file -dst-file=$tsfile -multi-au"
+ts_test "multiau" "-src $mp4file -dst-file=$tsfile -multi-au -pcr-init 0"
 
-ts_test "temi" "-src $mp4file -dst-file=$tsfile -temi -insert-ntp"
+ts_test "temi" "-src $mp4file -dst-file=$tsfile -temi -pcr-init 0"
 
 ts_test "pcr" "-src $mp4file -dst-file=$tsfile -pcr-ms 40 -force-pcr-only -pcr-init 0 -pcr-offset 30000 -rap"
 

--- a/tests/scripts/smooth.sh
+++ b/tests/scripts/smooth.sh
@@ -21,9 +21,10 @@ do_test "$MP4BOX -inter 1000 $1 -out $mp4file" "Unfrag"
 do_hash_test $mp4file "unfrag"
 
 #test extracting from the fragmented source
+rm -f $TEMP_DIR/test.tmp
 do_test "$MP4BOX -raw 1 $1 -out $TEMP_DIR/test.tmp" "raw"
 do_hash_test $TEMP_DIR/test.tmp "raw"
-
+rm -f $TEMP_DIR/test.tmp
 
 #no playback test for now since we only have encrypted files without the keys
 #do_playback_test "$TEMP_DIR/$testname.mpd" "dash-playback"

--- a/tests/scripts/xmlin.sh
+++ b/tests/scripts/xmlin.sh
@@ -18,6 +18,7 @@ nhml_test  ()
 
  do_test "$MP4BOX -info $mp4file" "info"
 
+ rm -f $TEMP_DIR/test.xml
  do_test "$MP4BOX -raw 1 $mp4file -out $TEMP_DIR/test.xml " "export-track"
  do_hash_test $TEMP_DIR/test.xml "export-track"
  rm -f $TEMP_DIR/test.xml
@@ -73,6 +74,7 @@ test_begin "xmlin-swf-stxt"
 do_test "$MP4BOX -add $MEDIA_DIR/xmlin4/anim.swf:fmt=svg -new $TEMP_DIR/text-stxt-svg.mp4" "import"
 do_hash_test $TEMP_DIR/text-stxt-svg.mp4 "import"
 
+rm -f $TEMP_DIR/test.svg
 do_test "$MP4BOX -raw 1 $TEMP_DIR/text-stxt-svg.mp4 -out $TEMP_DIR/test.svg" "export-track"
 do_hash_test $TEMP_DIR/test.svg "export-track"
 rm -f $TEMP_DIR/test.svg
@@ -87,6 +89,7 @@ test_begin "xmlin-ttml-stpp"
 do_test "$MP4BOX -add $MEDIA_DIR/xmlin4/ebu-ttd_sample.ttml -new $TEMP_DIR/subt-stpp-ttml.mp4" "import"
 do_hash_test $TEMP_DIR/subt-stpp-ttml.mp4 "import"
 
+rm -f $TEMP_DIR/test.ttml
 do_test "$MP4BOX -raw 1 $TEMP_DIR/subt-stpp-ttml.mp4 -out $TEMP_DIR/test.ttml" "export-track"
 do_hash_test $TEMP_DIR/test.ttml "export-track"
 rm -f $TEMP_DIR/test.ttml

--- a/tests/scripts/xmlin.sh
+++ b/tests/scripts/xmlin.sh
@@ -20,6 +20,7 @@ nhml_test  ()
 
  do_test "$MP4BOX -raw 1 $mp4file -out $TEMP_DIR/test.xml " "export-track"
  do_hash_test $TEMP_DIR/test.xml "export-track"
+ rm -f $TEMP_DIR/test.xml
 
  do_test "$MP4BOX -raws 1 $mp4file" "export-samples"
 
@@ -74,6 +75,7 @@ do_hash_test $TEMP_DIR/text-stxt-svg.mp4 "import"
 
 do_test "$MP4BOX -raw 1 $TEMP_DIR/text-stxt-svg.mp4 -out $TEMP_DIR/test.svg" "export-track"
 do_hash_test $TEMP_DIR/test.svg "export-track"
+rm -f $TEMP_DIR/test.svg
 
 do_test "$MP4BOX -raws 1 $TEMP_DIR/text-stxt-svg.mp4" "export-samples"
 
@@ -87,6 +89,7 @@ do_hash_test $TEMP_DIR/subt-stpp-ttml.mp4 "import"
 
 do_test "$MP4BOX -raw 1 $TEMP_DIR/subt-stpp-ttml.mp4 -out $TEMP_DIR/test.ttml" "export-track"
 do_hash_test $TEMP_DIR/test.ttml "export-track"
+rm -f $TEMP_DIR/test.ttml
 
 do_test "$MP4BOX -raws 1 $TEMP_DIR/subt-stpp-ttml.mp4" "export-samples"
 


### PR DESCRIPTION
Hash references (up to date for non playback tests) are available here : 

http://download.tsi.telecom-paristech.fr/gpac/gpac_test_suite/resources/hash_refs

use `./make_tests.sh -sync-hash`  to get them

A few tests are still not hashable across all platforms. 