### PR TITLE
ICC color profile support for HEIF

### DIFF
--- a/applications/mp4box/main.c
+++ b/applications/mp4box/main.c
@@ -830,6 +830,7 @@ void PrintMetaUsage()
 		"						 split_tiles		for an HEVC tiled image, each tile is stored as a separate item\n"
 		"                        rotation=a       sets the rotation angle for this image to 90*a degrees anti-clockwise.\n"
 		"                        image-hidden       indicates that this image item should be hidden.\n"
+		"                        icc_path           path to icc to add as colr.\n"
 		" -rem-item args       removes resource from meta - syntax: item_ID[:tk=ID]\n"
 		" -set-primary args    sets item as primary for meta - syntax: item_ID[:tk=ID]\n"
 		" -set-xml args        sets meta XML data\n"
@@ -1444,6 +1445,13 @@ static Bool parse_meta_args(MetaAction *meta, MetaActionType act_type, char *opt
 		}
 		else if (!stricmp(szSlot, "binary")) {
 			if (meta->act_type==META_ACTION_SET_XML) meta->act_type=META_ACTION_SET_BINARY_XML;
+			ret = 1;
+		}
+		else if (!strnicmp(szSlot, "icc_path=", 9)) {
+			if (!meta->image_props) {
+				GF_SAFEALLOC(meta->image_props, GF_ImageItemProperties);
+			}
+			strcpy(meta->image_props->iccPath, szSlot+9);
 			ret = 1;
 		}
 		else if (!strchr(szSlot, '=')) {

--- a/applications/mp4box/main.c
+++ b/applications/mp4box/main.c
@@ -434,6 +434,8 @@ void PrintDASHUsage()
 	        "                        both: sets ContentProtection in both elements\n"
 	        " -start-date          for live mode, sets start date (as xs:date, eg YYYY-MM-DDTHH:MM:SSZ. Default is now.\n"
 	        "                        !! Do not use with multiple periods, nor when DASH duration is not a multiple of GOP size !!\n"
+	        " -cues                ignores dash duration and segment according to cue times in given XML file. See tests/media/dash_cues for examples.\n"
+	        " -strict-cues         throw error if something is wrong while parsing cues or applying cue-based segmentation.\n"
 	        "\n");
 }
 
@@ -1972,6 +1974,8 @@ Bool segment_timeline = GF_FALSE;
 u32 segment_marker = GF_FALSE;
 GF_DashProfile dash_profile = GF_DASH_PROFILE_UNKNOWN;
 const char *dash_profile_extension = NULL;
+const char *dash_cues = NULL;
+Bool strict_cues = GF_FALSE;
 Bool use_url_template = GF_FALSE;
 Bool seg_at_rap = GF_FALSE;
 Bool frag_at_rap = GF_FALSE;
@@ -3566,6 +3570,14 @@ Bool mp4box_parse_args(int argc, char **argv)
 			segment_marker = GF_4CC(m[0], m[1], m[2], m[3]);
 			i++;
 		}
+		else if (!stricmp(arg, "-cues")) {
+			CHECK_NEXT_ARG
+			dash_cues = argv[i + 1];
+			i++;
+		}
+		else if (!stricmp(arg, "-strict-cues")) {
+			strict_cues = GF_TRUE;
+		}
 		else if (!stricmp(arg, "-insert-utc")) {
 			insert_utc = GF_TRUE;
 		}
@@ -4220,6 +4232,7 @@ int mp4boxMain(int argc, char **argv)
 		if (!e) e = gf_dasher_enable_loop_inputs(dasher, ! no_loop);
 		if (!e) e = gf_dasher_set_split_on_bound(dasher, split_on_bound);
 		if (!e) e = gf_dasher_set_split_on_closest(dasher, split_on_closest);
