### PR TITLE
small fixes

### DIFF
--- a/src/isomedia/meta.c
+++ b/src/isomedia/meta.c
@@ -419,12 +419,15 @@ GF_Err gf_isom_set_meta_xml(GF_ISOFile *file, Bool root_meta, u32 track_num, cha
 	assert(gf_ftell(xmlfile) < 1<<31);
 	length = (u32) gf_ftell(xmlfile);
 	gf_fseek(xmlfile, 0, SEEK_SET);
-	xml->xml = (char*)gf_malloc(sizeof(unsigned char)*length);
+	xml->xml = (char*)gf_malloc(sizeof(unsigned char)*(length+1));
 	bread =  (u32) fread(xml->xml, 1, sizeof(unsigned char)*length, xmlfile);
 	if (ferror(xmlfile) || (bread != length)) {
 		gf_free(xml->xml);
 		xml->xml = NULL;
 		return GF_BAD_PARAM;
+	}
+	else {
+		xml->xml[length] = '\0';
 	}
 	gf_fclose(xmlfile);
 	return GF_OK;

--- a/src/media_tools/isom_hinter.c
+++ b/src/media_tools/isom_hinter.c
@@ -587,7 +587,7 @@ GF_RTPHinter *gf_hinter_track_new(GF_ISOFile *file, u32 TrackNum,
 
 	my_sl.AUSeqNumLength = gf_get_bit_size(gf_isom_get_sample_count(file, TrackNum));
 	if (my_sl.AUSeqNumLength>16) my_sl.AUSeqNumLength=16;
-	
+
 	my_sl.CUDuration = const_dur;
 
 	if (gf_isom_has_sync_points(file, TrackNum)) {
@@ -694,14 +694,14 @@ GF_Err gf_hinter_track_process(GF_RTPHinter *tkHint)
 	u32 i, descIndex, duration;
 	u64 ts;
 	u8 PadBits;
-	Double ft;
+	GF_Fraction ft;
 	GF_ISOSample *samp;
 
 	tkHint->HintSample = tkHint->RTPTime = 0;
 
 	tkHint->TotalSample = gf_isom_get_sample_count(tkHint->file, tkHint->TrackNum);
-	ft = tkHint->rtp_p->sl_config.timestampResolution;
-	ft /= tkHint->OrigTimeScale;
+	ft.num = tkHint->rtp_p->sl_config.timestampResolution;
+	ft.den = tkHint->OrigTimeScale;
 
 	e = GF_OK;
 	for (i=0; i<tkHint->TotalSample; i++) {
@@ -718,10 +718,10 @@ GF_Err gf_hinter_track_process(GF_RTPHinter *tkHint)
 			samp->IsRAP = RAP;
 		}
 
-		ts = (u64) (ft * (s64) (samp->DTS+samp->CTS_Offset));
+		ts = (u64) (ft.num * (samp->DTS+samp->CTS_Offset) / ft.den);
 		tkHint->rtp_p->sl_header.compositionTimeStamp = ts;
 
-		ts = (u64) (ft * (s64)(samp->DTS));
+		ts = (u64) (ft.num * samp->DTS / ft.den);
 		tkHint->rtp_p->sl_header.decodingTimeStamp = ts;
 		tkHint->rtp_p->sl_header.randomAccessPointFlag = samp->IsRAP;
 


### PR DESCRIPTION
2 bugfixes: 

 * on -hint using a GF_Fraction for the time scale change prevents rounding errors 

 * on -set-xml, the length of an xml box is calculated by strlen so we have to add a \0 after reading from file otherwise it overflows

