### PR TITLE
add -mvex-after-traks option to MP4Box when dashing

### DIFF
--- a/applications/mp4box/main.c
+++ b/applications/mp4box/main.c
@@ -405,6 +405,7 @@ void PrintDASHUsage()
 	        " -pssh-moof           [deprecated] use -pssh=f\n"
 	        " -pssh=MODE           sets pssh store mode. Mode can be v (moov), f (frag), m (mpd) mv/vm (moov+mpd) mf/fm (moof+mpd).\n"
 	        " -sample-groups-traf  stores sample group descriptions in traf (duplicated for each traf). If not used, sample group descriptions are stored in the movie box.\n"
+			" -mvex-after-traks    Stores mvex box after trak boxes within the moov box. If not used, mvex is before.\n"
 	        " -no-cache            disable file cache for dash inputs .\n"
 	        " -no-loop             disables looping content in live mode and uses period switch instead.\n"
 	        " -bound               enables video segmentation with same method as audio (i.e.: always try to split before or at the segment boundary - not after)\n"
@@ -1967,6 +1968,7 @@ GF_MemTrackerType mem_track = GF_MemTrackerNone;
 Bool dump_iod = GF_FALSE;
 GF_DASHPSSHMode pssh_mode = 0;
 Bool samplegroups_in_traf = GF_FALSE;
+Bool mvex_after_traks = GF_FALSE;
 Bool daisy_chain_sidx = GF_FALSE;
 Bool single_segment = GF_FALSE;
 Bool single_file = GF_FALSE;
@@ -3529,6 +3531,9 @@ Bool mp4box_parse_args(int argc, char **argv)
 		else if (!stricmp(arg, "-sample-groups-traf")) {
 			samplegroups_in_traf = 1;
 		}
+		else if (!stricmp(arg, "-mvex-after-traks")) {
+			mvex_after_traks = GF_TRUE;
+		}
 		else if (!stricmp(arg, "-dash-profile") || !stricmp(arg, "-profile")) {
 			CHECK_NEXT_ARG
 			if (!stricmp(argv[i + 1], "live") || !stricmp(argv[i + 1], "simple")) dash_profile = GF_DASH_PROFILE_LIVE;
@@ -4233,6 +4238,7 @@ int mp4boxMain(int argc, char **argv)
 		if (!e) e = gf_dasher_set_split_on_bound(dasher, split_on_bound);
 		if (!e) e = gf_dasher_set_split_on_closest(dasher, split_on_closest);
 		if (!e && dash_cues) e = gf_dasher_set_cues(dasher, dash_cues, strict_cues);
+		if (!e) e = gf_dasher_set_isobmff_options(dasher, mvex_after_traks);
 
 		for (i=0; i < nb_dash_inputs; i++) {
 			if (!e) e = gf_dasher_add_input(dasher, &dash_inputs[i]);

--- a/include/gpac/internal/isomedia_dev.h
+++ b/include/gpac/internal/isomedia_dev.h
@@ -468,7 +468,6 @@ enum
 	GF_ISOM_SAMPLE_ENTRY_AUDIO = GF_4CC('a','u','d','i')
 };
 
-
 #ifndef GPAC_DISABLE_ISOM
 
 
@@ -703,6 +702,8 @@ typedef struct
 	GF_List *trackList;
 
 	GF_ISOFile *mov;
+
+	Bool mvex_after_traks;
 
 } GF_MovieBox;
 

--- a/include/gpac/isomedia.h
+++ b/include/gpac/isomedia.h
@@ -1436,7 +1436,7 @@ GF_Err gf_isom_clone_root_od(GF_ISOFile *input, GF_ISOFile *output);
 kept if keep_hint_tracks is set
 if keep_pssh, all pssh boxes will be kept
 fragment information (mvex) is not kept*/
