### PR TITLE
Get rid of spaces behind commas in ifeq/ifneq statements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,18 +111,18 @@ install:
 	$(INSTALL) -d "$(DESTDIR)$(prefix)"
 	$(INSTALL) -d "$(DESTDIR)$(prefix)/$(libdir)"
 	$(INSTALL) -d "$(DESTDIR)$(prefix)/bin"
-ifeq ($(DISABLE_ISOFF), no)
+ifeq ($(DISABLE_ISOFF),no)
 	if [ -f bin/gcc/MP4Box$(EXE_SUFFIX) ] ; then \
 	$(INSTALL) $(INSTFLAGS) -m 755 bin/gcc/MP4Box$(EXE_SUFFIX) "$(DESTDIR)$(prefix)/bin" ; \
 	fi
-ifneq ($(MP4BOX_STATIC), yes)
+ifneq ($(MP4BOX_STATIC),yes)
 	if [ -f bin/gcc/MP42TS$(EXE_SUFFIX) ] ; then \
 	$(INSTALL) $(INSTFLAGS) -m 755 bin/gcc/MP42TS$(EXE_SUFFIX) "$(DESTDIR)$(prefix)/bin" ; \
 	fi
-ifneq ($(CONFIG_WIN32), yes)
-ifneq ($(CONFIG_FFMPEG), no)
-ifneq ($(DISABLE_CORE_TOOLS), yes)
-ifneq ($(DISABLE_AV_PARSERS), yes)
+ifneq ($(CONFIG_WIN32),yes)
+ifneq ($(CONFIG_FFMPEG),no)
+ifneq ($(DISABLE_CORE_TOOLS),yes)
+ifneq ($(DISABLE_AV_PARSERS),yes)
 	if [ -f bin/gcc/DashCast$(EXE_SUFFIX) ] ; then \
 	$(INSTALL) $(INSTFLAGS) -m 755 bin/gcc/DashCast$(EXE_SUFFIX) "$(DESTDIR)$(prefix)/bin" ; \
 	fi
@@ -132,8 +132,8 @@ endif
 endif
 endif
 endif
-ifneq ($(MP4BOX_STATIC), yes)
-ifeq ($(DISABLE_PLAYER), no)
+ifneq ($(MP4BOX_STATIC),yes)
+ifeq ($(DISABLE_PLAYER),no)
 	if [ -f bin/gcc/MP4Client$(EXE_SUFFIX) ] ; then \
 	$(INSTALL) $(INSTFLAGS) -m 755 bin/gcc/MP4Client$(EXE_SUFFIX) "$(DESTDIR)$(prefix)/bin" ; \
 	fi
@@ -184,18 +184,18 @@ lninstall:
 	$(INSTALL) -d "$(DESTDIR)$(prefix)"
 	$(INSTALL) -d "$(DESTDIR)$(prefix)/$(libdir)"
 	$(INSTALL) -d "$(DESTDIR)$(prefix)/bin"
-ifeq ($(DISABLE_ISOFF), no)
+ifeq ($(DISABLE_ISOFF),no)
 	ln -sf $(BUILD_PATH)/bin/gcc/MP4Box$(EXE_SUFFIX) $(DESTDIR)$(prefix)/bin/MP4Box$(EXE_SUFFIX)
 	ln -sf $(BUILD_PATH)/bin/gcc/MP42TS$(EXE_SUFFIX) $(DESTDIR)$(prefix)/bin/MP42TS$(EXE_SUFFIX)
 endif
 ifneq ($(MP4BOX_STATIC),yes)
-ifeq ($(DISABLE_PLAYER), no)
+ifeq ($(DISABLE_PLAYER),no)
 	ln -sf $(BUILD_PATH)/bin/gcc/MP4Client$(EXE_SUFFIX) $(DESTDIR)$(prefix)/bin/MP4Client$(EXE_SUFFIX)
 endif
-ifneq ($(CONFIG_WIN32), yes)
-ifneq ($(CONFIG_FFMPEG), no)
-ifneq ($(DISABLE_CORE_TOOLS), yes)
-ifneq ($(DISABLE_AV_PARSERS), yes)
+ifneq ($(CONFIG_WIN32),yes)
+ifneq ($(CONFIG_FFMPEG),no)
+ifneq ($(DISABLE_CORE_TOOLS),yes)
+ifneq ($(DISABLE_AV_PARSERS),yes)
 	ln -sf $(BUILD_PATH)/bin/gcc/DashCast$(EXE_SUFFIX) $(DESTDIR)$(prefix)/bin/DashCast$(EXE_SUFFIX)
 endif
 endif
