### PR TITLE
Enablegrowingfiledashing

### DIFF
--- a/applications/mp4box/main.c
+++ b/applications/mp4box/main.c
@@ -380,6 +380,7 @@ void PrintDASHUsage()
 	        " -mem-frags           fragments will be produced in memory rather than on disk before flushing to disk\n"
 	        " -pssh-moof           stores PSSH boxes in first moof of each segments. By default PSSH are stored in movie box.\n"
 	        " -sample-groups-traf  stores sample group descriptions in traf (duplicated for each traf). If not used, sample group descriptions are stored in the movie box.\n"
+	        " -no-cache            disable file cache for dash inputs .\n"
 
 	        "\n"
 	        "Advanced Options, should not be needed when using -profile:\n"
@@ -1916,6 +1917,7 @@ const char *grab_ifce = NULL;
 FILE *logfile = NULL;
 static u32 dash_run_for;
 static u32 dash_cumulated_time,dash_prev_time,dash_now_time;
+static Bool no_cache=GF_FALSE;
 
 u32 mp4box_cleanup(u32 ret_code) {
 	if (mpd_base_urls) {
@@ -3223,6 +3225,9 @@ Bool mp4box_parse_args(int argc, char **argv)
 			CHECK_NEXT_ARG
 			dash_run_for = atoi(argv[i + 1]);
 			i++;
+		}
+		else if (!stricmp(arg, "-no-cache")) {
+			no_cache = GF_TRUE;
 		}
 		else if (!stricmp(arg, "-segment-ext")) {
 			CHECK_NEXT_ARG

--- a/applications/mp4box/main.c
+++ b/applications/mp4box/main.c
@@ -4012,6 +4012,7 @@ int mp4boxMain(int argc, char **argv)
 		if (!e) e = gf_dasher_enable_real_time(dasher, frag_real_time);
 		if (!e) e = gf_dasher_set_content_protection_location_mode(dasher, cp_location_mode);
 		if (!e) e = gf_dasher_set_profile_extension(dasher, dash_profile_extension);
+		if (!e) e = gf_dasher_set_cache_options(dasher, no_cache);
 
 		for (i=0; i < nb_dash_inputs; i++) {
 			if (!e) e = gf_dasher_add_input(dasher, &dash_inputs[i]);

--- a/applications/mp4box/main.c
+++ b/applications/mp4box/main.c
@@ -4012,7 +4012,7 @@ int mp4boxMain(int argc, char **argv)
 		if (!e) e = gf_dasher_enable_real_time(dasher, frag_real_time);
 		if (!e) e = gf_dasher_set_content_protection_location_mode(dasher, cp_location_mode);
 		if (!e) e = gf_dasher_set_profile_extension(dasher, dash_profile_extension);
-		if (!e) e = gf_dasher_set_cache_options(dasher, no_cache);
+		if (!e) e = gf_dasher_enable_cached_inputs(dasher, no_cache);
 		if (!e) e = gf_dasher_set_test_mode(dasher,force_test_mode);
 
 		for (i=0; i < nb_dash_inputs; i++) {

--- a/include/gpac/media_tools.h
+++ b/include/gpac/media_tools.h
@@ -838,14 +838,14 @@ GF_Err gf_dasher_set_profile_extension(GF_DASHSegmenter *dasher, const char *das
 GF_Err gf_dasher_set_test_mode(GF_DASHSegmenter *dasher, Bool forceTestMode);
 
 /*!
- Sets cache options for dasher .
+ Enable/Disable cached inputs .
  *	\param dasher the DASH segmenter object
  *	\param no_cache if true, input file will be reopen each time the dasher process function is called .
  *	\return error code if any
 */
 
 GF_EXPORT
-GF_Err gf_dasher_set_cache_options(GF_DASHSegmenter *dasher, Bool no_cache);
+GF_Err gf_dasher_enable_cached_inputs(GF_DASHSegmenter *dasher, Bool no_cache);
 
 /*!
  Adds a media input to the DASHer

--- a/include/gpac/media_tools.h
+++ b/include/gpac/media_tools.h
@@ -528,6 +528,8 @@ typedef struct
 	u32 bandwidth;
 	/*! forced period duration (used when using empty periods or xlink periods without content)*/
 	Double period_duration;
+	/*! if true, the dasher inputs will open each time the segmentation function is called */
+	Bool no_cache;
 } GF_DashSegmenterInput;
 
 /*!
@@ -827,6 +829,16 @@ GF_Err gf_dasher_set_content_protection_location_mode(GF_DASHSegmenter *dasher, 
  *	\return error code if any
 */
 GF_Err gf_dasher_set_profile_extension(GF_DASHSegmenter *dasher, const char *dash_profile_extension);
+
+/*!
+ Sets cache options for dasher .
+ *	\param dasher the DASH segmenter object
+ *	\param no_cache if true, input file will be reopen each time the dasher process function is called .
+ *	\return error code if any
+*/
+
+GF_EXPORT
+GF_Err gf_dasher_set_cache_options(GF_DASHSegmenter *dasher, Bool no_cache);
 
 /*!
  Adds a media input to the DASHer

--- a/src/media_tools/dash_segmenter.c
+++ b/src/media_tools/dash_segmenter.c
@@ -5887,7 +5887,7 @@ GF_Err gf_dasher_set_profile_extension(GF_DASHSegmenter *dasher, const char *das
 }
 
 GF_EXPORT
-GF_Err gf_dasher_set_cache_options(GF_DASHSegmenter *dasher, Bool no_cache)
+GF_Err gf_dasher_enable_cached_inputs(GF_DASHSegmenter *dasher, Bool no_cache)
 {
 	if (!dasher) return GF_BAD_PARAM;
 	if(no_cache)dasher->no_cache = GF_TRUE;

--- a/src/media_tools/dash_segmenter.c
+++ b/src/media_tools/dash_segmenter.c
@@ -132,6 +132,7 @@ struct __gf_dash_segmenter
 	GF_DASH_ContentLocationMode cp_location_mode;
 
 	Double max_segment_duration;
+	Bool no_cache;
 
 };
 
@@ -210,6 +211,7 @@ struct _dash_segment_input
 	Bool get_component_info_done;
 	//cached isobmf input
 	GF_ISOFile *isobmf_input;
+	Bool no_cache;
 };
 
 
@@ -3331,7 +3333,12 @@ static GF_Err dasher_isom_segment_file(GF_DashSegInput *dash_input, const char *
 	}
 
 
-	return gf_media_isom_segment_file(dash_input->isobmf_input, szOutName, dash_cfg, dash_input, first_in_set);
+	e= gf_media_isom_segment_file(dash_input->isobmf_input, szOutName, dash_cfg, dash_input, first_in_set);
+	if(dash_input->no_cache){
+		gf_isom_delete(dash_input->isobmf_input);
+		dash_input->isobmf_input=NULL;
+	}
+	return e;
 }
 
 #endif /*GPAC_DISABLE_ISOM_FRAGMENTS*/
@@ -5857,6 +5864,14 @@ GF_Err gf_dasher_set_profile_extension(GF_DASHSegmenter *dasher, const char *das
 	return GF_OK;
 }
 
+GF_EXPORT
+GF_Err gf_dasher_set_cache_options(GF_DASHSegmenter *dasher, Bool no_cache)
+{
+	if (!dasher) return GF_BAD_PARAM;
+	if(no_cache)dasher->no_cache = GF_TRUE;
+	return GF_OK;
+}
+
 
 GF_EXPORT
 GF_Err gf_dasher_add_input(GF_DASHSegmenter *dasher, GF_DashSegmenterInput *input)
@@ -5890,6 +5905,7 @@ GF_Err gf_dasher_add_input(GF_DASHSegmenter *dasher, GF_DashSegmenterInput *inpu
 	dash_input->as_c_descs = input->as_c_descs;
 	dash_input->nb_p_descs = input->nb_p_descs;
 	dash_input->p_descs = input->p_descs;
+	dash_input->no_cache = dasher->no_cache;
 
 	dash_input->bandwidth = input->bandwidth;
 


### PR DESCRIPTION
This PR adds an option to disable cache for dasher inputs. 

It fixes issue #835 

One can now use the following command with growing file:

MP3Box -dash-live 2000 -subdur 1000 /tmp/growingfile.mp4
