### PR TITLE
Fix build with OpenSSL 1.1

### DIFF
--- a/src/utils/downloader.c
+++ b/src/utils/downloader.c
@@ -394,8 +394,10 @@ static Bool init_ssl_lib() {
 	}
 	SSL_library_init();
 	SSL_load_error_strings();
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	SSLeay_add_all_algorithms();
 	SSLeay_add_ssl_algorithms();
+#endif
 	_ssl_is_initialized = GF_TRUE;
 	GF_LOG(GF_LOG_DEBUG, GF_LOG_NETWORK, ("[HTTPS] Initalization of SSL library complete.\n"));
 	return GF_FALSE;


### PR DESCRIPTION
#616 is partially fixed with this PR. Deprecated functions in OpenSSL are not handled yet.

By the way, wget uses a similar fix: http://git.savannah.gnu.org/cgit/wget.git/commit/src/openssl.c?id=309e72c74f4ea6c3707ca185bc92ae95ebf56b16

Test environment: Arch Linux x86_64