### PR TITLE
added parsing of vpcc box for VP8/9 (#1114)

### DIFF
--- a/include/gpac/internal/isomedia_dev.h
+++ b/include/gpac/internal/isomedia_dev.h
@@ -185,6 +185,11 @@ enum
 	GF_ISOM_BOX_TYPE_AV1C = GF_4CC('a', 'v', '1', 'C'),
 	GF_ISOM_BOX_TYPE_AV01 = GF_4CC('a', 'v', '0', '1'),
 
+	/* WebM */
+	GF_ISOM_BOX_TYPE_VPCC = GF_4CC('v', 'p', 'c', 'C'),
+	GF_ISOM_BOX_TYPE_VP08 = GF_4CC('v', 'p', '0', '8'),
+	GF_ISOM_BOX_TYPE_VP09 = GF_4CC('v', 'p', '0', '9'),
+
 	/*LASeR extension*/
 	GF_ISOM_BOX_TYPE_LSRC	= GF_4CC( 'l', 's', 'r', 'C' ),
 	GF_ISOM_BOX_TYPE_LSR1	= GF_4CC( 'l', 's', 'r', '1' ),
@@ -1138,6 +1143,12 @@ typedef struct
 
 typedef struct
 {
+	GF_ISOM_FULL_BOX
+	GF_VPConfig *config;
+} GF_VPConfigurationBox;
+
+typedef struct
+{
 	GF_ISOM_BOX
 	GF_3GPConfig cfg;
 } GF_3GPPConfigBox;
@@ -1158,6 +1169,9 @@ typedef struct
 	GF_HEVCConfigurationBox *lhvc_config;
 	/*av1 extension*/
 	GF_AV1ConfigurationBox *av1_config;
+	/*vp8-9 extension*/
+	GF_VPConfigurationBox *vp_config;
+
 
 	/*ext descriptors*/
 	GF_MPEG4ExtensionDescriptorsBox *descr;

--- a/include/gpac/isomedia.h
+++ b/include/gpac/isomedia.h
@@ -311,6 +311,10 @@ enum
 	/*AV1 media type*/
 	GF_ISOM_SUBTYPE_AV01 = GF_4CC('a', 'v', '0', '1'),
 
+	/* VP */
+	GF_ISOM_SUBTYPE_VP08 = GF_4CC('v', 'p', '0', '8'),
+	GF_ISOM_SUBTYPE_VP09 = GF_4CC('v', 'p', '0', '9'),
+
 	/*3GPP(2) extension subtypes*/
 	GF_ISOM_SUBTYPE_3GP_H263	= GF_4CC( 's', '2', '6', '3' ),
 	GF_ISOM_SUBTYPE_3GP_AMR		= GF_4CC( 's', 'a', 'm', 'r' ),
@@ -1128,7 +1132,7 @@ Use streamDescriptionIndex to specify the desired stream (if several)*/
 GF_Err gf_isom_add_sample_reference(GF_ISOFile *the_file, u32 trackNumber, u32 StreamDescriptionIndex, GF_ISOSample *sample, u64 dataOffset);
 
 /*set the duration of the last media sample. If not set, the duration of the last sample is the
-duration of the previous one if any, or media TimeScale (default value). This does not modify the edit list if any, 
+duration of the previous one if any, or media TimeScale (default value). This does not modify the edit list if any,
 you must modify this using gf_isom_set_edit_segment*/
 GF_Err gf_isom_set_last_sample_duration(GF_ISOFile *the_file, u32 trackNumber, u32 duration);
 
@@ -1988,6 +1992,9 @@ GF_HEVCConfig *gf_isom_lhvc_config_get(GF_ISOFile *the_file, u32 trackNumber, u3
 
 /*gets AV1 config - user is responsible for deleting it*/
 GF_AV1Config *gf_isom_av1_config_get(GF_ISOFile *the_file, u32 trackNumber, u32 DescriptionIndex);
+
+/*gets VP config - user is responsible for deleting it*/
+GF_VPConfig *gf_isom_vp_config_get(GF_ISOFile *the_file, u32 trackNumber, u32 DescriptionIndex);
 
 /*return true if track dependencies implying extractors or implicit reconstruction are found*/
 Bool gf_isom_needs_layer_reconstruction(GF_ISOFile *file);

--- a/include/gpac/mpeg4_odf.h
+++ b/include/gpac/mpeg4_odf.h
@@ -1010,6 +1010,29 @@ typedef struct
 	GF_List *obu_array; /*GF_AV1_OBUArrayEntry*/
 } GF_AV1Config;
 
+
+/*! VP8-9 config vpcC */
+typedef struct
+{
+	u8	profile;
+	u8	level;
+
+	/*unsigned int(4)     bitDepth;
+	unsigned int(3)     chromaSubsampling;
+	unsigned int(1)     videoFullRangeFlag;*/
+	u8   bit_depth;
+	u8   chroma_subsampling;
+	Bool video_fullRange_flag;
+
+	u8  colour_primaries;
+	u8  transfer_characteristics;
+	u8  matrix_coefficients;
+
+	/* MUST be 0 for VP8 and VP9 */
+	u16 codec_initdata_size;
+	u8* codec_initdata;
+} GF_VPConfig;
+
 /*! Media Segment Descriptor used for Media Control Extensions*/
 typedef struct
 {
@@ -1333,6 +1356,15 @@ GF_Err gf_odf_av1_cfg_write(GF_AV1Config *cfg, char **outData, u32 *outSize);
 \return the decoded HEVC config
 */
 GF_Err gf_odf_av1_cfg_write_bs(GF_AV1Config *cfg, GF_BitStream *bs);
+
+
+/* VP8-9 descriptors functions */
+GF_VPConfig *gf_odf_vp_cfg_new();
+void gf_odf_vp_cfg_del(GF_VPConfig *cfg);
+GF_Err gf_odf_vp_cfg_write_bs(GF_VPConfig *cfg, GF_BitStream *bs);
+GF_Err gf_odf_vp_cfg_write(GF_VPConfig *cfg, char **outData, u32 *outSize);
+GF_VPConfig *gf_odf_vp_cfg_read_bs(GF_BitStream *bs);
+GF_VPConfig *gf_odf_vp_cfg_read(char *dsi, u32 dsi_size);
 
 
 /*! destroy the descriptors in a list but not the list

--- a/src/isomedia/box_dump.c
+++ b/src/isomedia/box_dump.c
@@ -1608,6 +1608,29 @@ GF_Err av1c_dump(GF_Box *a, FILE *trace) {
 	return GF_OK;
 }
 
+
+GF_Err vpcc_dump(GF_Box *a, FILE *trace) {
+	GF_VPConfigurationBox *ptr = (GF_VPConfigurationBox*)a;
+	fprintf(trace, "<VPConfigurationBox>\n");
+	if (ptr->config) {
+		fprintf(trace, "<VPConfig");
+
+		fprintf(trace, " profile=\"%u\"", ptr->config->profile);
+		fprintf(trace, " level=\"%u\"", ptr->config->level);
+		fprintf(trace, " bit_depth=\"%u\"", ptr->config->bit_depth);
+		fprintf(trace, " chroma_subsampling=\"%u\"", ptr->config->chroma_subsampling);
+		fprintf(trace, " video_fullRange_flag=\"%u\"", ptr->config->video_fullRange_flag);
+		fprintf(trace, " colour_primaries=\"%u\"", ptr->config->colour_primaries);
+		fprintf(trace, " transfer_characteristics=\"%u\"", ptr->config->transfer_characteristics);
+		fprintf(trace, " matrix_coefficients=\"%u\"", ptr->config->matrix_coefficients);
+		fprintf(trace, " codec_initdata_size=\"%u\"", ptr->config->codec_initdata_size);
+
+		fprintf(trace, ">\n</VPConfig>\n");
+	}
+	fprintf(trace, "</VPConfigurationBox>\n");
+	return GF_OK;
+}
+
 GF_Err m4ds_dump(GF_Box *a, FILE * trace)
 {
 	u32 i;

--- a/src/isomedia/box_funcs.c
+++ b/src/isomedia/box_funcs.c
@@ -632,6 +632,7 @@ ISOM_BOX_IMPL_DECL(cslg)
 ISOM_BOX_IMPL_DECL(ccst)
 ISOM_BOX_IMPL_DECL(hvcc)
 ISOM_BOX_IMPL_DECL(av1c)
+ISOM_BOX_IMPL_DECL(vpcc)
 ISOM_BOX_IMPL_DECL(prft)
 
 ISOM_BOX_IMPL_DECL(trep)
@@ -1025,6 +1026,11 @@ static const struct box_registry_entry {
 	//AV1 in ISOBMFF boxes
 	BOX_DEFINE_S(GF_ISOM_BOX_TYPE_AV01, video_sample_entry, "stsd", "av1"),
 	FBOX_DEFINE_FLAGS_S(GF_ISOM_BOX_TYPE_AV1C, av1c, "av01 encv resv", 0, 0, "av1"),
+
+	// VP8-9 boxes
+	FBOX_DEFINE_FLAGS_S( GF_ISOM_BOX_TYPE_VPCC, vpcc, "vp08 vp09", 1, 0, "vp"),
+	BOX_DEFINE_S( GF_ISOM_BOX_TYPE_VP08, video_sample_entry, "stsd", "vp"),
+	BOX_DEFINE_S( GF_ISOM_BOX_TYPE_VP09, video_sample_entry, "stsd", "vp"),
 
 	//part20 boxes
 	BOX_DEFINE_S( GF_ISOM_BOX_TYPE_LSR1, lsr1, "stsd", "p20"),

--- a/src/media_tools/dash_segmenter.c
+++ b/src/media_tools/dash_segmenter.c
@@ -672,7 +672,7 @@ GF_Err gf_media_get_rfc_6381_codec_name(GF_ISOFile *movie, u32 track, char *szCo
 			av1_state.seq_profile, av1_state.seq_level_idx, av1_state.bit_depth,
 			av1_state.mono_chrome,
 			av1_state.chroma_subsampling_x, av1_state.chroma_subsampling_y, av1_state.chroma_sample_position);
-			
+
 		if (av1_state.color_description_present_flag) {
 			char tmp[RFC6381_CODEC_NAME_SIZE_MAX];
 			snprintf(tmp, RFC6381_CODEC_NAME_SIZE_MAX, "%01u.%01u.%01u.%01u", av1_state.color_primaries, av1_state.transfer_characteristics, av1_state.matrix_coefficients, av1_state.color_range);
@@ -691,6 +691,34 @@ GF_Err gf_media_get_rfc_6381_codec_name(GF_ISOFile *movie, u32 track, char *szCo
 		return GF_OK;
 	}
 #endif /*GPAC_DISABLE_AV1*/
+
+
+	case GF_ISOM_SUBTYPE_VP08:
+	case GF_ISOM_SUBTYPE_VP09:
+	{
+		GF_VPConfig *vpcc = NULL;
+
+		vpcc = gf_isom_vp_config_get(movie, track, 1);
+		if (!vpcc) {
+			GF_LOG(GF_LOG_DEBUG, GF_LOG_AUTHOR, ("[ISOM Tools] No config found for VP file (\"%s\") when computing RFC6381.\n", gf_4cc_to_str(subtype)));
+			return GF_BAD_PARAM;
+		}
+
+		snprintf(szCodec, RFC6381_CODEC_NAME_SIZE_MAX, "%s.%02u.%02u.%02u.%02u.%02u.%02u.%02u.%02u", gf_4cc_to_str(subtype),
+			vpcc->profile,
+			vpcc->level,
+			vpcc->bit_depth,
+			vpcc->chroma_subsampling,
+			vpcc->colour_primaries,
+			vpcc->transfer_characteristics,
+			vpcc->matrix_coefficients,
+			vpcc->video_fullRange_flag);
+
+
+		gf_odf_vp_cfg_del(vpcc);
+
+		return GF_OK;
+	}
 
 	default:
 		GF_LOG(GF_LOG_DEBUG, GF_LOG_AUTHOR, ("[ISOM Tools] codec parameters not known - setting codecs string to default value \"%s\"\n", gf_4cc_to_str(subtype) ));


### PR DESCRIPTION
[I'm putting this in a PR in case someone wants to review it before merging]

see #1114 for context

I added functions to parse the `vpcC` box of VP9 tracks base on this spec: https://www.webmproject.org/vp9/mp4

This allows to build an accurate codec info string for dash. I've probably missed some things but it should be enough for this particular purpose. 

[Note that when converting webm to mp4 with ffmpeg, the `level` field is lost and set to 0. I don't know if it's ffmpeg that doesn't copy it or if it's not actually stored in the webm file. In any case it works when giving it explicitly to ffmpeg: 

`ffmpeg -i in.web -c copy -level 50 out.mp4`

There's actually a commit at ffmpeg to guess the level based on other parameters but it's not in any release yet: https://github.com/FFmpeg/FFmpeg/commit/5b6cc3a73acb90df0d4fe5ca8f51527b64592bf8 ]
