### PR TITLE
fix edit list generation when CTS offsets are shifted

### DIFF
--- a/src/media_tools/media_import.c
+++ b/src/media_tools/media_import.c
@@ -5570,6 +5570,8 @@ restart_import:
 
 		if (min_cts_offset > 0) {
 			gf_isom_shift_cts_offset(import->dest, track, (s32)min_cts_offset);
+			max_cts -= min_cts_offset;
+			min_cts -= min_cts_offset;
 		}
 		/*and repack table*/
 		gf_isom_set_cts_packing(import->dest, track, GF_FALSE);


### PR DESCRIPTION
It seems that generation of edit lists was broken since 7b8a11912592f2ebe1f5db221e7b6b78af43 (May 31st, 2017!). The cts values were shifted but min and max used to generate the edit lists were not. In one example I have, the first cts_offset was 1000 but the edit list had a first segment starting at 2000, missing one frame. This can be reproduced with http://download.opencontent.netflix.com.s3.amazonaws.com/TechblogAssets/Sparks/encodes/Sparks_4096x2160_5994fps_SDR.mp4
Simply export and reimport the video track to see the problem.