+		if (!e && dash_cues) e = gf_dasher_set_cues(dasher, dash_cues, strict_cues);
 
 		for (i=0; i < nb_dash_inputs; i++) {
 			if (!e) e = gf_dasher_add_input(dasher, &dash_inputs[i]);

--- a/include/gpac/isomedia.h
+++ b/include/gpac/isomedia.h
@@ -350,6 +350,7 @@ enum
 
 	/* on-screen colours */
 	GF_ISOM_SUBTYPE_NCLX 		= GF_4CC( 'n', 'c', 'l', 'x' ),
+	GF_ISOM_SUBTYPE_PROF 		= GF_4CC( 'p', 'r', 'o', 'f' ),
 };
 
 
@@ -2471,6 +2472,7 @@ typedef struct
 	GF_TileItemMode tile_mode;
 	u32 single_tile_number;
 	double time;
+	char iccPath[GF_MAX_PATH];
 } GF_ImageItemProperties;
 
 GF_Err gf_isom_meta_get_next_item_id(GF_ISOFile *file, Bool root_meta, u32 track_num, u32 *item_id);

--- a/src/isomedia/box_dump.c
+++ b/src/isomedia/box_dump.c
@@ -28,6 +28,7 @@
 #include <gpac/network.h>
 #include <gpac/color.h>
 #include <gpac/avparse.h>
+#include <gpac/base_coding.h>
 #include <time.h>
 
 #ifndef GPAC_DISABLE_ISOM_DUMP
@@ -4746,10 +4747,21 @@ GF_Err ispe_dump(GF_Box *a, FILE * trace)
 
 GF_Err colr_dump(GF_Box *a, FILE * trace)
 {
+	u8 *prof_data_64=NULL;
+	u32 size_64;
 	GF_ColourInformationBox *ptr = (GF_ColourInformationBox *)a;
 	if (!a) return GF_BAD_PARAM;
 	gf_isom_box_dump_start(a, "ColourInformationBox", trace);
 	fprintf(trace, "colour_type=\"%s\" colour_primaries=\"%d\" transfer_characteristics=\"%d\" matrix_coefficients=\"%d\" full_range_flag=\"%d\">\n", gf_4cc_to_str(ptr->colour_type), ptr->colour_primaries, ptr->transfer_characteristics, ptr->matrix_coefficients, ptr->full_range_flag);
+	if (ptr->opaque != NULL && ptr->colour_type == GF_ISOM_SUBTYPE_PROF) {
+		fprintf(trace, "<profile><![CDATA[");
+		size_64 = 2*ptr->opaque_size;
+		prof_data_64 = gf_malloc(size_64);
+		size_64 = gf_base64_encode(ptr->opaque, ptr->opaque_size, (char *)prof_data_64, size_64);
+		prof_data_64[size_64] = 0;
+		fprintf(trace, "%s", prof_data_64);
+		fprintf(trace, "]]></profile>");
+	}
 	gf_isom_box_dump_done("ColourInformationBox", a, trace);
 	return GF_OK;
 }

--- a/src/isomedia/iff.c
+++ b/src/isomedia/iff.c
@@ -112,7 +112,6 @@ GF_Err colr_Read(GF_Box *s, GF_BitStream *bs)
 	} else {
 		p->opaque = gf_malloc(sizeof(u8)*(size_t)p->size);
 		p->opaque_size = (u32) p->size;
-		GF_LOG(GF_LOG_INFO, GF_LOG_CONTAINER, ("[iso file] %s colour profile not supported, not parsing\n", gf_4cc_to_str(p->colour_type) ));
 		gf_bs_read_data(bs, (char *) p->opaque, p->opaque_size);
 	}
 	return GF_OK;


### PR DESCRIPTION
This pull request closes issue #1080. It adds a command-line option to MP4Box (`icc_path`) to add an ICC color profile when writing a HEIF file. Also, when reading a HEIF file with an ICC color profile, it adds it (base64 encoded) to the IsoMedia XML dump.

This change is needed to correctly read and write HEIF images with a non-sRGB color profile, for example HEIF images created by iOS devices (which use the wider gamut P3 color profile).