### PR TITLE
fix use of -no-frag-defaults

### DIFF
--- a/include/gpac/internal/isomedia_dev.h
+++ b/include/gpac/internal/isomedia_dev.h
@@ -1994,6 +1994,8 @@ typedef struct
 	u32 def_sample_flags;
 	GF_TrackBox *track;
 
+	Bool cannot_use_default;
+	
 	GF_TrackFragmentRandomAccessBox *tfra;
 } GF_TrackExtendsBox;
 

--- a/src/isomedia/movie_fragments.c
+++ b/src/isomedia/movie_fragments.c
@@ -223,7 +223,10 @@ GF_Err gf_isom_change_track_fragment_defaults(GF_ISOFile *movie, u32 TrackID,
 	if (DefaultSampleIsSync) {
 		trex->def_sample_flags |= (2<<24);
 	}
-
+	if (DefaultSampleDescriptionIndex == 0 && DefaultSampleDuration == 0 && DefaultSampleSize == 0
+		&& DefaultSampleIsSync == 0 && DefaultSamplePadding == 0 && DefaultDegradationPriority == 0) {
+		trex->cannot_use_default = GF_TRUE;
+	}
 	return GF_OK;
 }
 
@@ -368,7 +371,7 @@ escape_size:
 		}
 	}
 	//store if #
-	if (DefValue && (DefValue != traf->trex->def_sample_flags)) {
+	if (traf->trex->cannot_use_default || (DefValue && (DefValue != traf->trex->def_sample_flags))) {
 		traf->tfhd->def_sample_flags = DefValue;
 	}
 }
@@ -512,7 +515,7 @@ u32 UpdateRuns(GF_ISOFile *movie, GF_TrackFragmentBox *traf)
 
 		//size checking
 		//constant size, check if this is from current fragment default or global default
-		if (RunSize && (traf->trex->def_sample_size == RunSize)) {
+		if (RunSize && (traf->trex->def_sample_size == RunSize) && !traf->trex->cannot_use_default) {
 			if (!UseDefaultSize) UseDefaultSize = 2;
 			else if (UseDefaultSize==1) RunSize = 0;
 		} else if (RunSize && (traf->tfhd->def_sample_size == RunSize)) {
@@ -528,7 +531,7 @@ u32 UpdateRuns(GF_ISOFile *movie, GF_TrackFragmentBox *traf)
 		if (!RunSize) trun->flags |= GF_ISOM_TRUN_SIZE;
 
 		//duration checking
-		if (RunDur && (traf->trex->def_sample_duration == RunDur)) {
+		if (RunDur && (traf->trex->def_sample_duration == RunDur) && !traf->trex->cannot_use_default) {
 			if (!UseDefaultDur) UseDefaultDur = 2;
 			else if (UseDefaultDur==1) RunDur = 0;
 		} else if (RunDur && (traf->tfhd->def_sample_duration == RunDur)) {
@@ -540,7 +543,7 @@ u32 UpdateRuns(GF_ISOFile *movie, GF_TrackFragmentBox *traf)
 		//flag checking
 		if (!NeedFlags) {
 			// all samples flags are the same after the 2nd entry
-			if (RunFlags == traf->trex->def_sample_flags) {
+			if (RunFlags == traf->trex->def_sample_flags && !traf->trex->cannot_use_default) {
 				/* this run can use trex flags */
 				if (!UseDefaultFlag) {
 					/* if all previous runs used explicit flags per sample, we can still use trex flags for this run */

--- a/src/media_tools/dash_segmenter.c
+++ b/src/media_tools/dash_segmenter.c
@@ -1409,7 +1409,7 @@ static GF_Err gf_media_isom_segment_file(GF_ISOFile *input, const char *output_f
 				                                 defaultPadding, defaultDegradationPriority);
 
 			} else {
-				e = gf_isom_setup_track_fragment(output, gf_isom_get_track_id(output, TrackNum), defaultDescriptionIndex, 0, 0, 0, 0, 0);
+				e = gf_isom_setup_track_fragment(output, gf_isom_get_track_id(output, TrackNum), 0, 0, 0, 0, 0, 0);
 			}
 			if (e) goto err_exit;
 		} else {


### PR DESCRIPTION
Files generated today with -no-frag-defaults do not pass CMAF validation checks. These changes fix that problem. Could be also behind another flag if -no-frag-defaults is really used.