### PR TITLE
Strip with '-S' instead of '-g' to fix macOS installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ ifeq ($(CONFIG_WIN32),yes)
 	$(INSTALL) $(INSTFLAGS) -m 755 bin/gcc/libgpac.dll $(DESTDIR)$(prefix)/bin
 else
 ifeq ($(DEBUGBUILD),no)
-	$(STRIP) -g bin/gcc/libgpac$(DYN_LIB_SUFFIX)
+	$(STRIP) -S bin/gcc/libgpac$(DYN_LIB_SUFFIX)
 endif
 ifeq ($(CONFIG_DARWIN),yes)
 	$(INSTALL) -m 755 bin/gcc/libgpac$(DYN_LIB_SUFFIX) $(DESTDIR)$(prefix)/$(libdir)/libgpac.$(VERSION)$(DYN_LIB_SUFFIX)


### PR DESCRIPTION
The [strip command provided with macOS](https://www.unix.com/man-page/osx/1/strip/) does not have a `-g` option, but does have `-S` which is also recognized by [GNU](https://linux.die.net/man/1/strip) and [BSD](https://www.freebsd.org/cgi/man.cgi?query=strip&sektion=1&manpath=freebsd-release-ports) strip.

So 8256a66ae5c17dff965c67cf14a03fa106448925 introduced the following error during installation of non-debug builds using Apple's strip:
```
make installdylib
error: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/strip: unrecognized option: -g
Usage: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/strip [-AnuSXx] [-] [-d filename] [-s filename] [-R filename] [-o output] file [...]
make[1]: *** [installdylib] Error 1
make: *** [install] Error 2
```