-GF_Err gf_isom_clone_movie(GF_ISOFile *orig_file, GF_ISOFile *dest_file, Bool clone_tracks, Bool keep_hint_tracks, Bool keep_pssh);
+GF_Err gf_isom_clone_movie(GF_ISOFile *orig_file, GF_ISOFile *dest_file, Bool clone_tracks, Bool keep_hint_tracks, Bool keep_pssh, Bool create_mvex_after_traks);
 
 /*returns true if same set of sample description in both tracks - this does include self-contained checking
 and reserved flags. The specific media cfg (DSI & co) is not analysed, only

--- a/include/gpac/media_tools.h
+++ b/include/gpac/media_tools.h
@@ -920,6 +920,14 @@ GF_Err gf_dasher_set_split_on_closest(GF_DASHSegmenter *dasher, Bool split_on_cl
 GF_Err gf_dasher_set_cues(GF_DASHSegmenter *dasher, const char *cues_file, Bool strict_cues);
 
 /*!
+ Sets ISOBMFF options.
+ *	\param dasher the DASH segmenter object
+ *	\param mvex_after_traks if true the mvex box will be after the trak boxes
+ *	\return error code if any
+ */
+GF_Err gf_dasher_set_isobmff_options(GF_DASHSegmenter *dasher, Bool mvex_after_traks);
+
+/*!
  Adds a media input to the DASHer
  *	\param dasher the DASH segmenter object
  *	\param input media source to add

--- a/src/isomedia/box_code_base.c
+++ b/src/isomedia/box_code_base.c
@@ -3804,7 +3804,7 @@ GF_Err moov_Write(GF_Box *s, GF_BitStream *bs)
 		if (e) return e;
 	}
 #ifndef	GPAC_DISABLE_ISOM_FRAGMENTS
-	if (ptr->mvex) {
+	if (ptr->mvex && !ptr->mvex_after_traks) {
 		e = gf_isom_box_write((GF_Box *) ptr->mvex, bs);
 		if (e) return e;
 	}
@@ -3812,6 +3812,13 @@ GF_Err moov_Write(GF_Box *s, GF_BitStream *bs)
 
 	e = gf_isom_box_array_write(s, ptr->trackList, bs);
 	if (e) return e;
+
+#ifndef	GPAC_DISABLE_ISOM_FRAGMENTS
+	if (ptr->mvex && ptr->mvex_after_traks) {
+		e = gf_isom_box_write((GF_Box *) ptr->mvex, bs);
+		if (e) return e;
+	}
+#endif
 
 	if (ptr->udta) {
 		e = gf_isom_box_write((GF_Box *) ptr->udta, bs);

--- a/src/isomedia/isom_write.c
+++ b/src/isomedia/isom_write.c
@@ -2666,7 +2666,7 @@ GF_Err gf_isom_clone_box(GF_Box *src, GF_Box **dst)
 	return e;
 }
 
-GF_Err gf_isom_clone_movie(GF_ISOFile *orig_file, GF_ISOFile *dest_file, Bool clone_tracks, Bool keep_hint_tracks, Bool keep_pssh)
+GF_Err gf_isom_clone_movie(GF_ISOFile *orig_file, GF_ISOFile *dest_file, Bool clone_tracks, Bool keep_hint_tracks, Bool keep_pssh, Bool mvex_after_traks)
 {
 	GF_Err e;
 	u32 i;
@@ -2716,6 +2716,7 @@ GF_Err gf_isom_clone_movie(GF_ISOFile *orig_file, GF_ISOFile *dest_file, Bool cl
 			dest_file->moov->mvex = NULL;
 		}
 #endif
+		dest_file->moov->mvex_after_traks = mvex_after_traks;
 
 		if (clone_tracks) {
 			for (i=0; i<gf_list_count(orig_file->moov->trackList); i++) {
@@ -2780,7 +2781,6 @@ GF_Err gf_isom_clone_movie(GF_ISOFile *orig_file, GF_ISOFile *dest_file, Bool cl
 
 	return GF_OK;
 }
-
 
 GF_EXPORT
 GF_Err gf_isom_clone_track(GF_ISOFile *orig_file, u32 orig_track, GF_ISOFile *dest_file, Bool keep_data_ref, u32 *dest_track)

--- a/src/media_tools/dash_segmenter.c
+++ b/src/media_tools/dash_segmenter.c
@@ -150,6 +150,8 @@ struct __gf_dash_segmenter
 	Bool split_on_closest;
 	const char *cues_file;
 	Bool strict_cues;
+
+	Bool mvex_after_traks;
 };
 
 struct _dash_segment_input
@@ -1245,7 +1247,7 @@ static GF_Err gf_media_isom_segment_file(GF_ISOFile *input, const char *output_f
 		Bool keep_pssh = GF_FALSE;
 		if ((dasher->pssh_mode==GF_DASH_PSSH_MOOV) || (dasher->pssh_mode==GF_DASH_PSSH_MOOV_MPD))
 			keep_pssh = GF_TRUE;
-		e = gf_isom_clone_movie(input, output, GF_FALSE, GF_FALSE, keep_pssh);
+		e = gf_isom_clone_movie(input, output, GF_FALSE, GF_FALSE, keep_pssh, dasher->mvex_after_traks);
 		if (e) goto err_exit;
 
 		/*because of movie fragments MOOF based offset, ISOM <4 is forbidden*/
@@ -6305,6 +6307,12 @@ GF_Err gf_dasher_set_cues(GF_DASHSegmenter *dasher, const char *cues_file, Bool 
 	return GF_OK;
 }
 
+GF_EXPORT
+GF_Err gf_dasher_set_isobmff_options(GF_DASHSegmenter *dasher, Bool mvex_after_traks)
+{
+	dasher->mvex_after_traks = mvex_after_traks;
+	return GF_OK;
+}
 
 static void dash_input_check_period_id(GF_DASHSegmenter *dasher, GF_DashSegInput *dash_input)
 {


### PR DESCRIPTION
Some devices seem to have a problem when `mvex` is provided before `trak`. Also Table 3 in CMAF places `mvex` after, although order of boxes is not mandated in CMAF.