### PR TITLE
cfgfile: rebuild plugins cache when running a new version

### DIFF
--- a/applications/mp4client/main.c
+++ b/applications/mp4client/main.c
@@ -1554,6 +1554,12 @@ int mp4client_main(int argc, char **argv)
 	}
 	fprintf(stderr, "Modules Found : %d \n", i);
 
+	str = gf_cfg_get_key(cfg_file, "General", "GPACVersion");
+	if (!str || strcmp(str, GPAC_FULL_VERSION)) {
+		gf_cfg_del_section(cfg_file, "PluginsCache");
+		gf_cfg_set_key(cfg_file, "General", "GPACVersion", GPAC_FULL_VERSION);
+	}
+
 	user.config = cfg_file;
 	user.EventProc = GPAC_EventProc;
 	/*dummy in this case (global vars) but MUST be non-NULL*/


### PR DESCRIPTION
linked to #843 : 
 * added GPACVersion in the General section on GPAC.cfg
 * when running mp4client, if GPACVersion is different from the current version, we rebuild the plugins cache

this will avoid failing because of changes in interfaces names