### PR TITLE
Typo in tenc_dump()

### DIFF
--- a/src/isomedia/box_dump.c
+++ b/src/isomedia/box_dump.c
@@ -4503,7 +4503,7 @@ GF_Err tenc_dump(GF_Box *a, FILE * trace)
 		fprintf(trace, " IV_size=\"%d\" KID=\"", ptr->Per_Sample_IV_Size);
 	else {
 		fprintf(trace, " constant_IV_size=\"%d\" constant_IV=\"", ptr->constant_IV_size);
-		dump_data_hex(trace, (char *) ptr->constant_IV, 16);
+		dump_data_hex(trace, (char *) ptr->constant_IV, ptr->constant_IV_size);
 		fprintf(trace, "\"  KID=\"");
 	}
 	dump_data_hex(trace, (char *) ptr->KID, 16);

--- a/src/isomedia/box_dump.c
+++ b/src/isomedia/box_dump.c
@@ -4503,7 +4503,7 @@ GF_Err tenc_dump(GF_Box *a, FILE * trace)
 		fprintf(trace, " IV_size=\"%d\" KID=\"", ptr->Per_Sample_IV_Size);
 	else {
 		fprintf(trace, " constant_IV_size=\"%d\" constant_IV=\"", ptr->constant_IV_size);
-		dump_data_hex(trace, (char *) ptr->KID, 16);
+		dump_data_hex(trace, (char *) ptr->constant_IV, 16);
 		fprintf(trace, "\"  KID=\"");
 	}
 	dump_data_hex(trace, (char *) ptr->KID, 16);


### PR DESCRIPTION
Hi,

I noticed that `tenc` box writes _key id_ value instead of _IV_ when doing `MP4Box -diso`. This is caused by a typo or copy-paste error that my pull request fixes.

Cheers, Tijn