### PR TITLE
fix 2 memory leaks in dash_segmenter

### DIFF
--- a/tests/make_tests.sh
+++ b/tests/make_tests.sh
@@ -1162,9 +1162,29 @@ do_hash_test ()
   rv=$?
 
   if [ $rv != 0 ] ; then
+   hashres=0
    fhash=`hexdump -ve '1/1 "%.2X"' $ref_hash`
    echo "Hash fail, ref hash $ref_hash was $fhash"  >> $log_subtest
-   echo "HASH_FAIL=1" >> $STATHASH_SH
+   shopt -s nullglob
+   for alt_ref in "$ref_hash-alt"* ; do
+    $DIFF $test_hash $alt_ref > /dev/null
+    rv_alt=$?
+    if [ $rv_alt != 0 ] ; then
+      fhash=`hexdump -ve '1/1 "%.2X"' $alt_ref`
+      echo "Hash alt fail, alt ref $alt_ref was $fhash"  >> $log_subtest
+    else
+      hashres=1
+      echo "Hash alt OK with alt ref $alt_ref"  >> $log_subtest
+      break
+    fi
+   done
+   shopt -u nullglob
+   if [ $hashres != 0 ] ; then
+    echo "Hash OK for $1"  >> $log_subtest
+    echo "HASH_FAIL=0" >> $STATHASH_SH
+   else
+    echo "HASH_FAIL=1" >> $STATHASH_SH
+   fi
   else
    echo "Hash OK for $1"  >> $log_subtest
    echo "HASH_FAIL=0" >> $STATHASH_SH

--- a/tests/scripts/dash-descriptor.sh
+++ b/tests/scripts/dash-descriptor.sh
@@ -1,4 +1,4 @@
-test_begin "dash"
+test_begin "dash-descriptor"
 
 do_test "$MP4BOX -add $EXTERNAL_MEDIA_DIR/counter/counter_30s_I25_baseline_1280x720_512kbps.264 -add $EXTERNAL_MEDIA_DIR/counter/counter_30s_audio.aac -new $TEMP_DIR/file.mp4" "dash-input-preparation"
 


### PR DESCRIPTION
running the tests with --enable-mem-track revealed two leaks in dash_segmenter that should be fixed by this PR

(also in this, small changes on test scripts)