### PR TITLE
Basic HTTP2 support 

### DIFF
--- a/src/utils/downloader.c
+++ b/src/utils/downloader.c
@@ -1556,8 +1556,6 @@ static GF_Err gf_dm_read_data(GF_DownloadSession *sess, char *data, u32 data_siz
 		if(session_send(sess))
 			return GF_IO_ERR;
 	}
-	
-	
 #endif //GPAC_HAS_HTTP2
 	gf_mx_v(sess->mx);
 	return e;
@@ -3058,8 +3056,8 @@ static GF_Err http_parse_remaining_body(GF_DownloadSession * sess, char * sHTTP)
 				u32 len = gf_cache_get_content_length(sess->cache_entry);
 				if (size > 0) {
 
-					if(sess->ishttp2) {
 #ifdef GPAC_HAS_HTTP2
+					if(sess->ishttp2) {
 						for (i=0; i<gf_list_count(sess->http2_data_frames); i++) {
 							http2_stream_data *frame_data = (http2_stream_data*)gf_list_get(sess->http2_data_frames, i);
 							gf_dm_data_received(sess, (u8 *) frame_data->start_data, frame_data->datalen, GF_TRUE, NULL);
@@ -3067,8 +3065,10 @@ static GF_Err http_parse_remaining_body(GF_DownloadSession * sess, char * sHTTP)
 						}
 						gf_list_del(sess->http2_data_frames);
 						sess->http2_data_frames = NULL;
-#endif //GPAC_HAS_HTTP2						
-					} else {
+					
+					} else 
+#endif //GPAC_HAS_HTTP2	
+					{
 						gf_dm_data_received(sess, (u8 *) sHTTP, size, GF_FALSE, NULL);
 					}
 					
@@ -3100,9 +3100,8 @@ static GF_Err http_parse_remaining_body(GF_DownloadSession * sess, char * sHTTP)
 			sess->remaining_data_size = 0;
 		}
 		sHTTP[size + remaining_data_size] = 0;
-		
+#ifdef GPAC_HAS_HTTP2		
 		if(sess->ishttp2) {
-#ifdef GPAC_HAS_HTTP2
 			for (i=0; i<gf_list_count(sess->http2_data_frames); i++) {
 				http2_stream_data *frame_data = (http2_stream_data*)gf_list_get(sess->http2_data_frames, i);
 				gf_dm_data_received(sess, (u8 *) frame_data->start_data, frame_data->datalen, GF_TRUE, NULL);
@@ -3110,8 +3109,9 @@ static GF_Err http_parse_remaining_body(GF_DownloadSession * sess, char * sHTTP)
 			}
 			gf_list_del(sess->http2_data_frames);
 			sess->http2_data_frames = NULL;
-#endif //GPAC_HAS_HTTP2			
-		} else {
+			} else
+#endif //GPAC_HAS_HTTP2	 
+		{
 			gf_dm_data_received(sess, (u8 *) sHTTP, size + remaining_data_size, GF_FALSE, NULL);
 		}
 	
@@ -3756,8 +3756,8 @@ static GF_Err wait_for_header_and_parse(GF_DownloadSession *sess, char * sHTTP)
 		sess->init_data_size = 0;
 		sess->init_data = NULL;
 		
+#ifdef GPAC_HAS_HTTP2		
 		if(sess->ishttp2) {
-#ifdef GPAC_HAS_HTTP2
 			for (i=0; i<gf_list_count(sess->http2_data_frames); i++) {
 			http2_stream_data *frame_data = (http2_stream_data*)gf_list_get(sess->http2_data_frames, i);
 			gf_dm_data_received(sess, (u8 *) frame_data->start_data, frame_data->datalen, GF_TRUE, NULL);
@@ -3765,8 +3765,9 @@ static GF_Err wait_for_header_and_parse(GF_DownloadSession *sess, char * sHTTP)
 		}
 		gf_list_del(sess->http2_data_frames);
 		sess->http2_data_frames = NULL;
-#endif //GPAC_HAS_HTTP2		
-		} else {
+		} else
+#endif //GPAC_HAS_HTTP2	 
+		{
 			gf_dm_data_received(sess, (u8 *) sHTTP + BodyStart, bytesRead - BodyStart, GF_TRUE, NULL);
 		}
 	}

