### PR TITLE
adding support for audio_roll

### DIFF
--- a/applications/mp4box/fileimport.c
+++ b/applications/mp4box/fileimport.c
@@ -560,6 +560,7 @@ GF_Err import_file(GF_ISOFile *dest, char *inName, u32 import_flags, Double forc
 		}
 
 		else if (!strnicmp(ext+1, "audio_roll=", 11)) {
+			import.audio_roll_change = GF_TRUE;
 			import.audio_roll = atoi(ext+12);
 		}
 

--- a/applications/mp4box/fileimport.c
+++ b/applications/mp4box/fileimport.c
@@ -559,6 +559,10 @@ GF_Err import_file(GF_ISOFile *dest, char *inName, u32 import_flags, Double forc
 				import.asemode = GF_IMPORT_AUDIO_SAMPLE_ENTRY_v1_QTFF;
 		}
 
+		else if (!strnicmp(ext+1, "audio_roll=", 11)) {
+			import.audio_roll = atoi(ext+12);
+		}
+
 		/*unrecognized, assume name has colon in it*/
 		else {
 			fprintf(stderr, "Unrecognized import option %s, ignoring\n", ext+1);

--- a/applications/mp4box/main.c
+++ b/applications/mp4box/main.c
@@ -532,6 +532,7 @@ void PrintImportUsage()
 	        " \"                       v0-2  : uses MPEG AudioSampleEntry v0 and the channel count is forced to 2\n"
 	        " \"                       v1    : uses MPEG AudioSampleEntry v1 and the channel count from the bitstream\n"
 	        " \"                       v1-qt : uses QuickTime Sound Sample Description Version 1 and the channel count from the bitstream (even if greater than 2)\n"
+			" \":audio_roll=N\"      adds a roll sample group with roll_distance = N\n"
 	        " \":mpeg4\"             same as -mpeg4 option\n"
 	        " \":nosei\"             discard all SEI messages during import\n"
 	        " \":svc\"               import SVC/LHVC with explicit signaling (no AVC base compatibility)\n"

--- a/include/gpac/media_tools.h
+++ b/include/gpac/media_tools.h
@@ -364,6 +364,8 @@ typedef struct __track_import
 	GF_Err last_error;
 
 	GF_AudioSampleEntryImportMode asemode;
+
+	s16 audio_roll;
 } GF_MediaImporter;
 
 /*!

--- a/include/gpac/media_tools.h
+++ b/include/gpac/media_tools.h
@@ -365,6 +365,7 @@ typedef struct __track_import
 
 	GF_AudioSampleEntryImportMode asemode;
 
+	Bool audio_roll_change;
 	s16 audio_roll;
 } GF_MediaImporter;
 

--- a/src/media_tools/media_import.c
+++ b/src/media_tools/media_import.c
@@ -1167,7 +1167,7 @@ GF_Err gf_import_aac_adts(GF_MediaImporter *import)
 	samp->DTS+=dts_inc;
 
 	cur_samp++;
-	if (import->audio_roll) {
+	if (import->audio_roll_change) {
 		e = gf_isom_set_sample_roll_group(import->dest, track, cur_samp, import->audio_roll);
 	}
 
@@ -1196,7 +1196,7 @@ GF_Err gf_import_aac_adts(GF_MediaImporter *import)
 		if (e) break;
 
 		cur_samp++;
-		if (import->audio_roll) {
+		if (import->audio_roll_change) {
 			e = gf_isom_set_sample_roll_group(import->dest, track, cur_samp, import->audio_roll);
 		}
 		cur_samp++;
@@ -2338,7 +2338,7 @@ GF_Err gf_import_isomedia(GF_MediaImporter *import)
 
 		gf_isom_copy_sample_info(import->dest, track, import->orig, track_in, i+1);
 
-		if (import->audio_roll) {
+		if (import->audio_roll_change) {
 			gf_isom_set_sample_roll_group(import->dest, track, i+1, import->audio_roll);
 		}
 

--- a/src/media_tools/media_import.c
+++ b/src/media_tools/media_import.c
@@ -2338,7 +2338,9 @@ GF_Err gf_import_isomedia(GF_MediaImporter *import)
 
 		gf_isom_copy_sample_info(import->dest, track, import->orig, track_in, i+1);
 
-		gf_isom_set_sample_roll_group(import->dest, track, i+1, import->audio_roll);
+		if (import->audio_roll) {
+			gf_isom_set_sample_roll_group(import->dest, track, i+1, import->audio_roll);
+		}
 
 		gf_set_progress("Importing ISO File", i+1, num_samples);
 

--- a/src/media_tools/media_import.c
+++ b/src/media_tools/media_import.c
@@ -972,6 +972,7 @@ GF_Err gf_import_aac_adts(GF_MediaImporter *import)
 	u64 offset, tot_size, done, duration;
 	u32 max_size, track, di, i;
 	GF_ISOSample *samp;
+	u32 cur_samp = 0;
 
 	in = gf_fopen(import->in_name, "rb");
 	if (!in) return gf_import_message(import, GF_URL_ERROR, "Opening file %s failed", import->in_name);
@@ -1165,6 +1166,11 @@ GF_Err gf_import_aac_adts(GF_MediaImporter *import)
 	if (e) goto exit;
 	samp->DTS+=dts_inc;
 
+	cur_samp++;
+	if (import->audio_roll) {
+		e = gf_isom_set_sample_roll_group(import->dest, track, cur_samp, import->audio_roll);
+	}
+
 	duration = import->duration;
 	duration *= sr;
 	duration /= 1000;
@@ -1188,6 +1194,12 @@ GF_Err gf_import_aac_adts(GF_MediaImporter *import)
 			e = gf_isom_add_sample(import->dest, track, di, samp);
 		}
 		if (e) break;
+
+		cur_samp++;
+		if (import->audio_roll) {
+			e = gf_isom_set_sample_roll_group(import->dest, track, cur_samp, import->audio_roll);
+		}
+		cur_samp++;
 
 		gf_set_progress("Importing AAC", done, tot_size);
 		samp->DTS += dts_inc;
@@ -2325,6 +2337,8 @@ GF_Err gf_import_isomedia(GF_MediaImporter *import)
 		gf_isom_sample_del(&samp);
 
 		gf_isom_copy_sample_info(import->dest, track, import->orig, track_in, i+1);
+
+		gf_isom_set_sample_roll_group(import->dest, track, i+1, import->audio_roll);
 
 		gf_set_progress("Importing ISO File", i+1, num_samples);
 


### PR DESCRIPTION
For AAC or HE-AAC it may be interesting to signal how much pre-roll is needed, as documented for example in [Apple documentation](https://developer.apple.com/library/archive/documentation/QuickTime/QTFF/QTFFAppenG/QTFFAppenG.html)