### PR TITLE
gf_isom_get_edit_list_type() offset is consistently in media timescale

### DIFF
--- a/include/gpac/isomedia.h
+++ b/include/gpac/isomedia.h
@@ -789,7 +789,9 @@ sampleNumber is optional and gives the number of the sample in the media
 */
 GF_Err gf_isom_get_sample_for_movie_time(GF_ISOFile *the_file, u32 trackNumber, u64 movieTime, u32 *StreamDescriptionIndex, u8 SearchMode, GF_ISOSample **sample, u32 *sampleNumber);
 
-/*return 1 if true edit list, 0 if no edit list or if time-shifting only edit list, in which case mediaOffset is set to the DTS offset value (e.g., your app should add mediaOffset to all sample DTS)*/
+/*return 1 if true edit list, 0 if no edit list or if time-shifting only edit list,
+  in which case mediaOffset is set to the DTS offset value in the media track timescale
+  (e.g., your app should add mediaOffset to all sample DTS)*/
 Bool gf_isom_get_edit_list_type(GF_ISOFile *the_file, u32 trackNumber, s64 *mediaOffset);
 
 /*get the number of edited segment*/
@@ -1212,7 +1214,7 @@ the new segment
 WARNING: The first segment always have an EditTime of 0. You should insert an empty or dwelled segment first.*/
 GF_Err gf_isom_set_edit_segment(GF_ISOFile *the_file, u32 trackNumber, u64 EditTime, u64 EditDuration, u64 MediaTime, u8 EditMode);
 
-/*same as above except only modifies duartion type and mediaType*/
+/*same as above except only modifies duration type and mediaType*/
 GF_Err gf_isom_modify_edit_segment(GF_ISOFile *the_file, u32 trackNumber, u32 seg_index, u64 EditDuration, u64 MediaTime, u8 EditMode);
 /*same as above except only appends new segment*/
 GF_Err gf_isom_append_edit_segment(GF_ISOFile *the_file, u32 trackNumber, u64 EditDuration, u64 MediaTime, u8 EditMode);

--- a/src/isomedia/isom_read.c
+++ b/src/isomedia/isom_read.c
@@ -2011,7 +2011,10 @@ Bool gf_isom_get_edit_list_type(GF_ISOFile *the_file, u32 trackNumber, s64 *medi
 	if (!ent) return GF_TRUE;
 	/*mediaRate>0, the track playback shall start at media time>0 -> mediaOffset is < 0 */
 	if ((count==1) && (ent->mediaRate==1)) {
-		*mediaOffset = - ent->mediaTime;
+		Double time = (Double)-ent->mediaTime;
+		time /= trak->moov->mvhd->timeScale;
+		time *= trak->Media->mediaHeader->timeScale;
+		*mediaOffset = (s64)time;
 		return GF_FALSE;
 	} else if (count==2) {
 		/*mediaRate==-1, the track playback shall be empty for segmentDuration -> mediaOffset is > 0 */
@@ -2019,7 +2022,6 @@ Bool gf_isom_get_edit_list_type(GF_ISOFile *the_file, u32 trackNumber, s64 *medi
 			Double time = (Double) ent->segmentDuration;
 			time /= trak->moov->mvhd->timeScale;
 			time *= trak->Media->mediaHeader->timeScale;
-
 			*mediaOffset = (s64) time;
 			return GF_FALSE;
 		}


### PR DESCRIPTION
@jeanlf used at https://github.com/gpac/gpac/search?utf8=%E2%9C%93&q=gf_isom_get_edit_list_type&type= so seems ok to me. Please merge if ok for you too