--- a/src/utils/downloader.c
+++ b/src/utils/downloader.c
@@ -3018,7 +3018,7 @@ static Bool dm_exceeds_cap_rate(GF_DownloadManager * dm)
  */
 static GF_Err http_parse_remaining_body(GF_DownloadSession * sess, char * sHTTP)
 {
-	u32 size, i;
+	u32 size;
 	GF_Err e;
 	u32 buf_size = sess->dm ? sess->dm->read_buf_size : GF_DOWNLOAD_BUFFER_SIZE;
 
@@ -3058,6 +3058,7 @@ static GF_Err http_parse_remaining_body(GF_DownloadSession * sess, char * sHTTP)
 
 #ifdef GPAC_HAS_HTTP2
 					if(sess->ishttp2) {
+						u32 i;
 						for (i=0; i<gf_list_count(sess->http2_data_frames); i++) {
 							http2_stream_data *frame_data = (http2_stream_data*)gf_list_get(sess->http2_data_frames, i);
 							gf_dm_data_received(sess, (u8 *) frame_data->start_data, frame_data->datalen, GF_TRUE, NULL);
@@ -3102,6 +3103,7 @@ static GF_Err http_parse_remaining_body(GF_DownloadSession * sess, char * sHTTP)
 		sHTTP[size + remaining_data_size] = 0;
 #ifdef GPAC_HAS_HTTP2		
 		if(sess->ishttp2) {
+			u32 i;
 			for (i=0; i<gf_list_count(sess->http2_data_frames); i++) {
 				http2_stream_data *frame_data = (http2_stream_data*)gf_list_get(sess->http2_data_frames, i);
 				gf_dm_data_received(sess, (u8 *) frame_data->start_data, frame_data->datalen, GF_TRUE, NULL);

--- a/src/utils/downloader.c
+++ b/src/utils/downloader.c
@@ -549,8 +549,7 @@ static int on_data_chunk_recv_callback(nghttp2_session *session ,
    stream), if it is closed, we send GOAWAY and tear down the
    session */
 static int on_stream_close_callback(nghttp2_session *session, int32_t stream_id,
-   
-									uint32_t error_code, void *user_data) {
+   				   uint32_t error_code, void *user_data) {
 	int rv;
 	GF_DownloadSession * sess = (GF_DownloadSession *)user_data;
   
@@ -3789,7 +3788,6 @@ exit:
 void http_do_requests(GF_DownloadSession *sess)
 {
 	char sHTTP[GF_DOWNLOAD_BUFFER_SIZE+1];
-	int rv;
 	if (sess->reused_cache_entry) {
 		//main session is done downloading, notify - to do we should send progress events on this session also ...
 		if (!gf_cache_is_in_progress(sess->cache_entry)) {

--- a/src/utils/downloader.c
+++ b/src/utils/downloader.c
@@ -546,8 +546,7 @@ static int on_data_chunk_recv_callback(nghttp2_session *session ,
    stream), if it is closed, we send GOAWAY and tear down the
    session */
 static int on_stream_close_callback(nghttp2_session *session, int32_t stream_id,
-   
-									uint32_t error_code, void *user_data) {
+				    uint32_t error_code, void *user_data) {
 	int rv;
 	GF_DownloadSession * sess = (GF_DownloadSession *)user_data;
   


### PR DESCRIPTION
This branch can be a good start for the  HTTP2 support.
For now, it only supports basic http2 features:
- HPACK compression/decompression
- TLS-ALPN
- Upgrade  (HTTP/1.1 -> HTTP/2)
- send/receive data using HTTP2