### PR TITLE
Use pkg-config to find freetype

### DIFF
--- a/configure
+++ b/configure
@@ -1125,8 +1125,8 @@ if docc $CFLAGS_DIR $ft_cflags $ft_lflags $LDFLAGS ; then
 fi
 if test "$cross_prefix" = "" ; then
     if test "$has_ft" = "no" ; then
-        ft_cflags="`freetype-config --cflags 2>>$logs`"
-        ft_lflags="`freetype-config --libs 2>>$logs`"
+        ft_cflags="`pkg-config --cflags freetype2 2>>$logs`"
+        ft_lflags="`pkg-config --libs freetype2 2>>$logs`"
         if docc $ft_cflags $ft_lflags $LDFLAGS ; then
             has_ft="system"
         fi


### PR DESCRIPTION
As of freetype-2.9.1 the freetype-config file no longer gets installed
by default.

See also [Make installation of `freetype-config' optional](http://git.savannah.gnu.org/cgit/freetype/freetype2.git/commit/?id=a7833f26c4ac45cafe1dffdcd7f7dcfd6493161c) commit by freetype upstream. 