### PR TITLE
Fix shift exponent is too large in gf_bs_write_int

### DIFF
--- a/src/isomedia/box_code_base.c
+++ b/src/isomedia/box_code_base.c
@@ -11513,7 +11513,11 @@ GF_Err dvcC_Write(GF_Box *s, GF_BitStream *bs)
 	gf_bs_write_int(bs, ptr->DOVIConfig.rpu_present_flag, 1);
 	gf_bs_write_int(bs, ptr->DOVIConfig.el_present_flag, 1);
 	gf_bs_write_int(bs, ptr->DOVIConfig.bl_present_flag, 1);
-	gf_bs_write_int(bs, 0, 5*32);
+	{
+		u32 data[5];
+		memset(data, 0, sizeof(data));
+		gf_bs_write_data(bs, (char*)data, sizeof(data));
+	}
 
 	return GF_OK;
 }


### PR DESCRIPTION
When importing mp4's containing dvcc box, MP4Box will fail complaining that:
`utils/bitstream.c:552:9: runtime error: shift exponent 4294967168 is too large for 32-bit type 'unsigned int'`

It was hapenning due to 160 being passed into the `gf_bs_write_int` (from dvcc_Write) and shifting the value beyond the valid range.

The fix ensures that the value is correctly written, by draining the count of bits all the way up until it reaches an acceptable value.