### PR TITLE
Added composing of the mfra box when producing fragmented mp4.

### DIFF
--- a/include/gpac/internal/isomedia_dev.h
+++ b/include/gpac/internal/isomedia_dev.h
@@ -3238,6 +3238,9 @@ struct __tag_isom {
 	/* 0: no moof found yet, 1: 1 moof found, 2: next moof found */
 	Bool single_moof_mode;
 	u32 single_moof_state;
+
+	/* optional mfra box used in write mode */
+	GF_MovieFragmentRandomAccessBox *mfra;
 #endif
 	GF_ProducerReferenceTimeBox *last_producer_ref_time;
 

--- a/src/isomedia/box_code_base.c
+++ b/src/isomedia/box_code_base.c
@@ -3141,6 +3141,9 @@ GF_Err mfra_Write(GF_Box *s, GF_BitStream *bs)
 	GF_Err e;
 	GF_MovieFragmentRandomAccessBox *ptr = (GF_MovieFragmentRandomAccessBox *)s;
 
+	e = gf_isom_box_write_header(s, bs);
+	if (e) return e;
+
 	e = gf_isom_box_array_write(s, ptr->tfra_list, bs);
 	if (e) return e;
 	if (ptr->mfro) {
@@ -3284,7 +3287,7 @@ GF_Err tfra_Size(GF_Box *s)
 
 	ptr->size += 12;
 
-	ptr->size += ptr->nb_entries * ( ((ptr->version==1) ? 16 : 8 ) + ptr->traf_bits + ptr->trun_bits + ptr->sample_bits);
+	ptr->size += ptr->nb_entries * ( ((ptr->version==1) ? 16 : 8 ) + ptr->traf_bits/8 + ptr->trun_bits/8 + ptr->sample_bits/8);
 	return GF_OK;
 }
 

--- a/src/isomedia/isom_intern.c
+++ b/src/isomedia/isom_intern.c
@@ -657,6 +657,7 @@ void gf_isom_delete_movie(GF_ISOFile *mov)
 	gf_isom_box_array_del(mov->TopBoxes);
 #ifndef GPAC_DISABLE_ISOM_FRAGMENTS
 	gf_isom_box_array_del(mov->moof_list);
+	gf_isom_box_del(mov->mfra);
 #endif
 	if (mov->last_producer_ref_time)
 		gf_isom_box_del((GF_Box *) mov->last_producer_ref_time);

--- a/src/isomedia/isom_read.c
+++ b/src/isomedia/isom_read.c
@@ -464,6 +464,16 @@ GF_Err gf_isom_write(GF_ISOFile *movie) {
 		if ( (movie->openMode == GF_ISOM_OPEN_WRITE) && (movie->FragmentsFlags & GF_ISOM_FRAG_WRITE_READY) ) {
 			e = gf_isom_close_fragments(movie);
 			if (e) return e;
+			//in case of mfra box usage -> create mfro, calculate box sizes and write it out
+			if (movie->mfra) {
+				movie->mfra->mfro = (GF_MovieFragmentRandomAccessOffsetBox *)gf_isom_box_new(GF_ISOM_BOX_TYPE_MFRO);
+				e = gf_isom_box_size((GF_Box *)movie->mfra);
+				if (e) return e;
+				movie->mfra->mfro->container_size = movie->mfra->size;
+				//write mfra
+				GF_BitStream *bs = movie->editFileMap->bs;
+				e = gf_isom_box_write((GF_Box *)movie->mfra, bs);
+			}
 		} else
 #endif
 			e = WriteToFile(movie);


### PR DESCRIPTION
mfra is created according to ISO/IEC 14496-12:2015(E)
part 8.8.9 Movie Fragment Random Access Box
Presence of this box speeds up seeking over fragmented file

It also fixes some issues on mfra write out (eg missed writing box header, etc)
Debugging/testing were done @win32 using msvc compiler on gpac_mp4box_mini solution.

As a proposal maybe it makes sense to add new cmd line option for this mfra box? (say "-mfra)