### PR TITLE
mark AV1 frames with refresh_frame_flags = 0 as disposable

### DIFF
--- a/applications/mp4box/filedump.c
+++ b/applications/mp4box/filedump.c
@@ -1564,10 +1564,13 @@ static void dump_obu(FILE *dump, u32 idx, AV1State *av1, char *obu, u32 obu_leng
 			else if (av1->frame_state.frame_type==AV1_INTER_FRAME) fprintf(dump, "frame_type=\"inter\" ");
 			else if (av1->frame_state.frame_type==AV1_INTRA_ONLY_FRAME) fprintf(dump, "frame_type=\"intra_only\" ");
 			else if (av1->frame_state.frame_type==AV1_SWITCH_FRAME) fprintf(dump, "frame_type=\"switch\" ");
+			fprintf(dump, "refresh_frame_flags=\"%d\" ", av1->frame_state.refresh_frame_flags);
 
 			DUMP_OBU_INT2("show_frame", av1->frame_state.show_frame);
 			if (av1->frame_state.show_existing_frame) {
 				DUMP_OBU_INT2("show_existing_frame", av1->frame_state.show_existing_frame);
+			} else {
+				DUMP_OBU_INT2("show_existing_frame", 0);
 			}
 		}
 		if (obu_type==OBU_FRAME_HEADER)

--- a/src/media_tools/media_import.c
+++ b/src/media_tools/media_import.c
@@ -7495,15 +7495,28 @@ static GF_Err gf_import_aom_av1(GF_MediaImporter *import)
 					if (a_hdr->obu) gf_free(a_hdr->obu);
 					gf_free(a_hdr);
 				}
+
 			}
 
 			e = gf_isom_add_sample(import->dest, track_num, di, samp);
 			if (e) goto exit;
+			cur_samp++;
+
+			//write sample deps
+			if (import->flags & GF_IMPORT_SAMPLE_DEPS) {
+				u32 isLeading, dependsOn, dependedOn, hasRedundant;
+				isLeading = 0;
+				dependsOn = samp->IsRAP ? 2 : 1;
+				dependedOn = state.frame_state.refresh_frame_flags ? 1 : 2;
+				hasRedundant = 0;
+
+				e = gf_isom_sample_set_dep_info(import->dest, track_num, cur_samp, isLeading, dependsOn, dependedOn, hasRedundant);
+				if (e) goto exit;
+			}
 
 			gf_isom_sample_del(&samp);
 
 			gf_set_progress("Importing AV1", gf_bs_get_position(bs), fsize);
-			cur_samp++;
 		}
 	}
 


### PR DESCRIPTION
I did the following test:
MP4Box -add file.obu:deps file_deps.mp4
MP4Box -add file_deps.mp4:refs file_deps_refs.mp4
I played the final file with VLC and did not see any issue.

For review. More tests to be done. Do not merge now.