### PR TITLE
Don't read NALU type if NALU size is 0

### DIFF
--- a/src/media_tools/ismacryp.c
+++ b/src/media_tools/ismacryp.c
@@ -936,6 +936,9 @@ static GF_Err gf_cenc_encrypt_sample_ctr(GF_Crypt *mc, GF_ISOSample *samp, Bool 
 			char nal_hdr[2];
 			GF_CENCSubSampleEntry *entry = (GF_CENCSubSampleEntry *)gf_malloc(sizeof(GF_CENCSubSampleEntry));
 			size = gf_bs_read_int(pleintext_bs, 8*nalu_size_length);
+			if (0 == size) {
+				continue;
+			}
 			if (size>max_size) {
 				buffer = (char*)gf_realloc(buffer, sizeof(char)*size);
 				max_size = size;


### PR DESCRIPTION
I had an issue with a file containing the following sample data:
```
00 00 00 02 09 50 
00 00 00 09 06 01 05 00 2c 00 00 10 80 
00 00 00 00 
00 00 00 02 0c 80 
00 00 00 02 09 50 
00 00 00 09 06 01 05 00 30 00 08 10 80 
00 00 00 0d 06 04 09 b5 00 31 44 54 47 31 41 f8 80 
00 00 02 0d 01 9e 0e 2d e4 67 f8 0a 5e 45 fe 31 5c 2e 58 8c 48 49 b1 14 a1 d6 b0 06 e9 2f a8 90 14 dc 7f d1 55 90 d2 d3 33 5a 60 9c 91 4f 1c 96 94 fa 72 4e da 8b d6 14 eb b4 c5 ef 61 64 c4 d1 8c cd f7 9d 26 1d fc 13 62 8e 66 9d af 96 a0 e4 e1 34 8f ec c8 23 4b 7b 62 ce 74 43 5f aa d2 0d e6 38 22 47 e7 a0 15 99 be 1e df a3 45 28 e4 5c 98 d3 25 fe dd 03 28 ce 76 f6 ae eb 05 e3 f4 c5 5f 4d 77 5d e2 8c 9f bf c7 48 da 55 7d 11 30 40 27 4d c6 50 bf 59 f2 0a 29 77 5b 91 6b 52 7e 3d d6 1b 0a 44 1c a2 0b 0a 25 c1 0c 29 98 e3 82 bd d7 b4 4b 87 6b 66 2d 78 c4 bb 58 2c f5 06 7f f0 82 55 13 44 31 f8 7a 0c e4 37 95 df 1d b3 68 ae ce 8b 8e fd 20 18 21 22 b1 1f 4d 23 1a 87 14 cc 55 a2 ac 5e ed c1 79 1b c7 7f 4f 5c 6f 31 a7 f1 50 93 b7 f1 49 5f 33 cb f8 4e 78 fe 04 73 88 2d 09 e2 6f 91 45 06 c6 92 ff 33 c3 5c 4d 64 29 ff a6 cc 75 be 70 d0 ea 26 e4 b0 6b a8 3c 59 19 59 0d c6 4a 8e c4 b6 5f 65 b5 4d e4 ac c8 ca 24 6d 0a a0 43 a8 2e 74 00 e0 6d b2 e6 eb 1b bb 14 57 c1 6f 2b 7b d3 4e 48 12 c6 4c 3f aa 67 f4 73 ba 38 fe 58 ee 1a f7 61 6d 1a af c7 b2 72 25 be fe bd 6f de b9 46 fd 05 32 3c 8d 11 64 2b 82 11 03 07 b9 0b 12 2f e3 cb 68 e0 b0 fc 94 d9 f5 be 58 8a 59 02 5d 3c 11 94 80 69 7e 7c ff 9e be ea 0e d6 81 b2 66 6b c4 b8 3b 08 b1 af 5a 85 c7 3f f3 ba 06 11 8f 09 db 1e 3c d4 04 f3 45 4c 37 4e b4 a6 d9 9b 34 31 d9 96 87 79 b8 54 a2 bf 7b 47 f7 54 fe 0a b2 06 54 57 e9 17 7d 78 91 5e 20 5c a5 b5 cc 56 67 9d 90 8b 0f 59 97 46 ad ed bb 13 a6 b5 c0 c7 32 d4 ce 15 24 2a 2d b9 76 22 32 2c fb 40 15 c0 9c 1e 39 65 7a bb ed 0b 7f b7 d9 1e c8 03 bc 5c 61 7f 9f 64 18 b4 8f 0e 40 d1 64 7f bc a0
```
As you can see the 3rd unit has a 0 size, but gf_cenc_encrypt_sample_ctr still tries to read the nal_hdr byte.