### PR TITLE
Piff senc dump fix

### DIFF
--- a/src/isomedia/box_dump.c
+++ b/src/isomedia/box_dump.c
@@ -4651,7 +4651,6 @@ GF_Err piff_psec_dump(GF_Box *a, FILE * trace)
 			GF_CENCSampleAuxInfo *cenc_sample = (GF_CENCSampleAuxInfo *)gf_list_get(ptr->samp_aux_info, i);
 
 			if (cenc_sample) {
-				if  (!strlen((char *)cenc_sample->IV)) continue;
 				fprintf(trace, "<PIFFSampleEncryptionEntry IV_size=\"%u\" IV=\"", cenc_sample->IV_size);
 				dump_data_hex(trace, (char *) cenc_sample->IV, cenc_sample->IV_size);
 				if (ptr->flags & 0x2) {

--- a/src/isomedia/box_dump.c
+++ b/src/isomedia/box_dump.c
@@ -4651,15 +4651,21 @@ GF_Err piff_psec_dump(GF_Box *a, FILE * trace)
 			GF_CENCSampleAuxInfo *cenc_sample = (GF_CENCSampleAuxInfo *)gf_list_get(ptr->samp_aux_info, i);
 
 			if (cenc_sample) {
-				fprintf(trace, "<PIFFSampleEncryptionEntry IV_size=\"%u\" IV=\"", cenc_sample->IV_size);
-				dump_data_hex(trace, (char *) cenc_sample->IV, cenc_sample->IV_size);
+				fprintf(trace, "<PIFFSampleEncryptionEntry sampleNumber=\"%d\" IV_size=\"%u\"", i+1, cenc_sample->IV_size);
+				if (cenc_sample->IV_size) {
+					fprintf(trace, " IV=\"");
+					dump_data_hex(trace, (char *) cenc_sample->IV, cenc_sample->IV_size);
+					fprintf(trace, "\"");
+				}
 				if (ptr->flags & 0x2) {
-					fprintf(trace, "\" SubsampleCount=\"%d\"", cenc_sample->subsample_count);
+					fprintf(trace, " SubsampleCount=\"%d\"", cenc_sample->subsample_count);
 					fprintf(trace, ">\n");
 
 					for (j=0; j<cenc_sample->subsample_count; j++) {
 						fprintf(trace, "<PIFFSubSampleEncryptionEntry NumClearBytes=\"%d\" NumEncryptedBytes=\"%d\"/>\n", cenc_sample->subsamples[j].bytes_clear_data, cenc_sample->subsamples[j].bytes_encrypted_data);
 					}
+				} else {
+					fprintf(trace, ">\n");
 				}
 				fprintf(trace, "</PIFFSampleEncryptionEntry>\n");
 			}


### PR DESCRIPTION
This PR fixes one problem: when the initialization vector starts with 0, no PIFFSampleEncryptionEntry was dumped because of the use of strlen.

The PR also harmonizes the dump between the PIFF senc box and the senc box (adding sample number in dump). Ideally the code should not be duplicated.