### PR TITLE
fix bug in dash-cue option

### DIFF
--- a/include/gpac/internal/mpd.h
+++ b/include/gpac/internal/mpd.h
@@ -488,6 +488,7 @@ typedef struct
 	u32 sample_num;
 	u64 dts;
 	s64 cts;
+	Bool is_processed;
 } GF_DASHCueInfo;
 
 GF_Err gf_mpd_load_cues(const char *cues_file, u32 stream_id, u32 *cues_timescale, Bool *use_edit_list, GF_DASHCueInfo **out_cues, u32 *nb_cues);


### PR DESCRIPTION
The current code which uses the `memmove` approach does not seem to work. Running a simple test (based on https://github.com/gpac/gpac/blob/master/tests/scripts/dash_cues.sh) in debug mode triggers an assert https://github.com/gpac/gpac/blob/master/src/isomedia/movie_fragments.c#L1520: 
```
Assertion failed: (movie->root_sidx_index == movie->root_sidx->nb_refs), function gf_isom_close_segment, file gpac/src/isomedia/movie_fragments.c, line 1520.
```
Also if run in non-debug mode, this generates an invalid `sidx`, with as many entries as cues but with only the first entry having non-zero values.

In this PR, the cues are not memmoved, each cue is marked if processed. The simulation pass and the normal pass both work with the same number of cues. 