### PR TITLE
Use the same variables leads to logic chaos

### DIFF
--- a/src/filters/dmx_dash.c
+++ b/src/filters/dmx_dash.c
@@ -1510,7 +1510,7 @@ GF_Err dashdmx_process(GF_Filter *filter)
 					if (group->nb_eos == group->nb_pids) {
 						u32 nb_block = 0;
 						//check all pids in this group, postpone segment switch if blocking
-						for (i=0; i<count; i++) {
+						for (u32 i=0; i<count; i++) {
 							GF_FilterPid *an_ipid = gf_filter_get_ipid(filter, i);
 							GF_FilterPid *an_opid = gf_filter_pid_get_udta(an_ipid);
 							GF_DASHGroup *agroup;
@@ -1530,7 +1530,7 @@ GF_Err dashdmx_process(GF_Filter *filter)
 
 						//good to switch, cancel all end of stream signals on pids from this group and switch
 						GF_LOG(GF_LOG_DEBUG, GF_LOG_DASH, ("[DASHDmx] End of segment for group %d, updating stats and switching segment\n", group->idx));
-						for (i=0; i<count; i++) {
+						for (u32 i=0; i<count; i++) {
 							GF_FilterPid *an_ipid = gf_filter_get_ipid(filter, i);
 							GF_FilterPid *an_opid = gf_filter_pid_get_udta(an_ipid);
 							GF_DASHGroup *agroup;


### PR DESCRIPTION
File：dmx_dash.c  Method：dashdmx_process
This method use the same  loop variables "i" in three traverses at the same time , it will sometimes cause failure when play the video. Redeclare "i" in new loop can avoid some unexpected exception.
 