### PR TITLE
Fix the description of -delay for MP4Box in its man pages

### DIFF
--- a/doc/man/mp4box.1
+++ b/doc/man/mp4box.1
@@ -139,7 +139,7 @@ forces creation of a new destination file.
 sets the language of all tracks or the given track. LAN is the ISO 639-2 3 character code.
 .TP
 .B -delay [tkID=]delay_ms
-sets the delay in milliseconds of all tracks or the given track. LAN is the ISO 639-2 3 character code.
+sets the delay in milliseconds of all tracks or the given track.
 .TP
 .B -par tkID=PAR
 sets visual track pixel aspect ratio (PAR=Num:Den or "none").


### PR DESCRIPTION
The `-delay` parameter does not accept any "LAN" (it accepts time in milliseconds).

The incorrect description was probably caused by a copy&paste from the `-lang` parameter:
```
-lang [tkID=]LAN
    sets the language of all tracks or the given track. LAN is the ISO 639-2 3 character code.
                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-delay [tkID=]delay_ms
    sets the delay in milliseconds of all tracks or the given track. LAN is the ISO 639-2 3 character code.
                                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