@@ -265,7 +265,7 @@ install-lib:
 	mkdir -p "$(DESTDIR)$(prefix)/include/gpac/modules"
 	$(INSTALL) $(INSTFLAGS) -m 644 $(SRC_PATH)/include/gpac/modules/*.h "$(DESTDIR)$(prefix)/include/gpac/modules"
 	$(INSTALL) $(INSTFLAGS) -m 644 config.h "$(DESTDIR)$(prefix)/include/gpac/configuration.h"
-ifeq ($(GPAC_ENST), yes)
+ifeq ($(GPAC_ENST),yes)
 	mkdir -p "$(DESTDIR)$(prefix)/include/gpac/enst"
 	$(INSTALL) $(INSTFLAGS) -m 644 $(SRC_PATH)/include/gpac/enst/*.h "$(DESTDIR)$(prefix)/include/gpac/enst"
 endif

--- a/applications/Makefile
+++ b/applications/Makefile
@@ -6,20 +6,20 @@ ifeq ($(MP4BOX_STATIC),yes)
 APPDIRS+=mp4box 
 else
 
-ifeq ($(DISABLE_PLAYER), no)
+ifeq ($(DISABLE_PLAYER),no)
 APPDIRS+=mp4client 
 endif
 
-ifeq ($(DISABLE_ISOFF), no)
+ifeq ($(DISABLE_ISOFF),no)
 APPDIRS+=mp4box 
-ifeq ($(DISABLE_M2TS_MUX), no)
+ifeq ($(DISABLE_M2TS_MUX),no)
 APPDIRS+=mp42ts 
 endif
 
-ifneq ($(CONFIG_WIN32), yes)
-ifneq ($(CONFIG_FFMPEG), no)
-ifneq ($(DISABLE_CORE_TOOLS), yes)
-ifneq ($(DISABLE_AV_PARSERS), yes)
+ifneq ($(CONFIG_WIN32),yes)
+ifneq ($(CONFIG_FFMPEG),no)
+ifneq ($(DISABLE_CORE_TOOLS),yes)
+ifneq ($(DISABLE_AV_PARSERS),yes)
 APPDIRS+=dashcast
 endif
 endif
@@ -38,7 +38,7 @@ else
 endif
 
 #disable due to version incompatibilities
-ifeq ($(USE_WXWIDGETS), yes)
+ifeq ($(USE_WXWIDGETS),yes)
 #APPDIRS+=osmo4_wx
 #V4STUDIODIR=V4Studio
 #INSTDIRS+=osmo4_wx

--- a/applications/dashcast/Makefile
+++ b/applications/dashcast/Makefile
@@ -6,17 +6,17 @@ CFLAGS= $(OPTFLAGS) -D_GNU_SOURCE -Wno-deprecated-declarations -I"$(SRC_PATH)/in
 
 LINKFLAGS=$(GPAC_SH_FLAGS)
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
 
-ifeq ($(GPACREADONLY), yes)
+ifeq ($(GPACREADONLY),yes)
 CFLAGS+=-DGPAC_READ_ONLY
 endif
 
@@ -53,7 +53,7 @@ CFLAGS+=-DDC_AUDIO_RESAMPLER
 LINKFLAGS+=-lswresample
 endif
 
-ifeq ($(CONFIG_DARWIN), yes)
+ifeq ($(CONFIG_DARWIN),yes)
 #fixme - use proper detection of libavdevice dependencies
 #LINKFLAGS+=-lavfilter -lswresample -lbz2
 endif

--- a/applications/generators/MPEG4/Makefile
+++ b/applications/generators/MPEG4/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/applications/generators/MPEG4
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/applications/generators/Makefile
+++ b/applications/generators/Makefile
@@ -2,9 +2,9 @@ include ../../config.mak
 
 GENDIRS=MPEG4 X3D
 
-ifeq ($(HAS_LIBXML2), yes)
+ifeq ($(HAS_LIBXML2),yes)
 #sorry minGW friends, I can't get a stable libxml2 to compile ...
-ifeq ($(CONFIG_WIN32), yes)
+ifeq ($(CONFIG_WIN32),yes)
 else
 GENDIRS+=SVG
 endif

--- a/applications/generators/SVG/Makefile
+++ b/applications/generators/SVG/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/applications/generators/SVG
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/applications/generators/X3D/Makefile
+++ b/applications/generators/X3D/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/applications/generators/X3D
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/applications/mp42avi/Makefile
+++ b/applications/mp42avi/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/applications/mp42avi
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/applications/mp42ts/Makefile
+++ b/applications/mp42ts/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/applications/mp42ts
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
@@ -28,7 +28,7 @@ ifeq ($(STATICBUILD),yes)
 include ../../static.mak
 
 #FIXME we have to disable AAC+bifs support in mp42ts since it reuses things from aac_in already in libgpac ...
-ifeq ($(STATIC_MODULES), yes)
+ifeq ($(STATIC_MODULES),yes)
 CFLAGS+=-DGPAC_DISABLE_PLAYER
 endif
 

--- a/applications/mp4box/Makefile
+++ b/applications/mp4box/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/applications/mp4box
 
 CFLAGS= $(OPTFLAGS) -DGPAC_HAVE_CONFIG_H -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/applications/mp4client/Makefile
+++ b/applications/mp4client/Makefile
@@ -6,17 +6,17 @@ CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include" -I../../
 
 LINKFLAGS=$(GPAC_SH_FLAGS)
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
 
-ifeq ($(GPACREADONLY), yes)
+ifeq ($(GPACREADONLY),yes)
 CFLAGS+=-DGPAC_READ_ONLY
 endif
 

--- a/applications/osmo4_wx/Makefile
+++ b/applications/osmo4_wx/Makefile
@@ -4,17 +4,17 @@ vpath %.cpp $(SRC_PATH)/applications/osmo4_wx
 
 CFLAGS= $(CXXFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
 
-ifeq ($(GPACREADONLY), yes)
+ifeq ($(GPACREADONLY),yes)
 CFLAGS+=-DGPAC_READ_ONLY
 endif
 

--- a/applications/osmozilla/Makefile
+++ b/applications/osmozilla/Makefile
@@ -6,7 +6,7 @@ ifeq ($(CONFIG_WIN32),yes)
 USER_NAME=root
 else
 USER_NAME=$(shell whoami)
-ifeq ($(USER_NAME), root)
+ifeq ($(USER_NAME),root)
 else
 MOZILLA_DIR=local
 endif
@@ -14,12 +14,12 @@ endif
 
 CFLAGS=$(CXXFLAGS) $(XUL_CFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
@@ -72,8 +72,8 @@ ifeq ($(CONFIG_WIN32),yes)
 endif
 
 install: 
-ifeq ($(MOZILLA_DIR), local)
-ifeq ($(USER_NAME), root)
+ifeq ($(MOZILLA_DIR),local)
+ifeq ($(USER_NAME),root)
 	@echo "*** Root cannot install local mozilla plugins! ***"
 	@echo "*** Exit root mode and reinstall mozilla plugin! ***"
 else
@@ -87,8 +87,8 @@ else
 endif
 
 uninstall:
-ifeq ($(MOZILLA_DIR), local)
-ifeq ($(USER_NAME), root)
+ifeq ($(MOZILLA_DIR),local)
+ifeq ($(USER_NAME),root)
 else
 	rm -rf "$(HOME)/.mozilla/plugins/$(LIB)"
 	rm -rf "$(HOME)/.mozilla/components/nposmozilla.xpt"

--- a/applications/testapps/atscdmx/Makefile
+++ b/applications/testapps/atscdmx/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/applications/testapps/atscdmx
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include" 
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/applications/testapps/bmp4demux/Makefile
+++ b/applications/testapps/bmp4demux/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/applications/testapps/bmp4demux
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/applications/testapps/broadcaster/Makefile
+++ b/applications/testapps/broadcaster/Makefile
@@ -8,12 +8,12 @@ SOURCES=
 APPNAME=broadcaster
 
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/applications/testapps/fmp4demux/Makefile
+++ b/applications/testapps/fmp4demux/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/applications/testapps/fmp4demux
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/applications/testapps/hevcbench/Makefile
+++ b/applications/testapps/hevcbench/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/applications/testapps/hevcbench
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include" $(SDL_CFLAGS) $(OGL_INCLS) $(OHEVC_CFLAGS)
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/applications/testapps/loadcompare/Makefile
+++ b/applications/testapps/loadcompare/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/applications/testapps/loadcompare
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/applications/testapps/mpedemux/Makefile
+++ b/applications/testapps/mpedemux/Makefile
@@ -4,22 +4,22 @@ vpath %.c $(SRC_PATH)/applications/test_apps/mpedemux
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
 
 #file format is read-only
-ifeq ($(GPACREADONLY), yes)
+ifeq ($(GPACREADONLY),yes)
 CFLAGS+= -DGPAC_READ_ONLY
 endif
 
-ifeq ($(DISABLE_SVG), yes)
+ifeq ($(DISABLE_SVG),yes)
 CFLAGS+=-DGPAC_DISABLE_SVG
 endif
 

--- a/applications/testapps/segmp4demux/Makefile
+++ b/applications/testapps/segmp4demux/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/applications/testapps/segmp4demux
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/applications/ts2hds/Makefile
+++ b/applications/ts2hds/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/applications/ts2hds
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/applications/udptsseg/Makefile
+++ b/applications/udptsseg/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/applications/udptsseg
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -3,7 +3,7 @@ include ../config.mak
 #all OS and lib independent
 PLUGDIRS=aac_in ac3_in amr_dec atsc_in audio_filter bifs_dec dummy_in soft_raster mp3_in isom_in odf_dec rtp_in timedtext img_in saf_in ismacryp raw_out validator netctrl
 
-ifeq ($(DISABLE_DASH_CLIENT), no)
+ifeq ($(DISABLE_DASH_CLIENT),no)
 PLUGDIRS+=mpd_in
 ifeq ($(CONFIG_JS),no)
 else
@@ -11,21 +11,21 @@ PLUGDIRS+=mse_in
 endif
 endif
 
-ifeq ($(DISABLE_MEDIA_IMPORT), no)
+ifeq ($(DISABLE_MEDIA_IMPORT),no)
 PLUGDIRS+=mpegts_in 
 endif
 
-ifeq ($(DISABLE_SMGR), no)
+ifeq ($(DISABLE_SMGR),no)
 PLUGDIRS+=ctx_load svg_in
 endif
 
-ifeq ($(DISABLE_SVG), no)
+ifeq ($(DISABLE_SVG),no)
 PLUGDIRS+=laser_dec svg_in 
-ifeq ($(DISABLE_TTXT), no)
+ifeq ($(DISABLE_TTXT),no)
 PLUGDIRS+=vtt_in
 endif
 
-ifneq ($(CONFIG_ZLIB), no)
+ifneq ($(CONFIG_ZLIB),no)
 PLUGDIRS+=widgetman
 ifeq ($(DISABLE_VRML),no)
 ifeq ($(DISABLE_LOADER_BT),no)
@@ -35,43 +35,43 @@ endif
 endif
 endif
 
-ifeq ($(CONFIG_FT), no)
+ifeq ($(CONFIG_FT),no)
 else
 PLUGDIRS+=ft_font
 endif
 
-ifeq ($(CONFIG_XVID), no)
+ifeq ($(CONFIG_XVID),no)
 else
 PLUGDIRS+=xvid_dec
 endif
 
-ifeq ($(CONFIG_OGG), no)
+ifeq ($(CONFIG_OGG),no)
 else
 PLUGDIRS+=ogg
 endif
 
-ifeq ($(CONFIG_FREENECT), no)
+ifeq ($(CONFIG_FREENECT),no)
 else
 PLUGDIRS+=freenect
 endif
 
-ifeq ($(CONFIG_OSS_AUDIO), no)
+ifeq ($(CONFIG_OSS_AUDIO),no)
 else
 PLUGDIRS+=oss_audio
 endif
 
-ifeq ($(CONFIG_ALSA), yes)
+ifeq ($(CONFIG_ALSA),yes)
 PLUGDIRS+=alsa
 endif
 
-ifeq ($(CONFIG_JACK), yes)
+ifeq ($(CONFIG_JACK),yes)
 PLUGDIRS+=jack
 endif
 
-ifeq ($(CONFIG_SDL), yes)
+ifeq ($(CONFIG_SDL),yes)
 PLUGDIRS+=sdl_out
 endif
-ifeq ($(CONFIG_PULSEAUDIO), yes)
+ifeq ($(CONFIG_PULSEAUDIO),yes)
 PLUGDIRS+=pulseaudio
 endif
 
@@ -120,11 +120,11 @@ PLUGDIRS+=nvdec
 endif
 endif
 
-ifneq ($(CONFIG_FFMPEG), no)
+ifneq ($(CONFIG_FFMPEG),no)
 ifeq ($(CONFIG_OPENHEVC),no)
 PLUGDIRS+=ffmpeg_in
 else
-ifneq ($(STATIC_MODULES), yes)
+ifneq ($(STATIC_MODULES),yes)
 PLUGDIRS+=ffmpeg_in
 endif
 endif
@@ -133,7 +133,7 @@ endif
 #openHEVC is disabled in static build
 
 #if static modules are used, disable all previous modules (built-in in libgpac)
-ifeq ($(STATIC_MODULES), yes)
+ifeq ($(STATIC_MODULES),yes)
 PLUGDIRS=
 
 else 
@@ -147,10 +147,10 @@ endif
 
 #all modules below are not (yet) included in static build
 
-ifeq ($(CONFIG_AMR_NB_FT), yes)
+ifeq ($(CONFIG_AMR_NB_FT),yes)
 PLUGDIRS+=amr_float_dec
 else
-ifeq ($(CONFIG_AMR_WB_FT), yes)
+ifeq ($(CONFIG_AMR_WB_FT),yes)
 PLUGDIRS+=amr_float_dec
 endif
 endif
@@ -169,7 +169,7 @@ PLUGDIRS+=avcap
 endif
 
 
-ifeq ($(DISABLE_PLAYER), yes)
+ifeq ($(DISABLE_PLAYER),yes)
 PLUGDIRS=
 endif
 

--- a/modules/aac_in/Makefile
+++ b/modules/aac_in/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/aac_in
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
@@ -20,12 +20,12 @@ OBJS= aac_in.o
 SRCS := $(OBJS:.o=.c)
 
 #faad config
-ifeq ($(CONFIG_FAAD), no)
+ifeq ($(CONFIG_FAAD),no)
 else
 OBJS+=faad_dec.o
 CFLAGS+=-DGPAC_HAS_FAAD
 #local faad lib
-ifeq ($(CONFIG_FAAD), local)
+ifeq ($(CONFIG_FAAD),local)
 EXTRALIBS+=-L../../extra_lib/lib/gcc
 CFLAGS+= -I"$(LOCAL_INC_PATH)"
 endif

--- a/modules/ac3_in/Makefile
+++ b/modules/ac3_in/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/ac3_in
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
@@ -20,12 +20,12 @@ OBJS= ac3_in.o
 SRCS := $(OBJS:.o=.c) 
 
 #faad config
-ifeq ($(CONFIG_A52), no)
+ifeq ($(CONFIG_A52),no)
 else
 OBJS+=liba52_dec.o
 CFLAGS+=-DGPAC_HAS_LIBA52
 #local faad lib
-ifeq ($(CONFIG_FAAD), local)
+ifeq ($(CONFIG_FAAD),local)
 EXTRALIBS+=-L../../extra_lib/lib/gcc
 CFLAGS+= -I"$(LOCAL_INC_PATH)"
 endif

--- a/modules/alsa/Makefile
+++ b/modules/alsa/Makefile
@@ -5,12 +5,12 @@ vpath %.c $(SRC_PATH)/modules/alsa
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include" $(OSS_CFLAGS)
 LDFLAGS+=$(OSS_LDFLAGS)
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/amr_dec/Makefile
+++ b/modules/amr_dec/Makefile
@@ -6,12 +6,12 @@ vpath %.c $(SRC_PATH)/modules/amr_dec
 CFLAGS= $(OPTFLAGS) -w -I"$(SRC_PATH)/include" -D__MSDOS__ -DMMS_IO -DWMOPS=0 -DVAD1
 
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g -DDEBUG
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
@@ -21,7 +21,7 @@ OBJS=amr_in.o
 NAME=amr_in
 AMRLIBS=
 
-ifeq ($(CONFIG_AMR_NB), yes)
+ifeq ($(CONFIG_AMR_NB),yes)
 NAME=amr_dec
 OBJS+= amr_dec.o
 AMRLIBS=-L../../extra_lib/lib/gcc -lopencore-amrnb -lopencore-amrwb

--- a/modules/amr_float_dec/Makefile
+++ b/modules/amr_float_dec/Makefile
@@ -5,12 +5,12 @@ vpath %.c $(SRC_PATH)/modules/amr_float_dec
 #note: __MSDOS__ defined is the same cfg as linux. There may be some pbs on other platforms, to check...
 CFLAGS= $(OPTFLAGS) -w -I"$(SRC_PATH)/include" -D__MSDOS__
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g -DDEBUG
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
@@ -20,14 +20,14 @@ OBJS=amr_float_dec.o
 
 #AMR NB obj
 CFLAGS+=-DGPAC_HAS_AMR_FT
-# ifeq ($(CONFIG_AMR_NB_FT), yes)
+# ifeq ($(CONFIG_AMR_NB_FT),yes)
 # OBJS+=./amr_nb_ft/interf_dec.o ./amr_nb_ft/interf_enc.o ./amr_nb_ft/sp_dec.o ./amr_nb_ft/sp_enc.o
 # endif
 
 
 #AMR WB obj
 CFLAGS+=-DGPAC_HAS_AMR_FT_WB
-#ifeq ($(CONFIG_AMR_WB_FT), yes)
+#ifeq ($(CONFIG_AMR_WB_FT),yes)
 # OBJS+=./amr_wb_ft/dec_acelp.o ./amr_wb_ft/dec_dtx.o ./amr_wb_ft/dec_gain.o ./amr_wb_ft/dec_if.o ./amr_wb_ft/dec_lpc.o ./amr_wb_ft/dec_main.o \
 # 	./amr_wb_ft/dec_rom.o ./amr_wb_ft/dec_util.o ./amr_wb_ft/enc_acelp.o ./amr_wb_ft/enc_dtx.o ./amr_wb_ft/enc_gain.o ./amr_wb_ft/enc_if.o \
 # 	./amr_wb_ft/enc_lpc.o ./amr_wb_ft/enc_main.o ./amr_wb_ft/enc_rom.o ./amr_wb_ft/enc_util.o ./amr_wb_ft/if_rom.o

--- a/modules/atsc_in/Makefile
+++ b/modules/atsc_in/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/atsc_in
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/audio_filter/Makefile
+++ b/modules/audio_filter/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/audio_filter
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/avcap/Makefile
+++ b/modules/avcap/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/avcap
 
 CFLAGS= $(CXXFLAGS) -I"$(SRC_PATH)/include" $(AVCAP_CFLAGS)
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/bifs_dec/Makefile
+++ b/modules/bifs_dec/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/bifs_dec
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/ctx_load/Makefile
+++ b/modules/ctx_load/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/ctx_load
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/dektec_out/Makefile
+++ b/modules/dektec_out/Makefile
@@ -4,21 +4,21 @@ vpath %.c $(SRC_PATH)/modules/dektec_out
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include" -DGPAC_HAVE_CONFIG_H -I../../
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
 
-ifeq ($(ENABLE_JOYSTICK), yes)
+ifeq ($(ENABLE_JOYSTICK),yes)
 CFLAGS+=-DENABLE_JOYSTICK
 endif
 
-ifeq ($(ENABLE_JOYSTICK_NO_CURSOR), yes)
+ifeq ($(ENABLE_JOYSTICK_NO_CURSOR),yes)
 CFLAGS+=-DENABLE_JOYSTICK_NO_CURSOR
 endif
 

--- a/modules/demo_is/Makefile
+++ b/modules/demo_is/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/demo_is
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/directfb_out/Makefile
+++ b/modules/directfb_out/Makefile
@@ -6,12 +6,12 @@ CFLAGS= $(OPTFLAGS)
 CFLAGS+=-I"$(SRC_PATH)/include" -I$(DIRECTFB_INC_PATH)
 LDFLAGS+=$(DIRECTFB_LIB)
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/dummy_in/Makefile
+++ b/modules/dummy_in/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/dummy_in
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/dx_hw/Makefile
+++ b/modules/dx_hw/Makefile
@@ -5,17 +5,17 @@ vpath %.c $(SRC_PATH)/modules/dx_hw
 #DIRECTSOUND_VERSION is needed for GCC compil..
 CFLAGS= $(OPTFLAGS) -w -I"$(SRC_PATH)/include" -DDIRECTSOUND_VERSION=0x0500
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
 
-ifeq ($(DX_PATH), system)
+ifeq ($(DX_PATH),system)
 LDFLAGS_DX=-ldsound -ldxguid -lddraw -lole32 -lgdi32 -lopengl32
 else
 CFLAGS+= -I$(DX_PATH)/include

--- a/modules/ffmpeg_in/Makefile
+++ b/modules/ffmpeg_in/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/ffmpeg_in
 
 CFLAGS=-fPIC $(OPTFLAGS) -Wno-deprecated-declarations -I"$(SRC_PATH)/include" $(ffmpeg_cflags)
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
@@ -37,19 +37,19 @@ LINKFLAGS+=-lbz2
 endif
 
 #old ffmpeg lib
-ifeq ($(CONFIG_FFMPEG_OLD), yes)
+ifeq ($(CONFIG_FFMPEG_OLD),yes)
 CFLAGS+=-DFFMPEG_OLD_HEADERS -I/usr/include
 else
 LINKFLAGS+=-lswscale
 endif
 
 #local ffmpeg lib
-ifeq ($(CONFIG_FFMPEG), local)
+ifeq ($(CONFIG_FFMPEG),local)
 LOCAL_LIB=-L../../extra_lib/lib/gcc
 CFLAGS+= -I"$(LOCAL_INC_PATH)"
 endif
 
-ifeq ($(CONFIG_ZLIB), local)
+ifeq ($(CONFIG_ZLIB),local)
 LOCAL_LIB=-L../../extra_lib/lib/gcc
 endif
 

--- a/modules/freenect/Makefile
+++ b/modules/freenect/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/freenect
 
 CFLAGS= $(CXXFLAGS) -I"$(SRC_PATH)/include" $(FREENECT_CFLAGS)
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
@@ -17,7 +17,7 @@ endif
 
 LINKLIBS=
 
-ifeq ($(CONFIG_FREENECT), local)
+ifeq ($(CONFIG_FREENECT),local)
 LINKLIBS+=-L../../extra_lib/lib/gcc
 CFLAGS+= -I"$(LOCAL_INC_PATH)"
 endif

--- a/modules/ft_font/Makefile
+++ b/modules/ft_font/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/ft_font
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include" $(FT_CFLAGS)
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/gpac_js/Makefile
+++ b/modules/gpac_js/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/gpac_js
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/hyb_in/Makefile
+++ b/modules/hyb_in/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/hyb_in
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/img_in/Makefile
+++ b/modules/img_in/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/img_in
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
@@ -26,13 +26,13 @@ endif
 OBJS=img_dec.o img_in.o bmp_dec.o png_dec.o jpeg_dec.o
 
 #openjpeg config
-ifeq ($(CONFIG_JP2), no)
+ifeq ($(CONFIG_JP2),no)
 else
 OBJS+=jp2_dec.o
 LINKLIBS+= -lopenjpeg -lm
 CFLAGS+=-DGPAC_HAS_JP2
 #local openjpeg lib
-ifeq ($(CONFIG_JP2), local)
+ifeq ($(CONFIG_JP2),local)
 NEED_LOCAL_LIB="yes"
 CFLAGS+= -DOPJ_STATIC -I"$(LOCAL_INC_PATH)/openjpeg"
 endif
@@ -40,7 +40,7 @@ endif
 
 
 #add local lib path
-ifeq ($(NEED_LOCAL_LIB), "yes")
+ifeq ($(NEED_LOCAL_LIB),yes)
 LOCAL_LIB+=-L../../extra_lib/lib/gcc
 endif
 

--- a/modules/ismacryp/Makefile
+++ b/modules/ismacryp/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/ismacryp
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/isom_in/Makefile
+++ b/modules/isom_in/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/isom_in
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/jack/Makefile
+++ b/modules/jack/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/jack
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include" $(OSS_CFLAGS) -Wno-deprecated-declarations
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/laser_dec/Makefile
+++ b/modules/laser_dec/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/laser_dec
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/libplayer/Makefile
+++ b/modules/libplayer/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/libplayer
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/mediacodec_dec/Makefile
+++ b/modules/mediacodec_dec/Makefile
@@ -4,21 +4,21 @@ vpath %.c $(SRC_PATH)/modules/mediacodec_dec
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include" -DGPAC_HAVE_CONFIG_H -I../../
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
 
-ifeq ($(ENABLE_JOYSTICK), yes)
+ifeq ($(ENABLE_JOYSTICK),yes)
 CFLAGS+=-DENABLE_JOYSTICK
 endif
 
-ifeq ($(ENABLE_JOYSTICK_NO_CURSOR), yes)
+ifeq ($(ENABLE_JOYSTICK_NO_CURSOR),yes)
 CFLAGS+=-DENABLE_JOYSTICK_NO_CURSOR
 endif
 

--- a/modules/mp3_in/Makefile
+++ b/modules/mp3_in/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/mp3_in
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
@@ -20,12 +20,12 @@ OBJS= mp3_in.o
 
 
 #mad config
-ifeq ($(CONFIG_MAD), no)
+ifeq ($(CONFIG_MAD),no)
 else
 OBJS+=mad_dec.o
 CFLAGS+=-DGPAC_HAS_MAD
 #local mad lib
-ifeq ($(CONFIG_MAD), local)
+ifeq ($(CONFIG_MAD),local)
 EXTRALIBS+=-L../../extra_lib/lib/gcc
 CFLAGS+= -I"$(LOCAL_INC_PATH)"
 endif

--- a/modules/mpd_in/Makefile
+++ b/modules/mpd_in/Makefile
@@ -5,12 +5,12 @@ vpath %.c $(SRC_PATH)/modules/mpd_in
 CFLAGS= $(OPTFLAGS) -w -I"$(SRC_PATH)/include" -Wall
 
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g -DDEBUG
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/mpegts_in/Makefile
+++ b/modules/mpegts_in/Makefile
@@ -5,12 +5,12 @@ vpath %.c $(SRC_PATH)/modules/mpegts_in
 CFLAGS= $(OPTFLAGS) -w -I"$(SRC_PATH)/include"
 
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g -DDEBUG
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/mse_in/Makefile
+++ b/modules/mse_in/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/mse_in
 
 CFLAGS= $(OPTFLAGS) -w -I"$(SRC_PATH)/include" -Wall
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g -DDEBUG
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/netctrl/Makefile
+++ b/modules/netctrl/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/netctrl
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/nvdec/Makefile
+++ b/modules/nvdec/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/nvdec
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
@@ -20,12 +20,12 @@ OBJS=nvdec.o cuda_sdk.o
 SRCS := $(OBJS:.o=.c) 
 
 
-ifeq ($(CONFIG_WIN32), yes)
+ifeq ($(CONFIG_WIN32),yes)
 else
 EXTRALIBS+=-ldl
 endif
 
-ifeq ($(HAS_OPENGL), yes)
+ifeq ($(HAS_OPENGL),yes)
 CFLAGS+=$(OGL_INCLS)
 EXTRALIBS+=$(OGL_LIBS)
 

--- a/modules/odf_dec/Makefile
+++ b/modules/odf_dec/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/odf_dec
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/ogg/Makefile
+++ b/modules/ogg/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/ogg
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
@@ -19,39 +19,39 @@ OBJS= ogg_in.o ogg_load.o
 
 SRCS := $(OBJS:.o=.c) 
 
-NEED_LOCAL_LIB="no"
+NEED_LOCAL_LIB=no
 LOCAL_LIB=../../bin/gcc
 LINKLIBS= -lgpac -logg
 
-ifeq ($(CONFIG_OGG), local)
-NEED_LOCAL_LIB="yes"
+ifeq ($(CONFIG_OGG),local)
+NEED_LOCAL_LIB=yes
 endif
 
-ifeq ($(CONFIG_VORBIS), no)
+ifeq ($(CONFIG_VORBIS),no)
 else
 OBJS+= vorbis_dec.o
 LINKLIBS+= -lvorbis
 CFLAGS+=-DGPAC_HAS_VORBIS
-ifeq ($(CONFIG_VORBIS), local)
-NEED_LOCAL_LIB="yes"
+ifeq ($(CONFIG_VORBIS),local)
+NEED_LOCAL_LIB=yes
 CFLAGS+= -I"$(LOCAL_INC_PATH)"
 endif
 endif
 
-ifeq ($(CONFIG_THEORA), no)
+ifeq ($(CONFIG_THEORA),no)
 else
 OBJS+= theora_dec.o
 LINKLIBS+= -ltheora
 CFLAGS+=-DGPAC_HAS_THEORA
-ifeq ($(CONFIG_THEORA), local)
-NEED_LOCAL_LIB="yes"
+ifeq ($(CONFIG_THEORA),local)
+NEED_LOCAL_LIB=yes
 CFLAGS+= -I"$(LOCAL_INC_PATH)"
 endif
 endif
 
 
 #add local lib path
-ifeq ($(NEED_LOCAL_LIB), "yes")
+ifeq ($(NEED_LOCAL_LIB),yes)
 LOCAL_LIB+=-L../../extra_lib/lib/gcc
 endif
 

--- a/modules/opencv_is/Makefile
+++ b/modules/opencv_is/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/opencv_is
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/openhevc_dec/Makefile
+++ b/modules/openhevc_dec/Makefile
@@ -4,16 +4,16 @@ vpath %.c $(SRC_PATH)/modules/openhevc_dec
 
 CFLAGS=$(OPTFLAGS) -I"$(SRC_PATH)/include" $(OHEVC_CFLAGS)
 
-ifeq ($(CONFIG_LINUX), yes)
+ifeq ($(CONFIG_LINUX),yes)
 LDFLAGS+=-Wl,-Bsymbolic
 endif
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/opensvc_dec/Makefile
+++ b/modules/opensvc_dec/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/opensvc_dec
 
 CFLAGS=$(OPTFLAGS) -I"$(SRC_PATH)/include" $(OSVC_CFLAGS)
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/osd/Makefile
+++ b/modules/osd/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/osd
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/oss_audio/Makefile
+++ b/modules/oss_audio/Makefile
@@ -5,22 +5,22 @@ vpath %.c $(SRC_PATH)/modules/oss_audio
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include" $(OSS_CFLAGS)
 LDFLAGS+=$(OSS_LDFLAGS)
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
 
-ifeq ($(OSS_INC_TYPE), yes)
+ifeq ($(OSS_INC_TYPE),yes)
 else
 CFLAGS+=-DOSS_FIX_INC
 endif
 
-ifeq ($(TARGET_ARCH_ARMV4L), yes)
+ifeq ($(TARGET_ARCH_ARMV4L),yes)
 CFLAGS+=-DFORCE_SR_LIMIT
 endif
 

--- a/modules/platinum/Makefile
+++ b/modules/platinum/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/platinum
 
 CFLAGS= $(CXXFLAGS) -I"$(SRC_PATH)/include" -I$(SRC_PATH)/extra_lib/include/platinum/ -DGPAC_HAVE_CONFIG_H -I../..
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
@@ -39,7 +39,7 @@ ifeq ($(CONFIG_WIN32),yes)
 LINKLIBS+= -lwsock32 -lws2_32 -static-libstdc++ -static-libgcc
 endif
 
-ifeq ($(CONFIG_DARWIN), yes)
+ifeq ($(CONFIG_DARWIN),yes)
 LDFLAGS+=-framework Foundation
 endif
 

--- a/modules/psvr/Makefile
+++ b/modules/psvr/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/psvr
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/pulseaudio/Makefile
+++ b/modules/pulseaudio/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/pulseaudio
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/raw_out/Makefile
+++ b/modules/raw_out/Makefile
@@ -4,21 +4,21 @@ vpath %.c $(SRC_PATH)/modules/raw_out
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include" -DGPAC_HAVE_CONFIG_H -I../../
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
 
-ifeq ($(ENABLE_JOYSTICK), yes)
+ifeq ($(ENABLE_JOYSTICK),yes)
 CFLAGS+=-DENABLE_JOYSTICK
 endif
 
-ifeq ($(ENABLE_JOYSTICK_NO_CURSOR), yes)
+ifeq ($(ENABLE_JOYSTICK_NO_CURSOR),yes)
 CFLAGS+=-DENABLE_JOYSTICK_NO_CURSOR
 endif
 

--- a/modules/redirect_av/Makefile
+++ b/modules/redirect_av/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/redirect_av
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include" $(ffmpeg_cflags)
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
@@ -20,7 +20,7 @@ LOCAL_LIB=../../bin/gcc
 #common objects
 OBJS=redirect_av.o
 
-ifeq ($(CONFIG_DARWIN), yes)
+ifeq ($(CONFIG_DARWIN),yes)
 #fixme - use proper detection of libavdevice dependencies
 LINKLIBS+=-lbz2 
 endif

--- a/modules/rtp_in/Makefile
+++ b/modules/rtp_in/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/rtp_in
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/rvc_dec/Makefile
+++ b/modules/rvc_dec/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/rvc_dec
 
 CFLAGS= $(OPTFLAGS) -I$(SRC_PATH)/include
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/saf_in/Makefile
+++ b/modules/saf_in/Makefile
@@ -5,12 +5,12 @@ vpath %.c $(SRC_PATH)/modules/saf_in
 CFLAGS= $(OPTFLAGS) -w -I"$(SRC_PATH)/include"
 
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g -DDEBUG
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/sdl_out/Makefile
+++ b/modules/sdl_out/Makefile
@@ -4,19 +4,19 @@ vpath %.c $(SRC_PATH)/modules/sdl_out
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include" $(SDL_CFLAGS)
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
 
 LINKFLAGS=-L../../bin/gcc -lgpac $(SDL_LIBS)
 
-ifeq ($(CONFIG_DARWIN), yes)
+ifeq ($(CONFIG_DARWIN),yes)
 LINKFLAGS+=-framework OpenGL
 endif
 

--- a/modules/soft_raster/Makefile
+++ b/modules/soft_raster/Makefile
@@ -4,18 +4,18 @@ vpath %.c $(SRC_PATH)/modules/soft_raster
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
 
 #big-endian config (needed for ARGB pixel format)
-ifeq ($(IS_BIGENDIAN), yes)
+ifeq ($(IS_BIGENDIAN),yes)
 CFLAGS+=-DEVG_BIG_ENDIAN
 endif
 

--- a/modules/svg_in/Makefile
+++ b/modules/svg_in/Makefile
@@ -4,21 +4,21 @@ vpath %.c $(SRC_PATH)/modules/svg_in
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
 
-ifeq ($(CONFIG_ZLIB), local)
+ifeq ($(CONFIG_ZLIB),local)
 CFLAGS+= -I"$(LOCAL_INC_PATH)/zlib"
 EXTRALIBS+=-L../../extra_lib/lib/gcc
 endif
-ifneq ($(CONFIG_ZLIB), no)
+ifneq ($(CONFIG_ZLIB),no)
 EXTRALIBS+=-lz
 endif
 

--- a/modules/timedtext/Makefile
+++ b/modules/timedtext/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/timedtext
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/ui_rec/Makefile
+++ b/modules/ui_rec/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/ui_rec
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/validator/Makefile
+++ b/modules/validator/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/validator
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include" -DGPAC_HAVE_CONFIG_H -I../..
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/vtb_decode/Makefile
+++ b/modules/vtb_decode/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/vtb_decode
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/vtt_in/Makefile
+++ b/modules/vtt_in/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/vtt_in
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/wav_out/Makefile
+++ b/modules/wav_out/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/wav_out
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include" -DDISABLE_WAVE_EX
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/widgetman/Makefile
+++ b/modules/widgetman/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/widgetman
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
@@ -20,7 +20,7 @@ LOCAL_LIB=-L../../bin/gcc
 #common objects
 OBJS=widgetman.o unzip.o widget.o wgt_load.o
 
-ifeq ($(CONFIG_ZLIB), local)
+ifeq ($(CONFIG_ZLIB),local)
 CFLAGS+=-I"$(LOCAL_INC_PATH)/zlib"
 LOCAL_LIB+= -L../../extra_lib/lib/gcc
 endif

--- a/modules/wiiis/Makefile
+++ b/modules/wiiis/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/wiiis
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif

--- a/modules/x11_out/Makefile
+++ b/modules/x11_out/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/x11_out
 
 CFLAGS= $(OPTFLAGS) -Wno-deprecated-declarations
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
@@ -17,28 +17,28 @@ endif
 CFLAGS+=-I"$(SRC_PATH)/include"
 
 
-ifeq ($(X11_INC_PATH), )
+ifeq ($(X11_INC_PATH),)
 else
 CFLAGS+=-I$(X11_INC_PATH)
 endif
 
-ifeq ($(X11_LIB_PATH), )
+ifeq ($(X11_LIB_PATH),)
 else
 EXTRALIBS+=-L$(X11_LIB_PATH)
 endif
 
-ifeq ($(USE_X11_XV), yes)
+ifeq ($(USE_X11_XV),yes)
 CFLAGS+=-DGPAC_HAS_X11_XV
 EXTRALIBS+=-lXv
 endif
 
-ifeq ($(USE_X11_SHM), yes)
+ifeq ($(USE_X11_SHM),yes)
 CFLAGS+=-DGPAC_HAS_X11_SHM
 EXTRALIBS+=-lXext
 endif
 
-ifeq ($(HAS_OPENGL), yes)
-ifeq ($(GPAC_USE_TINYGL), yes)
+ifeq ($(HAS_OPENGL),yes)
+ifeq ($(GPAC_USE_TINYGL),yes)
 else
 CFLAGS+=$(OGL_INCLS)
 EXTRALIBS+=$(OGL_LIBS)

--- a/modules/xvid_dec/Makefile
+++ b/modules/xvid_dec/Makefile
@@ -4,12 +4,12 @@ vpath %.c $(SRC_PATH)/modules/xvid_dec
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
@@ -18,7 +18,7 @@ endif
 OBJS=xvid_dec.o
 
 #local xvid lib
-ifeq ($(CONFIG_XVID), local)
+ifeq ($(CONFIG_XVID),local)
 CFLAGS+= -I"$(LOCAL_INC_PATH)"
 EXTRALIBS+= -L../../extra_lib/lib/gcc
 endif
@@ -32,8 +32,8 @@ ifeq ($(CONFIG_WIN32),yes)
 endif
 
 
-ifneq ($(prefix), /usr/local)
-ifneq ($(prefix), /usr)
+ifneq ($(prefix),/usr/local)
+ifneq ($(prefix),/usr)
 EXTRALIBS+=-L$(prefix)/$(libdir)
 endif
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -4,70 +4,70 @@ vpath %.c $(SRC_PATH)/src
 
 CFLAGS= $(OPTFLAGS) -I"$(SRC_PATH)/include"
 
-ifeq ($(DEBUGBUILD), yes)
+ifeq ($(DEBUGBUILD),yes)
 CFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-ifeq ($(GPROFBUILD), yes)
+ifeq ($(GPROFBUILD),yes)
 CFLAGS+=-pg
 LDFLAGS+=-pg
 endif
 
 ## libgpac objects gathering: src/utils
 LIBGPAC_UTILS=utils/os_divers.o utils/os_file.o utils/list.o utils/bitstream.o utils/error.o utils/alloc.o utils/url.o utils/configfile.o 
-ifeq ($(DISABLE_CORE_TOOLS), no)
+ifeq ($(DISABLE_CORE_TOOLS),no)
 LIBGPAC_UTILS+=utils/sha1.o utils/base_encoding.o utils/math.o utils/os_net.o utils/os_thread.o utils/os_config_init.o utils/cache.o utils/downloader.o utils/xml_parser.o utils/utf.o utils/token.o utils/color.o 
 endif
 
-ifeq ($(DISABLE_PLAYER), no)
+ifeq ($(DISABLE_PLAYER),no)
 LIBGPAC_UTILS+=utils/os_module.o utils/path2d.o utils/path2d_stroker.o utils/module.o utils/uni_bidi.o utils/ringbuffer.o utils/unicode.o utils/map.o 
 endif
 
 ## libgpac objects gathering: src/ietf
 LIBGPAC_IETF=
-ifeq ($(DISABLE_STREAMING), no)
+ifeq ($(DISABLE_STREAMING),no)
 LIBGPAC_IETF=ietf/rtcp.o ietf/rtp.o ietf/rtp_packetizer.o ietf/rtp_pck_3gpp.o ietf/rtp_pck_mpeg12.o ietf/rtp_pck_mpeg4.o ietf/rtsp_command.o ietf/rtsp_common.o ietf/rtsp_response.o ietf/rtsp_session.o ietf/sdp.o ietf/rtp_depacketizer.o ietf/rtp_streamer.o
 endif
 
 ## libgpac objects gathering: src/bifs
 LIBGPAC_BIFS=
-ifeq ($(DISABLE_BIFS), no)
+ifeq ($(DISABLE_BIFS),no)
 LIBGPAC_BIFS=bifs/arith_decoder.o bifs/bifs_codec.o bifs/bifs_node_tables.o bifs/com_dec.o bifs/com_enc.o bifs/conditional.o bifs/field_decode.o bifs/field_encode.o bifs/memory_decoder.o bifs/predictive_mffield.o bifs/quantize.o bifs/script_dec.o bifs/script_enc.o bifs/unquantize.o
 endif
 
 ## libgpac objects gathering: src/isomedia
 LIBGPAC_ISOM=isomedia/avc_ext.o isomedia/box_code_3gpp.o isomedia/box_code_apple.o isomedia/box_code_base.o isomedia/box_code_drm.o isomedia/box_code_meta.o isomedia/box_dump.o isomedia/box_funcs.o isomedia/data_map.o isomedia/drm_sample.o isomedia/isom_intern.o isomedia/isom_read.o isomedia/isom_store.o isomedia/isom_write.o isomedia/media.o isomedia/media_odf.o isomedia/meta.o isomedia/movie_fragments.o isomedia/sample_descs.o isomedia/stbl_read.o isomedia/stbl_write.o isomedia/track.o isomedia/tx3g.o isomedia/iff.o   
-ifeq ($(DISABLE_ISOFF_HINT), no)
+ifeq ($(DISABLE_ISOFF_HINT),no)
 LIBGPAC_ISOM+=isomedia/hint_track.o isomedia/hinting.o
 endif
-ifeq ($(DISABLE_ISOM_ADOBE), no)
+ifeq ($(DISABLE_ISOM_ADOBE),no)
 LIBGPAC_ISOM+=isomedia/box_code_adobe.o
 endif
-ifeq ($(DISABLE_TTML), no)
+ifeq ($(DISABLE_TTML),no)
 LIBGPAC_ISOM+=isomedia/ttml.o
 endif
 
 
 ## libgpac objects gathering: src/odf
 LIBGPAC_ODF=odf/desc_private.o odf/descriptors.o odf/odf_code.o odf/odf_codec.o odf/odf_command.o odf/qos.o odf/slc.o 
-ifeq ($(MINIMAL_OD), no)
+ifeq ($(MINIMAL_OD),no)
 LIBGPAC_ODF+=odf/ipmpx_code.o odf/oci_codec.o 
 
-ifeq ($(DISABLE_OD_DUMP), no)
+ifeq ($(DISABLE_OD_DUMP),no)
 LIBGPAC_ODF+=odf/ipmpx_dump.o
 endif
 
-ifeq ($(DISABLE_OD_PARSE), no)
+ifeq ($(DISABLE_OD_PARSE),no)
 LIBGPAC_ODF+=odf/ipmpx_parse.o
 endif
 
 endif
 
-ifeq ($(DISABLE_OD_DUMP), no)
+ifeq ($(DISABLE_OD_DUMP),no)
 LIBGPAC_ODF+=odf/odf_dump.o
 endif
-ifeq ($(DISABLE_OD_PARSE), no)
+ifeq ($(DISABLE_OD_PARSE),no)
 LIBGPAC_ODF+=odf/odf_parse.o
 endif
 
@@ -76,70 +76,70 @@ LIBGPAC_SCENE=scenegraph/base_scenegraph.o scenegraph/mpeg4_animators.o scenegra
 
 ## libgpac objects gathering: src/crypto
 LIBGPAC_CRYPTO=
-ifeq ($(DISABLE_CRYPTO), no)
+ifeq ($(DISABLE_CRYPTO),no)
 LIBGPAC_CRYPTO+=crypto/g_crypt.o crypto/g_crypt_openssl.o crypto/g_crypt_tinyaes.o crypto/tiny_aes.o
 endif
 
 ## libgpac objects gathering: src/media tools
 LIBGPAC_MEDIATOOLS=media_tools/isom_tools.o media_tools/dash_segmenter.o media_tools/av_parsers.o media_tools/atsc_dmx.o
 
-ifeq ($(DISABLE_AV_PARSERS), no)
+ifeq ($(DISABLE_AV_PARSERS),no)
 LIBGPAC_MEDIATOOLS+=media_tools/img.o
 endif
-ifeq ($(DISABLE_MEDIA_IMPORT), no)
+ifeq ($(DISABLE_MEDIA_IMPORT),no)
 LIBGPAC_MEDIATOOLS+=media_tools/media_import.o
 endif
-ifeq ($(DISABLE_M2TS), no)
+ifeq ($(DISABLE_M2TS),no)
 LIBGPAC_MEDIATOOLS+=media_tools/mpegts.o
 endif
-ifeq ($(DISABLE_MPD), no)
+ifeq ($(DISABLE_MPD),no)
 LIBGPAC_MEDIATOOLS+=media_tools/m3u8.o media_tools/mpd.o
 endif
-ifeq ($(DISABLE_DASH_CLIENT), no)
+ifeq ($(DISABLE_DASH_CLIENT),no)
 LIBGPAC_MEDIATOOLS+=media_tools/dash_client.o 
 endif
-ifeq ($(DISABLE_MEDIA_EXPORT), no)
+ifeq ($(DISABLE_MEDIA_EXPORT),no)
 LIBGPAC_MEDIATOOLS+=media_tools/media_export.o
 endif
-ifeq ($(DISABLE_M2TS_MUX), no)
+ifeq ($(DISABLE_M2TS_MUX),no)
 LIBGPAC_MEDIATOOLS+=media_tools/m2ts_mux.o
 endif
-ifeq ($(DISABLE_STREAMING), no)
+ifeq ($(DISABLE_STREAMING),no)
 LIBGPAC_MEDIATOOLS+=media_tools/filestreamer.o
 endif
-ifeq ($(DISABLE_DVBX), no)
+ifeq ($(DISABLE_DVBX),no)
 LIBGPAC_MEDIATOOLS+=media_tools/ait.o media_tools/dsmcc.o media_tools/dvb_mpe.o media_tools/reedsolomon.o
 endif
-ifeq ($(DISABLE_AVILIB), no)
+ifeq ($(DISABLE_AVILIB),no)
 LIBGPAC_MEDIATOOLS+=media_tools/avilib.o
 endif
-ifeq ($(DISABLE_M2PS), no)
+ifeq ($(DISABLE_M2PS),no)
 LIBGPAC_MEDIATOOLS+=media_tools/mpeg2_ps.o
 endif
-ifeq ($(DISABLE_OGG), no)
+ifeq ($(DISABLE_OGG),no)
 LIBGPAC_MEDIATOOLS+=media_tools/gpac_ogg.o
 endif
-ifeq ($(DISABLE_CRYPTO), no)
+ifeq ($(DISABLE_CRYPTO),no)
 LIBGPAC_MEDIATOOLS+=media_tools/ismacryp.o
 endif
-ifeq ($(DISABLE_ISOFF_HINT), no)
+ifeq ($(DISABLE_ISOFF_HINT),no)
 LIBGPAC_MEDIATOOLS+=media_tools/isom_hinter.o
 else
-ifeq ($(DISABLE_STREAMING), no)
+ifeq ($(DISABLE_STREAMING),no)
 LIBGPAC_MEDIATOOLS+=media_tools/isom_hinter.o
 endif
 endif
-ifeq ($(DISABLE_SAF), no)
+ifeq ($(DISABLE_SAF),no)
 LIBGPAC_MEDIATOOLS+=media_tools/saf.o
 endif
-ifeq ($(DISABLE_VOBSUB), no)
+ifeq ($(DISABLE_VOBSUB),no)
 LIBGPAC_MEDIATOOLS+=media_tools/vobsub.o
 endif
-ifeq ($(DISABLE_TTXT), no)
+ifeq ($(DISABLE_TTXT),no)
 LIBGPAC_MEDIATOOLS+=media_tools/text_import.o
 endif
 
-ifeq ($(DISABLE_PLAYER), no)
+ifeq ($(DISABLE_PLAYER),no)
 LIBGPAC_MEDIATOOLS+=media_tools/html5_media.o media_tools/html5_mse.o
 endif
 
@@ -148,37 +148,37 @@ LIBGPAC_MEDIATOOLS+=media_tools/webvtt.o
 
 ## libgpac objects gathering: src/scene_manager
 LIBGPAC_SCENEMANAGER=
-ifeq ($(DISABLE_SMGR), no)
+ifeq ($(DISABLE_SMGR),no)
 LIBGPAC_SCENEMANAGER+=scene_manager/scene_manager.o scene_manager/text_to_bifs.o
 endif
-ifeq ($(DISABLE_LOADER_BT), no)
+ifeq ($(DISABLE_LOADER_BT),no)
 LIBGPAC_SCENEMANAGER+=scene_manager/loader_bt.o
 endif
-ifeq ($(DISABLE_LOADER_XMT), no)
+ifeq ($(DISABLE_LOADER_XMT),no)
 LIBGPAC_SCENEMANAGER+=scene_manager/loader_xmt.o
 endif
-ifeq ($(DISABLE_LOADER_ISOFF), no)
+ifeq ($(DISABLE_LOADER_ISOFF),no)
 LIBGPAC_SCENEMANAGER+=scene_manager/loader_isom.o
 endif
-ifeq ($(DISABLE_LOADER_QTVR), no)
+ifeq ($(DISABLE_LOADER_QTVR),no)
 LIBGPAC_SCENEMANAGER+=scene_manager/loader_qt.o
 endif
-ifeq ($(DISABLE_SVG), no)
+ifeq ($(DISABLE_SVG),no)
 LIBGPAC_SCENEMANAGER+=scene_manager/loader_svg.o 
 endif
-ifeq ($(DISABLE_LOADER_SWF), no)
+ifeq ($(DISABLE_LOADER_SWF),no)
 LIBGPAC_SCENEMANAGER+=scene_manager/swf_parse.o scene_manager/swf_bifs.o scene_manager/swf_svg.o 
 endif
-ifeq ($(DISABLE_SCENE_DUMP), no)
+ifeq ($(DISABLE_SCENE_DUMP),no)
 LIBGPAC_SCENEMANAGER+=scene_manager/scene_dump.o
 endif
-ifeq ($(DISABLE_SCENE_STATS), no)
+ifeq ($(DISABLE_SCENE_STATS),no)
 LIBGPAC_SCENEMANAGER+=scene_manager/scene_stats.o
 endif
-ifeq ($(DISABLE_SENG), no)
+ifeq ($(DISABLE_SENG),no)
 LIBGPAC_SCENEMANAGER+=scene_manager/scene_engine.o 
 endif
-ifeq ($(DISABLE_SCENE_ENCODE), no)
+ifeq ($(DISABLE_SCENE_ENCODE),no)
 LIBGPAC_SCENEMANAGER+=scene_manager/encode_isom.o
 endif
 
@@ -188,11 +188,11 @@ LIBGPAC_TERMINAL=terminal/channel.o terminal/clock.o terminal/decoder.o terminal
 ## libgpac objects gathering: src/compositor
 LIBGPAC_COMPOSITOR=compositor/audio_input.o compositor/audio_mixer.o compositor/audio_render.o compositor/bindable.o compositor/camera.o compositor/compositor.o compositor/compositor_2d.o compositor/compositor_3d.o compositor/compositor_node_init.o compositor/drawable.o compositor/events.o compositor/font_engine.o compositor/hc_flash_shape.o compositor/hardcoded_protos.o compositor/mesh.o compositor/mesh_collide.o compositor/mesh_tesselate.o compositor/mpeg4_animstream.o compositor/mpeg4_audio.o compositor/mpeg4_background.o compositor/mpeg4_background2d.o compositor/mpeg4_bitmap.o compositor/mpeg4_composite.o compositor/mpeg4_form.o compositor/mpeg4_geometry_2d.o compositor/mpeg4_geometry_3d.o compositor/mpeg4_geometry_ifs2d.o compositor/mpeg4_geometry_ils2d.o compositor/mpeg4_gradients.o compositor/mpeg4_grouping.o compositor/mpeg4_grouping_2d.o compositor/mpeg4_grouping_3d.o compositor/mpeg4_layer_2d.o compositor/mpeg4_layer_3d.o compositor/mpeg4_layout.o compositor/mpeg4_lighting.o compositor/mpeg4_path_layout.o compositor/mpeg4_sensors.o compositor/mpeg4_sound.o compositor/mpeg4_text.o compositor/mpeg4_textures.o compositor/mpeg4_timesensor.o compositor/mpeg4_viewport.o compositor/navigate.o compositor/offscreen_cache.o compositor/svg_base.o compositor/svg_filters.o compositor/svg_font.o compositor/svg_geometry.o compositor/svg_grouping.o compositor/svg_media.o compositor/svg_paint_servers.o compositor/svg_text.o compositor/texturing.o compositor/texturing_gl.o compositor/visual_manager.o compositor/visual_manager_2d.o compositor/visual_manager_2d_draw.o compositor/visual_manager_3d.o compositor/visual_manager_3d_gl.o compositor/x3d_geometry.o
 
-ifeq ($(DISABLE_PLAYER), yes)
+ifeq ($(DISABLE_PLAYER),yes)
 LIBGPAC_COMPOSITOR=
 LIBGPAC_TERMINAL=
 endif
-ifeq ($(DISABLE_SCENEGRAPH), yes)
+ifeq ($(DISABLE_SCENEGRAPH),yes)
 LIBGPAC_SCENE=
 endif
 
@@ -200,7 +200,7 @@ endif
 
 ## libgpac objects gathering: src/laser
 LIBGPAC_LASER=
-ifeq ($(DISABLE_LASER), no)
+ifeq ($(DISABLE_LASER),no)
 LIBGPAC_LASER=laser/lsr_enc.o laser/lsr_dec.o laser/lsr_tables.o
 endif
 
@@ -227,11 +227,11 @@ EXTRALIBS+=$(GPAC_SH_FLAGS)
 endif
 
 LD_SONAME="-Wl,-soname,libgpac.so.$(VERSION_MAJOR)"
-ifeq ($(CONFIG_DARWIN), yes)
+ifeq ($(CONFIG_DARWIN),yes)
 LD_SONAME=
 endif
 
-ifeq ($(CONFIG_SUNOS), yes)
+ifeq ($(CONFIG_SUNOS),yes)
 LD_SONAME="-Wl,-h,$(LIB)"
 EXTRALIBS+= -lrt
 endif
@@ -288,7 +288,7 @@ endif
 
 endif
 
-ifeq ($(shell fgrep "Libs.private:" ../gpac.pc 1>&2 2> /dev/null ; echo $$?), 1)
+ifeq ($(shell fgrep "Libs.private:" ../gpac.pc 1>&2 2> /dev/null ; echo $$?),1)
 	@echo "Libs.private: -lgpac_static $(EXTRALIBS)" >> ../gpac.pc
 endif
 

--- a/static.mak
+++ b/static.mak
@@ -2,19 +2,19 @@
 NEED_LOCAL_LIB="no"
 LINKLIBS=
 
-ifeq ($(DISABLE_CORE_TOOLS), no)
+ifeq ($(DISABLE_CORE_TOOLS),no)
 
 #1 - zlib support
-ifeq ($(CONFIG_ZLIB), local)
+ifeq ($(CONFIG_ZLIB),local)
 CFLAGS+= -I"$(LOCAL_INC_PATH)/zlib"
 NEED_LOCAL_LIB="yes"
 endif
-ifneq ($(CONFIG_ZLIB), no)
+ifneq ($(CONFIG_ZLIB),no)
 LINKLIBS+=-lz
 endif
 
 #2 - ssl support
-ifeq ($(HAS_OPENSSL), yes)
+ifeq ($(HAS_OPENSSL),yes)
 LINKLIBS+=$(SSL_LIBS)
 endif
 
@@ -31,11 +31,11 @@ endif
 endif
 
 #4 - JPEG support
-ifeq ($(CONFIG_JPEG), no)
+ifeq ($(CONFIG_JPEG),no)
 else
 LINKLIBS+= -ljpeg
 #local lib
-ifeq ($(CONFIG_JPEG), local)
+ifeq ($(CONFIG_JPEG),local)
 NEED_LOCAL_LIB="yes"
 MEDIATOOLS_CFLAGS+=-I"$(LOCAL_INC_PATH)/jpeg"
 endif
@@ -43,10 +43,10 @@ endif
 
 
 #5 - PNG support
-ifeq ($(CONFIG_PNG), no)
+ifeq ($(CONFIG_PNG),no)
 else
 LINKLIBS+= -lpng
-ifeq ($(CONFIG_PNG), local)
+ifeq ($(CONFIG_PNG),local)
 NEED_LOCAL_LIB="yes"
 MEDIATOOLS_CFLAGS+=-I"$(LOCAL_INC_PATH)/png"
 endif
@@ -57,8 +57,8 @@ endif
 COMPOSITOR_CFLAGS=
 
 ## Add prefix before every lib
-ifneq ($(prefix), /usr/local)
-ifneq ($(prefix), /usr)
+ifneq ($(prefix),/usr/local)
+ifneq ($(prefix),/usr)
 EXTRALIBS+=-L$(prefix)/lib
 endif
 endif
@@ -69,30 +69,30 @@ EXTRALIBS+= $(OGL_LIBS)
 COMPOSITOR_CFLAGS+=$(OGL_INCLS)
 endif
 
-ifeq ($(NEED_LOCAL_LIB), "yes")
+ifeq ($(NEED_LOCAL_LIB),yes)
 EXTRALIBS+=-L../extra_lib/lib/gcc
 endif
 
 EXTRALIBS+=$(LINKLIBS)
 
-ifeq ($(GPAC_USE_TINYGL), yes)
+ifeq ($(GPAC_USE_TINYGL),yes)
 COMPOSITOR_CFLAGS+=-I"$(SRC_PATH)/../TinyGL/include"
 else
 COMPOSITOR_CFLAGS+=-DGPAC_HAS_GLU
 endif
 
-ifeq ($(ENABLE_JOYSTICK), yes)
+ifeq ($(ENABLE_JOYSTICK),yes)
 COMPOSITOR_CFLAGS+=-DENABLE_JOYSTICK
 endif
 
 
 ## libgpac media tools compilation options
-ifeq ($(GPACREADONLY), yes)
+ifeq ($(GPACREADONLY),yes)
 MEDIATOOLS_CFLAGS=-DGPAC_READ_ONLY
 endif
 
 
-ifeq ($(GPAC_ENST), yes)
+ifeq ($(GPAC_ENST),yes)
 OBJS+=$(LIBGPAC_ENST)
 EXTRALIBS+=-liconv
 MEDIATOOLS_CFLAGS+=-DGPAC_ENST_PRIVATE
@@ -105,19 +105,19 @@ endif
 ## static modules
 
 # configure static modules
-ifeq ($(STATIC_MODULES), yes)
+ifeq ($(STATIC_MODULES),yes)
 
 CFLAGS+= -DGPAC_STATIC_MODULES
 
 OBJS+=../modules/aac_in/aac_in.o
-ifneq ($(CONFIG_FAAD), no)
+ifneq ($(CONFIG_FAAD),no)
 OBJS+=../modules/aac_in/faad_dec.o
 CFLAGS+=-DGPAC_HAS_FAAD
 EXTRALIBS+= -lfaad
 endif
 
 OBJS+=../modules/ac3_in/ac3_in.o
-ifneq ($(CONFIG_A52), no)
+ifneq ($(CONFIG_A52),no)
 OBJS+=../modules/ac3_in/liba52_dec.o
 CFLAGS+=-DGPAC_HAS_LIBA52
 EXTRALIBS+= -la52
@@ -126,7 +126,7 @@ endif
 OBJS+=../modules/amr_dec/amr_in.o
 CFLAGS+=-DGPAC_AMR_IN_STANDALONE
 
-ifeq ($(CONFIG_ALSA), yes)
+ifeq ($(CONFIG_ALSA),yes)
 OBJS+=../modules/alsa/alsa.o
 CFLAGS+=-DGPAC_HAS_ALSA
 EXTRALIBS+= -lasound
@@ -135,24 +135,24 @@ endif
 OBJS+=../modules/audio_filter/audio_filter.o
 OBJS+=../modules/bifs_dec/bifs_dec.o
 
-ifeq ($(DISABLE_SMGR), no)
+ifeq ($(DISABLE_SMGR),no)
 OBJS+=../modules/ctx_load/ctx_load.o
 OBJS+=../modules/svg_in/svg_in.o
 endif
 
 OBJS+=../modules/dummy_in/dummy_in.o
 OBJS+=../modules/ismacryp/isma_ea.o
-ifneq ($(CONFIG_JS), no)
+ifneq ($(CONFIG_JS),no)
 CFLAGS+=$(JS_FLAGS)
 OBJS+=../modules/gpac_js/gpac_js.o
 endif
-ifeq ($(DISABLE_SVG), no)
+ifeq ($(DISABLE_SVG),no)
 OBJS+=../modules/laser_dec/laser_dec.o
 endif
 OBJS+=../modules/soft_raster/ftgrays.o ../modules/soft_raster/raster_load.o ../modules/soft_raster/raster_565.o ../modules/soft_raster/raster_argb.o ../modules/soft_raster/raster_rgb.o ../modules/soft_raster/stencil.o ../modules/soft_raster/surface.o
 
 OBJS+=../modules/mp3_in/mp3_in.o
-ifneq ($(CONFIG_MAD), no)
+ifneq ($(CONFIG_MAD),no)
 OBJS+=../modules/mp3_in/mad_dec.o
 CFLAGS+=-DGPAC_HAS_MAD
 EXTRALIBS+= -lmad
@@ -161,7 +161,7 @@ OBJS+=../modules/isom_in/load.o ../modules/isom_in/read.o ../modules/isom_in/rea
 OBJS+=../modules/odf_dec/odf_dec.o
 OBJS+=../modules/rtp_in/rtp_in.o ../modules/rtp_in/rtp_session.o ../modules/rtp_in/rtp_signaling.o ../modules/rtp_in/rtp_stream.o ../modules/rtp_in/sdp_fetch.o ../modules/rtp_in/sdp_load.o
 OBJS+=../modules/saf_in/saf_in.o
-ifeq ($(DISABLE_DASH_CLIENT), no)
+ifeq ($(DISABLE_DASH_CLIENT),no)
 OBJS+=../modules/mpd_in/mpd_in.o
 ifneq ($(CONFIG_JS),no)
 OBJS+=../modules/mse_in/mse_in.o
@@ -170,33 +170,33 @@ endif
 OBJS+=../modules/timedtext/timedtext_dec.o ../modules/timedtext/timedtext_in.o
 OBJS+=../modules/validator/validator.o
 OBJS+=../modules/raw_out/raw_video.o
-ifeq ($(DISABLE_TTXT), no)
+ifeq ($(DISABLE_TTXT),no)
 OBJS+=../modules/vtt_in/vtt_in.o ../modules/vtt_in/vtt_dec.o
 endif
 
 OBJS+=../modules/img_in/img_dec.o ../modules/img_in/img_in.o ../modules/img_in/bmp_dec.o ../modules/img_in/png_dec.o ../modules/img_in/jpeg_dec.o
-ifneq ($(CONFIG_JP2), no)
+ifneq ($(CONFIG_JP2),no)
 OBJS+=../modules/img_in/jp2_dec.o
 EXTRALIBS+= -lopenjpeg -lm
 CFLAGS+=-DGPAC_HAS_JP2
 endif
 
-ifneq ($(CONFIG_FT), no)
+ifneq ($(CONFIG_FT),no)
 OBJS+=../modules/ft_font/ft_font.o
 EXTRALIBS+= $(FT_LIBS)
 CFLAGS+=-DGPAC_HAS_FREETYPE $(FT_CFLAGS)
 endif
 
-ifeq ($(DISABLE_MEDIA_IMPORT), no)
+ifeq ($(DISABLE_MEDIA_IMPORT),no)
 OBJS+=../modules/mpegts_in/mpegts_in.o
 endif
 
-ifeq ($(DISABLE_LOADER_BT), no)
+ifeq ($(DISABLE_LOADER_BT),no)
 OBJS+=../modules/osd/osd.o
 endif
 
 #cf comment for openHEVC - we cannot build ffmpeg and openhevc as static modules for the current time :(
-ifneq ($(CONFIG_FFMPEG), no)
+ifneq ($(CONFIG_FFMPEG),no)
 OBJS+=../modules/ffmpeg_in/ffmpeg_decode.o ../modules/ffmpeg_in/ffmpeg_demux.o ../modules/ffmpeg_in/ffmpeg_load.o
 CFLAGS+=-DGPAC_HAS_FFMPEG -Wno-deprecated-declarations -I"$(SRC_PATH)/include" $(ffmpeg_cflags)
 EXTRALIBS+= $(ffmpeg_lflags)
@@ -204,21 +204,21 @@ EXTRALIBS+= $(ffmpeg_lflags)
 #OBJS+=../modules/redirect_av/redirect_av.o
 endif
 
-ifneq ($(CONFIG_XVID), no)
+ifneq ($(CONFIG_XVID),no)
 OBJS+=../modules/xvid_dec/xvid_dec.o
 CFLAGS+=-DGPAC_HAS_XVID
 EXTRALIBS+= -lxvidcore
 endif
 
-ifneq ($(CONFIG_OGG), no)
+ifneq ($(CONFIG_OGG),no)
 OBJS+=../modules/ogg/ogg_load.o ../modules/ogg/ogg_in.o ../modules/ogg/theora_dec.o ../modules/ogg/vorbis_dec.o
 CFLAGS+=-DGPAC_HAS_OGG
 EXTRALIBS+= -logg
-ifneq ($(CONFIG_VORBIS), no)
+ifneq ($(CONFIG_VORBIS),no)
 CFLAGS+=-DGPAC_HAS_VORBIS
 EXTRALIBS+= -lvorbis
 endif
-ifneq ($(CONFIG_THEORA), no)
+ifneq ($(CONFIG_THEORA),no)
 CFLAGS+=-DGPAC_HAS_THEORA
 EXTRALIBS+= -ltheora
 endif
@@ -226,14 +226,14 @@ endif
 endif
 
 
-ifeq ($(CONFIG_SDL), yes)
+ifeq ($(CONFIG_SDL),yes)
 CFLAGS+=-DGPAC_HAS_SDL $(SDL_CFLAGS)
 EXTRALIBS+= $(SDL_LIBS)
 OBJS+=../modules/sdl_out/sdl_out.o ../modules/sdl_out/audio.o ../modules/sdl_out/video.o
 endif
 
 
-ifeq ($(DISABLE_SVG), no)
+ifeq ($(DISABLE_SVG),no)
 OBJS+=../modules/widgetman/widgetman.o ../modules/widgetman/unzip.o ../modules/widgetman/widget.o ../modules/widgetman/wgt_load.o
 endif
 
@@ -245,7 +245,7 @@ endif
 
 #cannot include openhevc and ffmpeg (yet) here since it uses avcodec_* calls which are relocated to libavcodec.so ...
 ifeq ($(CONFIG_OPENHEVC),yes)
-ifeq ($(CONFIG_FFMPEG), no)
+ifeq ($(CONFIG_FFMPEG),no)
 OBJS+= ../modules/openhevc_dec/openhevc_dec.o
 CFLAGS+=-DGPAC_HAS_OPENHEVC $(OHEVC_CFLAGS)
 EXTRALIBS+=$(OHEVC_LDFLAGS)
@@ -255,31 +255,31 @@ endif
 ifeq ($(CONFIG_X11),yes)
 OBJS+= ../modules/x11_out/x11_out.o
 CFLAGS+=-DGPAC_HAS_X11
-ifneq ($(X11_INC_PATH), )
+ifneq ($(X11_INC_PATH),)
 CFLAGS+=-I$(X11_INC_PATH)
 endif
 
-ifneq ($(X11_LIB_PATH), )
+ifneq ($(X11_LIB_PATH),)
 EXTRALIBS+=-L$(X11_LIB_PATH)
 endif
 EXTRALIBS+=-lX11
 
-ifeq ($(USE_X11_XV), yes)
+ifeq ($(USE_X11_XV),yes)
 CFLAGS+=-DGPAC_HAS_X11_XV
 EXTRALIBS+=-lXv
 endif
 
-ifeq ($(USE_X11_XV), yes)
+ifeq ($(USE_X11_XV),yes)
 CFLAGS+=-DGPAC_HAS_X11_XV
 EXTRALIBS+=-lXv
 endif
 
-ifeq ($(USE_X11_SHM), yes)
+ifeq ($(USE_X11_SHM),yes)
 CFLAGS+=-DGPAC_HAS_X11_SHM
 EXTRALIBS+=-lXext
 endif
 
-ifeq ($(HAS_OPENGL), yes)
+ifeq ($(HAS_OPENGL),yes)
 ifeq ($(CONFIG_DARWIN),yes)
 EXTRALIBS+=-lGL -lGLU
 endif
@@ -289,27 +289,27 @@ endif
 endif
 
 
-ifeq ($(CONFIG_JACK), yes)
+ifeq ($(CONFIG_JACK),yes)
 OBJS+= ../modules/jack/jack.o
 CFLAGS+=-DGPAC_HAS_JACK
 EXTRALIBS+=-ljack
 endif
 
-ifneq ($(CONFIG_OSS_AUDIO), no)
+ifneq ($(CONFIG_OSS_AUDIO),no)
 OBJS+= ../modules/oss_audio/oss.o
 CFLAGS+=-DGPAC_HAS_OSS $(OSS_CFLAGS)
 EXTRALIBS+=$(OSS_LDFLAGS)
-ifneq ($(OSS_INC_TYPE), yes)
+ifneq ($(OSS_INC_TYPE),yes)
 CFLAGS+=-DOSS_FIX_INC
 endif
-ifeq ($(TARGET_ARCH_ARMV4L), yes)
+ifeq ($(TARGET_ARCH_ARMV4L),yes)
 CFLAGS+=-DFORCE_SR_LIMIT
 endif
 
 endif
 
 
-ifeq ($(CONFIG_PULSEAUDIO), yes)
+ifeq ($(CONFIG_PULSEAUDIO),yes)
 OBJS+= ../modules/pulseaudio/pulseaudio.o
 CFLAGS+=-DGPAC_HAS_PULSEAUDIO
 EXTRALIBS+=-lpulse -lpulse-simple
@@ -330,7 +330,7 @@ endif
 ifeq ($(CONFIG_DIRECTX),yes)
 OBJS+= ../modules/dx_hw/dx_audio.o ../modules/dx_hw/dx_video.o ../modules/dx_hw/dx_window.o ../modules/dx_hw/dx_2d.o ../modules/dx_hw/copy_pixels.o
 CFLAGS+=-DGPAC_HAS_DIRECTX -DDIRECTSOUND_VERSION=0x0500
-ifneq ($(DX_PATH), system)
+ifneq ($(DX_PATH),system)
 EXTRALIBS+=-L$(DX_PATH)/lib
 CFLAGS+= -I$(DX_PATH)/include
 endif
@@ -338,10 +338,10 @@ EXTRALIBS+=-ldsound -ldxguid -lddraw -lole32 -lgdi32 -lopengl32
 endif
 
 
-ifneq ($(CONFIG_FREENECT), no)
+ifneq ($(CONFIG_FREENECT),no)
 OBJS+= ../modules/freenect/freenect.o
 CFLAGS+=-DGPAC_HAS_FREENECT $(FREENECT_CFLAGS)
-ifeq ($(CONFIG_FREENECT), local)
+ifeq ($(CONFIG_FREENECT),local)
 CFLAGS+= -I"$(LOCAL_INC_PATH)"
 EXTRALIBS+=-L../../extra_lib/lib/gcc
 endif


### PR DESCRIPTION
make (or at least some implementations of it, such as GNU make 4.3) take
the space as a part of the expression following the comma, resulting in
a matching of variables against things like "[space]/usr", "[space]yes"
etc.

Fixes a part of https://github.com/gpac/gpac/issues/1417