### PR TITLE
Fix an error while executing dpkg-genbuildinfo

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -103,7 +103,7 @@ binary-arch: build install
 	dh_shlibdeps
 	dh_gencontrol
 	dh_md5sums
-	dh_builddeb --destdir=.
+	dh_builddeb --destdir=..
 
 binary: binary-indep binary-arch
 .PHONY: build clean binary-indep binary-arch binary install


### PR DESCRIPTION
`dpkg-buildpackage -j10 -uc -us` fails with such an error:

```bash
% dpkg-genbuildinfo

dpkg-genbuildinfo: error: cannot fstat file ../gpac-dbgsym_0.8.0_amd64.ddeb: No such file or directory
dpkg-buildpackage: error: dpkg-genbuildinfo subprocess returned exit status 255
```

In this patch, this issue is resolved by set destdir to parent directory.

Please take a look!