### PR TITLE
Improve avilib code

### DIFF
--- a/include/gpac/internal/avilib.h
+++ b/include/gpac/internal/avilib.h
@@ -138,14 +138,14 @@ typedef struct track_s
 typedef struct
 {
 	u32  bi_size;
-	u32  bi_width;
-	u32  bi_height;
+	s32  bi_width;
+	s32  bi_height;
 	u16  bi_planes;
 	u16  bi_bit_count;
 	u32  bi_compression;
 	u32  bi_size_image;
-	u32  bi_x_pels_per_meter;
-	u32  bi_y_pels_per_meter;
+	s32  bi_x_pels_per_meter;
+	s32  bi_y_pels_per_meter;
 	u32  bi_clr_used;
 	u32  bi_clr_important;
 } alBITMAPINFOHEADER;


### PR DESCRIPTION
For a project of mine, I create an AVI file using my own code.
I'm already using libgpac to create MP4 files so only using libgpac would be quite logic.
The only feature missing in libgpac is adding an AVI subtitle.
Eventually I'll add it but I'm starting with some small commits to minimize regression risk.

Currently, we allocate buffers, we fill data and then we write the full chunk on disk.
I propose to write chunk fields one after another to avoid allocating/freeing memory for each chunk.
I created some helpers and demonstrated their usage reimplementing a function.
If you don't like "if(ret) goto on_error" lines, we can use a macro like CHECK_GOTO(conditon, label).

My ultimate goal is to store all needed informations in avi_t and write the AVI file once for all.
It'll use more memory so I'm not sure whether it's an improvement.

Anyway, I'm open to suggestions.