### PR TITLE
Improved HEIF/MIAF/AVIF support

### DIFF
--- a/applications/mp4box/fileimport.c
+++ b/applications/mp4box/fileimport.c
@@ -435,6 +435,7 @@ GF_Err import_file(GF_ISOFile *dest, char *inName, u32 import_flags, Double forc
 		else if (!stricmp(ext+1, "subsamples")) import_flags |= GF_IMPORT_SET_SUBSAMPLES;
 		else if (!stricmp(ext+1, "deps")) import_flags |= GF_IMPORT_SAMPLE_DEPS;
 		else if (!stricmp(ext+1, "ccst")) import_flags |= GF_IMPORT_USE_CCST;
+		else if (!stricmp(ext+1, "alpha")) import.is_alpha = GF_TRUE;
 		else if (!stricmp(ext+1, "forcesync")) import_flags |= GF_IMPORT_FORCE_SYNC;
 		else if (!stricmp(ext+1, "xps_inband")) import_flags |= GF_IMPORT_FORCE_XPS_INBAND;
 		else if (!strnicmp(ext+1, "max_lid=", 8) || !strnicmp(ext+1, "max_tid=", 8)) {

--- a/include/gpac/internal/isomedia_dev.h
+++ b/include/gpac/internal/isomedia_dev.h
@@ -1096,6 +1096,7 @@ typedef struct
 	struct __tag_protect_box *rinf;				\
 	GF_RVCConfigurationBox *rvcc;		\
 
+
 typedef struct
 {
 	GF_ISOM_VISUAL_SAMPLE_ENTRY

--- a/include/gpac/internal/isomedia_dev.h
+++ b/include/gpac/internal/isomedia_dev.h
@@ -407,6 +407,7 @@ enum
 	GF_ISOM_BOX_TYPE_GRPL   = GF_4CC( 'g', 'r', 'p', 'l'),
 	GF_ISOM_BOX_TYPE_CCST	= GF_4CC( 'c', 'c', 's', 't' ),
 	GF_ISOM_BOX_TYPE_AUXC	= GF_4CC( 'a', 'u', 'x', 'C' ),
+	GF_ISOM_BOX_TYPE_AUXI	= GF_4CC( 'a', 'u', 'x', 'i' ),
 	GF_ISOM_BOX_TYPE_OINF	= GF_4CC( 'o', 'i', 'n', 'f' ),
 	GF_ISOM_BOX_TYPE_TOLS	= GF_4CC( 't', 'o', 'l', 's' ),
 
@@ -1071,6 +1072,12 @@ typedef struct
 
 typedef struct
 {
+	GF_ISOM_FULL_BOX
+	char *aux_track_type;
+} GF_AuxiliaryTypeInfoBox;
+
+typedef struct
+{
 	GF_ISOM_BOX
 	u16 predefined_rvc_config;
 	u32 rvc_meta_idx;
@@ -1093,6 +1100,7 @@ typedef struct
 	GF_PixelAspectRatioBox *pasp;		\
 	GF_CleanAppertureBox *clap;		\
 	GF_CodingConstraintsBox *ccst;		\
+	GF_AuxiliaryTypeInfoBox *auxi;		\
 	struct __tag_protect_box *rinf;				\
 	GF_RVCConfigurationBox *rvcc;		\
 

--- a/include/gpac/isomedia.h
+++ b/include/gpac/isomedia.h
@@ -1323,6 +1323,7 @@ GF_Err gf_isom_set_pixel_aspect_ratio(GF_ISOFile *the_file, u32 trackNumber, u32
 GF_Err gf_isom_set_clean_aperture(GF_ISOFile *movie, u32 trackNumber, u32 StreamDescriptionIndex, u32 cleanApertureWidthN, u32 cleanApertureWidthD, u32 cleanApertureHeightN, u32 cleanApertureHeightD, u32 horizOffN, u32 horizOffD, u32 vertOffN, u32 vertOffD);
 
 GF_Err gf_isom_set_image_sequence_coding_constraints(GF_ISOFile *movie, u32 trackNumber, u32 StreamDescriptionIndex, Bool remove, Bool all_ref_pics_intra, Bool intra_pred_used, u32 max_ref_per_pic);
+GF_Err gf_isom_set_image_sequence_alpha(GF_ISOFile *movie, u32 trackNumber, u32 StreamDescriptionIndex, Bool remove);
 
 /*set SR & nbChans for audio description*/
 typedef enum {

--- a/include/gpac/isomedia.h
+++ b/include/gpac/isomedia.h
@@ -2509,6 +2509,8 @@ typedef struct
 	double time;
 	char iccPath[GF_MAX_PATH];
 	Bool alpha;
+	u8 num_channels;
+	u8 bits_per_channel[3];
 } GF_ImageItemProperties;
 
 GF_Err gf_isom_meta_get_next_item_id(GF_ISOFile *file, Bool root_meta, u32 track_num, u32 *item_id);

--- a/include/gpac/media_tools.h
+++ b/include/gpac/media_tools.h
@@ -372,6 +372,8 @@ typedef struct __track_import
 
 	Bool audio_roll_change;
 	s16 audio_roll;
+
+	Bool is_alpha;
 } GF_MediaImporter;
 
 /*!

--- a/src/isomedia/box_code_base.c
+++ b/src/isomedia/box_code_base.c
@@ -4273,6 +4273,10 @@ GF_Err video_sample_entry_AddBox(GF_Box *s, GF_Box *a)
 		if (ptr->ccst) ERROR_ON_DUPLICATED_BOX(a, ptr)
 			ptr->ccst = (GF_CodingConstraintsBox *)a;
 		break;
+	case GF_ISOM_BOX_TYPE_AUXI:
+		if (ptr->auxi) ERROR_ON_DUPLICATED_BOX(a, ptr)
+			ptr->auxi = (GF_AuxiliaryTypeInfoBox *)a;
+		break;
 	case GF_ISOM_BOX_TYPE_RVCC:
 		if (ptr->rvcc) ERROR_ON_DUPLICATED_BOX(a, ptr)
 			ptr->rvcc = (GF_RVCConfigurationBox *)a;
@@ -4384,6 +4388,10 @@ GF_Err video_sample_entry_Write(GF_Box *s, GF_BitStream *bs)
 		e = gf_isom_box_write((GF_Box *)ptr->ccst, bs);
 		if (e) return e;
 	}
+	if (ptr->auxi) {
+		e = gf_isom_box_write((GF_Box *)ptr->auxi, bs);
+		if (e) return e;
+	}
 	if (ptr->rvcc) {
 		e = gf_isom_box_write((GF_Box *)ptr->rvcc, bs);
 		if (e) return e;
@@ -4482,6 +4490,11 @@ GF_Err video_sample_entry_Size(GF_Box *s)
 		e = gf_isom_box_size((GF_Box *)ptr->ccst);
 		if (e) return e;
 		ptr->size += ptr->ccst->size;
+	}
+	if (ptr->auxi) {
+		e = gf_isom_box_size((GF_Box *)ptr->auxi);
+		if (e) return e;
+		ptr->size += ptr->auxi->size;
 	}
 	if (ptr->rvcc) {
 		e = gf_isom_box_size((GF_Box *)ptr->rvcc);

--- a/src/isomedia/box_dump.c
+++ b/src/isomedia/box_dump.c
@@ -635,6 +635,7 @@ GF_Err video_sample_entry_dump(GF_Box *a, FILE * trace)
 	if (p->pasp) gf_isom_box_dump(p->pasp, trace);
 	if (p->clap) gf_isom_box_dump(p->clap, trace);
 	if (p->ccst) gf_isom_box_dump(p->ccst, trace);
+	if (p->auxi) gf_isom_box_dump(p->auxi, trace);
 	if (p->rvcc) gf_isom_box_dump(p->rvcc, trace);
 	if (p->rinf) gf_isom_box_dump(p->rinf, trace);
 
@@ -4971,6 +4972,17 @@ GF_Err auxc_dump(GF_Box *a, FILE * trace)
 	dump_data_attribute(trace, "aux_subtype", ptr->data, ptr->data_size);
 	fprintf(trace, ">\n");
 	gf_isom_box_dump_done("AuxiliaryTypePropertyBox", a, trace);
+	return GF_OK;
+}
+
+GF_Err auxi_dump(GF_Box *a, FILE * trace)
+{
+	GF_AuxiliaryTypeInfoBox *ptr = (GF_AuxiliaryTypeInfoBox *)a;
+
+	gf_isom_box_dump_start(a, "AuxiliaryTypeInfoBox", trace);
+	fprintf(trace, "aux_track_type=\"%s\" ", ptr->aux_track_type);
+	fprintf(trace, ">\n");
+	gf_isom_box_dump_done("AuxiliaryTypeInfoBox", a, trace);
 	return GF_OK;
 }
 

--- a/src/isomedia/box_funcs.c
+++ b/src/isomedia/box_funcs.c
@@ -629,6 +629,7 @@ ISOM_BOX_IMPL_DECL(piff_pssh)
 ISOM_BOX_IMPL_DECL(senc)
 ISOM_BOX_IMPL_DECL(cslg)
 ISOM_BOX_IMPL_DECL(ccst)
+ISOM_BOX_IMPL_DECL(auxi)
 ISOM_BOX_IMPL_DECL(hvcc)
 ISOM_BOX_IMPL_DECL(av1c)
 ISOM_BOX_IMPL_DECL(prft)
@@ -1082,6 +1083,7 @@ static struct box_registry_entry {
 	FBOX_DEFINE_FLAGS_S( GF_ISOM_BOX_TYPE_IPMA, ipma, "iprp", 1, 1, "iff"),
 	BOX_DEFINE_S( GF_ISOM_BOX_TYPE_GRPL, grpl, "meta", "iff"),
 	FBOX_DEFINE_S( GF_ISOM_BOX_TYPE_CCST, ccst, "sample_entry", 0, "iff"),
+	FBOX_DEFINE_S( GF_ISOM_BOX_TYPE_AUXI, auxi, "sample_entry", 0, "iff"),
 	TRGT_DEFINE(GF_ISOM_BOX_TYPE_GRPT, grptype, "grpl", GF_ISOM_BOX_TYPE_ALTR, 0, "iff"),
 	FBOX_DEFINE_S( GF_ISOM_BOX_TYPE_AUXC, auxc, "ipco", 0, "iff"),
 	FBOX_DEFINE_S( GF_ISOM_BOX_TYPE_OINF, oinf, "ipco", 0, "iff"),

--- a/src/isomedia/iff.c
+++ b/src/isomedia/iff.c
@@ -715,7 +715,48 @@ GF_Err auxc_Size(GF_Box *s)
 
 #endif /*GPAC_DISABLE_ISOM_WRITE*/
 
+void auxi_del(GF_Box *s)
+{
+	GF_AuxiliaryTypeInfoBox *ptr = (GF_AuxiliaryTypeInfoBox *)s;
+	if (ptr->aux_track_type) gf_free(ptr->aux_track_type);
+	if (ptr) gf_free(ptr);
+	return;
+}
 
+GF_Err auxi_Read(GF_Box *s, GF_BitStream *bs)
+{
+	GF_AuxiliaryTypeInfoBox *ptr = (GF_AuxiliaryTypeInfoBox *)s;
+	return gf_isom_read_null_terminated_string(s, bs, s->size, &ptr->aux_track_type);
+}
+
+GF_Box *auxi_New()
+{
+	ISOM_DECL_BOX_ALLOC(GF_AuxiliaryTypeInfoBox, GF_ISOM_BOX_TYPE_AUXI);
+	return (GF_Box *) tmp;
+}
+
+#ifndef GPAC_DISABLE_ISOM_WRITE
+
+GF_Err auxi_Write(GF_Box *s, GF_BitStream *bs)
+{
+	GF_Err e;
+	GF_AuxiliaryTypeInfoBox *ptr = (GF_AuxiliaryTypeInfoBox *)s;
+
+	e = gf_isom_full_box_write(s, bs);
+	if (e) return e;
+	//with terminating 0
+	gf_bs_write_data(bs, ptr->aux_track_type, (u32) strlen(ptr->aux_track_type) + 1 );
+	return GF_OK;
+}
+
+GF_Err auxi_Size(GF_Box *s)
+{
+	GF_AuxiliaryTypeInfoBox *ptr = (GF_AuxiliaryTypeInfoBox *)s;
+	ptr->size += strlen(ptr->aux_track_type) + 1;
+	return GF_OK;
+}
+
+#endif /*GPAC_DISABLE_ISOM_WRITE*/
 GF_Box *oinf_New()
 {
 	ISOM_DECL_BOX_ALLOC(GF_OINFPropertyBox, GF_ISOM_BOX_TYPE_OINF);

--- a/src/isomedia/iff.c
+++ b/src/isomedia/iff.c
@@ -909,6 +909,8 @@ GF_Err gf_isom_iff_create_image_item_from_track(GF_ISOFile *movie, Bool root_met
 	u32 imported_sample_desc_index = 1;
 //	u32 sample_index = 1;
 	u32 w, h, hSpacing, vSpacing;
+	u8 num_channels;
+	u8 bits_per_channel[3];
 	u32 subtype;
 	GF_ISOSample *sample = NULL;
 	u32 timescale;
@@ -983,18 +985,30 @@ GF_Err gf_isom_iff_create_image_item_from_track(GF_ISOFile *movie, Bool root_met
 			((GF_AVCConfigurationBox *)config_box)->config = gf_isom_avc_config_get(movie, imported_track, imported_sample_desc_index);
 			item_type = GF_ISOM_SUBTYPE_AVC_H264;
 			config_needed = 1;
+			num_channels = 3;
+			bits_per_channel[0] = ((GF_AVCConfigurationBox *)config_box)->config->luma_bit_depth;
+			bits_per_channel[1] = ((GF_AVCConfigurationBox *)config_box)->config->chroma_bit_depth;
+			bits_per_channel[2] = ((GF_AVCConfigurationBox *)config_box)->config->chroma_bit_depth;
 			break;
 		case GF_ISOM_SUBTYPE_SVC_H264:
 			config_box = gf_isom_box_new(GF_ISOM_BOX_TYPE_SVCC);
 			((GF_AVCConfigurationBox *)config_box)->config = gf_isom_svc_config_get(movie, imported_track, imported_sample_desc_index);
 			item_type = GF_ISOM_SUBTYPE_SVC_H264;
 			config_needed = 1;
+			num_channels = 3;
+			bits_per_channel[0] = ((GF_AVCConfigurationBox *)config_box)->config->luma_bit_depth;
+			bits_per_channel[1] = ((GF_AVCConfigurationBox *)config_box)->config->chroma_bit_depth;
+			bits_per_channel[2] = ((GF_AVCConfigurationBox *)config_box)->config->chroma_bit_depth;
 			break;
 		case GF_ISOM_SUBTYPE_MVC_H264:
 			config_box = gf_isom_box_new(GF_ISOM_BOX_TYPE_MVCC);
 			((GF_AVCConfigurationBox *)config_box)->config = gf_isom_mvc_config_get(movie, imported_track, imported_sample_desc_index);
 			item_type = GF_ISOM_SUBTYPE_MVC_H264;
 			config_needed = 1;
+			num_channels = 3;
+			bits_per_channel[0] = ((GF_AVCConfigurationBox *)config_box)->config->luma_bit_depth;
+			bits_per_channel[1] = ((GF_AVCConfigurationBox *)config_box)->config->chroma_bit_depth;
+			bits_per_channel[2] = ((GF_AVCConfigurationBox *)config_box)->config->chroma_bit_depth;
 			break;
 		case GF_ISOM_SUBTYPE_HVC1:
 		case GF_ISOM_SUBTYPE_HEV1:
@@ -1016,14 +1030,32 @@ GF_Err gf_isom_iff_create_image_item_from_track(GF_ISOFile *movie, Bool root_met
 				((GF_HEVCConfigurationBox *)config_box)->config = gf_isom_lhvc_config_get(movie, imported_track, imported_sample_desc_index);
 				item_type = GF_ISOM_SUBTYPE_LHV1;
 			}
+			num_channels = 3;
+			bits_per_channel[0] = ((GF_HEVCConfigurationBox *)config_box)->config->luma_bit_depth;
+			bits_per_channel[1] = ((GF_HEVCConfigurationBox *)config_box)->config->chroma_bit_depth;
+			bits_per_channel[2] = ((GF_HEVCConfigurationBox *)config_box)->config->chroma_bit_depth;
 			//media_brand = GF_ISOM_BRAND_HEIC;
 			break;
 		case GF_ISOM_SUBTYPE_AV01:
-			config_box = gf_isom_box_new(GF_ISOM_BOX_TYPE_AV1C);
-			((GF_AV1ConfigurationBox *)config_box)->config = gf_isom_av1_config_get(movie, imported_track, imported_sample_desc_index);
-			item_type = GF_ISOM_SUBTYPE_AV01;
-			config_needed = 1;
-			//media_brand = GF_ISOM_BRAND_HEIC;
+			{
+				config_box = gf_isom_box_new(GF_ISOM_BOX_TYPE_AV1C);
+				((GF_AV1ConfigurationBox *)config_box)->config = gf_isom_av1_config_get(movie, imported_track, imported_sample_desc_index);
+				item_type = GF_ISOM_SUBTYPE_AV01;
+				config_needed = 1;
+				u8 depth = ((GF_AV1ConfigurationBox *)config_box)->config->high_bitdepth ? (((GF_AV1ConfigurationBox *)config_box)->config->twelve_bit ? 12 : 10 ) : 8;
+				if (((GF_AV1ConfigurationBox *)config_box)->config->monochrome) {
+					num_channels = 1;
+					bits_per_channel[0] = depth;
+					bits_per_channel[1] = 0;
+					bits_per_channel[2] = 0;
+				} else {
+					num_channels = 3;
+					bits_per_channel[0] = depth;
+					bits_per_channel[1] = depth;
+					bits_per_channel[2] = depth;
+				}
+				//media_brand = GF_ISOM_BRAND_AVIF;
+			}
 			break;
 		default:
 			GF_LOG(GF_LOG_ERROR, GF_LOG_CONTAINER, ("Error: Codec not supported to create HEIF image items\n"));
@@ -1059,6 +1091,12 @@ GF_Err gf_isom_iff_create_image_item_from_track(GF_ISOFile *movie, Bool root_met
 			image_props->vSpacing = vSpacing;
 		}
 		image_props->config = config_box;
+		if (!image_props->num_channels) {
+			image_props->num_channels = num_channels;
+			image_props->bits_per_channel[0] = bits_per_channel[0];
+			image_props->bits_per_channel[1] = bits_per_channel[1];
+			image_props->bits_per_channel[2] = bits_per_channel[2];
+		}
 
 		timescale = gf_isom_get_media_timescale(movie, imported_track);
 		e = gf_isom_get_sample_for_media_time(movie, imported_track, (u64)(image_props->time*timescale), &sample_desc_index, GF_ISOM_SEARCH_SYNC_FORWARD, &sample, NULL);

--- a/src/isomedia/iff.c
+++ b/src/isomedia/iff.c
@@ -709,7 +709,7 @@ GF_Err auxc_Write(GF_Box *s, GF_BitStream *bs)
 GF_Err auxc_Size(GF_Box *s)
 {
 	GF_AuxiliaryTypePropertyBox *p = (GF_AuxiliaryTypePropertyBox*)s;
-	p->size += 1;
+	p->size += strlen(p->aux_urn) + 1 + p->data_size;
 	return GF_OK;
 }
 

--- a/src/isomedia/isom_write.c
+++ b/src/isomedia/isom_write.c
@@ -1428,6 +1428,44 @@ GF_Err gf_isom_set_image_sequence_coding_constraints(GF_ISOFile *movie, u32 trac
 }
 
 GF_EXPORT
+GF_Err gf_isom_set_image_sequence_alpha(GF_ISOFile *movie, u32 trackNumber, u32 StreamDescriptionIndex, Bool remove)
+{
+	GF_Err e;
+	GF_TrackBox *trak;
+	GF_SampleEntryBox *entry;
+	GF_VisualSampleEntryBox*vent;
+	GF_SampleDescriptionBox *stsd;
+	e = CanAccessMovie(movie, GF_ISOM_OPEN_WRITE);
+	if (e) return e;
+
+	trak = gf_isom_get_track_from_file(movie, trackNumber);
+	if (!trak) return GF_BAD_PARAM;
+
+	stsd = trak->Media->information->sampleTable->SampleDescription;
+	if (!stsd) return movie->LastError = GF_ISOM_INVALID_FILE;
+	if (!StreamDescriptionIndex || StreamDescriptionIndex > gf_list_count(stsd->other_boxes)) {
+		return movie->LastError = GF_BAD_PARAM;
+	}
+	entry = (GF_SampleEntryBox *)gf_list_get(stsd->other_boxes, StreamDescriptionIndex - 1);
+	//no support for generic sample entries (eg, no MPEG4 descriptor)
+	if (entry == NULL) return GF_BAD_PARAM;
+	if (!movie->keep_utc)
+		trak->Media->mediaHeader->modificationTime = gf_isom_get_mp4time();
+
+	if (entry->internal_type != GF_ISOM_SAMPLE_ENTRY_VIDEO) return GF_BAD_PARAM;
+
+	vent = (GF_VisualSampleEntryBox*)entry;
+	if (remove)  {
+		if (vent->auxi) gf_isom_box_del((GF_Box*)vent->auxi);
+		vent->ccst = NULL;
+		return GF_OK;
+	}
+	if (!vent->auxi) vent->auxi = (GF_AuxiliaryTypeInfoBox*)gf_isom_box_new(GF_ISOM_BOX_TYPE_AUXI);
+	vent->auxi->aux_track_type = gf_strdup("urn:mpeg:mpegB:cicp:systems:auxiliary:alpha");
+	return GF_OK;
+}
+
+GF_EXPORT
 GF_Err gf_isom_set_audio_info(GF_ISOFile *movie, u32 trackNumber, u32 StreamDescriptionIndex, u32 sampleRate, u32 nbChannels, u8 bitsPerSample, GF_AudioSampleEntryImportMode asemode)
 {
 	GF_Err e;

--- a/src/isomedia/meta.c
+++ b/src/isomedia/meta.c
@@ -846,6 +846,7 @@ static void meta_process_image_properties(GF_MetaBox *meta, u32 item_ID, GF_Imag
 			prop_index = gf_list_count(ipco->other_boxes) - 1;
 		}
 		meta_add_item_property_association(ipma, item_ID, prop_index + 1, GF_TRUE);
+		searchprop.config = NULL;
 	}
 	if (image_props->alpha) {
 		searchprop.alpha = image_props->alpha;
@@ -857,6 +858,7 @@ static void meta_process_image_properties(GF_MetaBox *meta, u32 item_ID, GF_Imag
 			prop_index = gf_list_count(ipco->other_boxes) - 1;
 		}
 		meta_add_item_property_association(ipma, item_ID, prop_index + 1, GF_TRUE);
+		searchprop.alpha = GF_FALSE;
 	}
 	if (image_props->num_channels) {
 		searchprop.num_channels = image_props->num_channels;
@@ -871,6 +873,7 @@ static void meta_process_image_properties(GF_MetaBox *meta, u32 item_ID, GF_Imag
 			prop_index = gf_list_count(ipco->other_boxes) - 1;
 		}
 		meta_add_item_property_association(ipma, item_ID, prop_index + 1, GF_TRUE);
+		searchprop.num_channels = 0;
 	}
 }
 

--- a/src/isomedia/meta.c
+++ b/src/isomedia/meta.c
@@ -619,6 +619,17 @@ GF_Err gf_isom_get_meta_image_props(GF_ISOFile *file, Bool root_meta, u32 track_
 					prop->vSpacing = pasp->vSpacing;
 				}
 				break;
+				case GF_ISOM_BOX_TYPE_PIXI:
+				{
+					GF_PixelInformationPropertyBox *pixi = (GF_PixelInformationPropertyBox *)b;
+					if (pixi->num_channels > 3) {
+						return GF_BAD_PARAM;
+					}
+					prop->num_channels = pixi->num_channels;
+					memset(prop->bits_per_channel, 0, 3);
+					memcpy(prop->bits_per_channel, pixi->bits_per_channel, pixi->num_channels);
+				}
+				break;
 				case GF_ISOM_BOX_TYPE_IROT:
 				{
 					GF_ImageRotationBox *irot = (GF_ImageRotationBox *)b;
@@ -671,6 +682,20 @@ static s32 meta_find_prop(GF_ItemPropertyContainerBox *boxes, GF_ImageItemProper
 		{
 			GF_ImageRotationBox *irot = (GF_ImageRotationBox *)b;
 			if (prop->angle && irot->angle*90 == prop->angle) {
+				return i;
+			}
+		}
+		break;
+		case GF_ISOM_BOX_TYPE_PIXI:
+		{
+			GF_PixelInformationPropertyBox *pixi = (GF_PixelInformationPropertyBox *)b;
+			if (prop->num_channels && pixi->num_channels == prop->num_channels) {
+				int j;
+				for (j = 0; j < pixi->num_channels; j++) {
+					if (pixi->bits_per_channel[j] != prop->bits_per_channel[j]) {
+						break;
+					}
+				}
 				return i;
 			}
 		}
@@ -829,6 +854,20 @@ static void meta_process_image_properties(GF_MetaBox *meta, u32 item_ID, GF_Imag
 			GF_AuxiliaryTypePropertyBox *auxC = (GF_AuxiliaryTypePropertyBox *)gf_isom_box_new(GF_ISOM_BOX_TYPE_AUXC);
 			auxC->aux_urn = gf_strdup("urn:mpeg:mpegB:cicp:systems:auxiliary:alpha");
 			gf_list_add(ipco->other_boxes, auxC);
+			prop_index = gf_list_count(ipco->other_boxes) - 1;
+		}
+		meta_add_item_property_association(ipma, item_ID, prop_index + 1, GF_TRUE);
+	}
+	if (image_props->num_channels) {
+		searchprop.num_channels = image_props->num_channels;
+		memcpy(searchprop.bits_per_channel, image_props->bits_per_channel, 3);
+		prop_index = meta_find_prop(ipco, &searchprop);
+		if (prop_index < 0) {
+			GF_PixelInformationPropertyBox *pixi = (GF_PixelInformationPropertyBox *)gf_isom_box_new(GF_ISOM_BOX_TYPE_PIXI);
+			pixi->num_channels = image_props->num_channels;
+			pixi->bits_per_channel = gf_malloc(pixi->num_channels);
+			memcpy(pixi->bits_per_channel, image_props->bits_per_channel, image_props->num_channels);
+			gf_list_add(ipco->other_boxes, pixi);
 			prop_index = gf_list_count(ipco->other_boxes) - 1;
 		}
 		meta_add_item_property_association(ipma, item_ID, prop_index + 1, GF_TRUE);

--- a/src/media_tools/media_import.c
+++ b/src/media_tools/media_import.c
@@ -2430,6 +2430,10 @@ GF_Err gf_import_isomedia(GF_MediaImporter *import)
 			e = gf_isom_set_image_sequence_coding_constraints(import->dest, track, di, GF_FALSE, GF_FALSE, GF_TRUE, 15);
 			if (e) goto exit;
 		}
+		if (import->is_alpha) {
+			e = gf_isom_set_image_sequence_alpha(import->dest, track, di, GF_FALSE);
+			if (e) goto exit;
+		}
 	}
 
 exit:
@@ -5757,6 +5761,10 @@ restart_import:
 		e = gf_isom_set_image_sequence_coding_constraints(import->dest, track, di, GF_FALSE, GF_FALSE, GF_TRUE, 15);
 		if (e) goto exit;
 	}
+	if (import->is_alpha) {
+		e = gf_isom_set_image_sequence_alpha(import->dest, track, di, GF_FALSE);
+		if (e) goto exit;
+	}
 
 	gf_media_update_par(import->dest, track);
 	gf_media_update_bitrate(import->dest, track);
@@ -7108,6 +7116,10 @@ next_nal:
 		e = gf_isom_set_image_sequence_coding_constraints(import->dest, track, di, GF_FALSE, GF_FALSE, GF_TRUE, 15);
 		if (e) goto exit;
 	}
+	if (import->is_alpha) {
+		e = gf_isom_set_image_sequence_alpha(import->dest, track, di, GF_FALSE);
+		if (e) goto exit;
+	}
 
 	gf_media_update_par(import->dest, track);
 	gf_media_update_bitrate(import->dest, track);
@@ -7469,6 +7481,10 @@ static GF_Err gf_import_aom_av1(GF_MediaImporter *import)
 		e = gf_isom_set_image_sequence_coding_constraints(import->dest, track_num, di, GF_FALSE, GF_FALSE, GF_TRUE, 15);
 		if (e) goto exit;
 	}
+	if (import->is_alpha) {
+		e = gf_isom_set_image_sequence_alpha(import->dest, track_num, di, GF_FALSE);
+		if (e) goto exit;
+	}
 
 	/*rewrite ESD*/
 	if (import->esd) {
@@ -7648,6 +7664,10 @@ static GF_Err gf_import_vp9(GF_MediaImporter *import)
 
 	if (import->flags & GF_IMPORT_USE_CCST) {
 		e = gf_isom_set_image_sequence_coding_constraints(import->dest, track_num, di, GF_FALSE, GF_FALSE, GF_TRUE, 15);
+		if (e) goto exit;
+	}
+	if (import->is_alpha) {
+		e = gf_isom_set_image_sequence_alpha(import->dest, track_num, di, GF_FALSE);
 		if (e) goto exit;
 	}
 


### PR DESCRIPTION
Few comments about this PR:
- it enables addressing comments in https://github.com/AOMediaCodec/av1-avif/pull/50
- it adds support for the `pixi` box for all image items
- it adds the `auxi` box when the `alpha` import string is given. Meant to be used as in `-add file.obu:hdlr=auxv:alpha`.  
- it fixes a bug with writing of `auxC`
- the `meta_find_prop` seems buggy. It searches for a property that as the same value as the given in the `searchprop` field but `searchprop` is initialized to 0 which might be a value for which a property is searched... I did not fix that here.
- We've reached the end of `GF_MediaImporter flags` space (32 flags defined). I had to use a separate field `is_alpha`. Some harmonization may be needed here or at least some guidance on when to use flags and when to use fields.