### PR TITLE
Add option to MP4Box to set initialization segment extension

### DIFF
--- a/applications/mp4box/main.c
+++ b/applications/mp4box/main.c
@@ -379,6 +379,7 @@ void PrintDASHUsage()
 	        "                      $Segment=NAME$ is replaced by NAME for media segments, ignored for init segments. May occur multiple times.\n"
 			"\n"
 	        " -segment-ext name    sets the segment extension. Default is m4s, \"null\" means no extension\n"
+	        " -init-segment-ext n  sets the segment extension for init segments (and index and bitstream switching segments). Default is mp4, \"null\" means no extension\n"
 	        " -segment-timeline    uses SegmentTimeline when generating segments.\n"
 	        " -segment-marker MARK adds a box of type \'MARK\' at the end of each DASH segment. MARK shall be a 4CC identifier\n"
 	        " -insert-utc          inserts UTC clock at the begining of each ISOBMF segment\n"

--- a/applications/mp4box/main.c
+++ b/applications/mp4box/main.c
@@ -1996,6 +1996,7 @@ GF_DashSegmenterInput *dash_inputs = NULL;
 u32 nb_dash_inputs = 0;
 char *gf_logs = NULL;
 char *seg_ext = NULL;
+char *init_seg_ext = NULL;
 const char *dash_title = NULL;
 const char *dash_source = NULL;
 const char *dash_more_info = NULL;
@@ -3393,6 +3394,11 @@ Bool mp4box_parse_args(int argc, char **argv)
 			seg_ext = argv[i + 1];
 			i++;
 		}
+		else if (!stricmp(arg, "-init-segment-ext")) {
+			CHECK_NEXT_ARG
+			init_seg_ext = argv[i + 1];
+			i++;
+		}
 		else if (!stricmp(arg, "-bs-switching")) {
 			CHECK_NEXT_ARG
 			if (!stricmp(argv[i + 1], "no") || !stricmp(argv[i + 1], "off")) bitstream_switching_mode = GF_DASH_BSMODE_NONE;
@@ -4208,7 +4214,7 @@ int mp4boxMain(int argc, char **argv)
 			use_url_template = GF_TRUE;
 		}
 
-		e = gf_dasher_enable_url_template(dasher, (Bool) use_url_template, seg_name, seg_ext);
+		e = gf_dasher_enable_url_template(dasher, (Bool) use_url_template, seg_name, seg_ext, init_seg_ext);
 		if (!e) e = gf_dasher_enable_segment_timeline(dasher, segment_timeline);
 		if (!e) e = gf_dasher_enable_single_segment(dasher, single_segment);
 		if (!e) e = gf_dasher_enable_single_file(dasher, single_file);

--- a/include/gpac/media_tools.h
+++ b/include/gpac/media_tools.h
@@ -690,10 +690,11 @@ GF_Err gf_dasher_add_base_url(GF_DASHSegmenter *dasher, const char *base_url);
  *	\param enable enable usage of URL template
  *	\param default_template template for the segment name
  *	\param default_extension extension for the segment name
+ *	\param default_extension extension for the initialization segment name
  *	\return error code if any
 */
 
-GF_Err gf_dasher_enable_url_template(GF_DASHSegmenter *dasher, Bool enable, const char *default_template, const char *default_extension);
+GF_Err gf_dasher_enable_url_template(GF_DASHSegmenter *dasher, Bool enable, const char *default_template, const char *default_extension, const char *default_init_extension);
 
 /*!
  Enable Segment Timeline template - may be overriden by the current profile


### PR DESCRIPTION
"-segment-ext" is currently ignored for initialization segments (and bitstream switching segments, and index segments). This PR adds "-init-segment-ext" to fix that.