### PR TITLE
use -p=0 by default for MP4Box

### DIFF
--- a/applications/mp4box/main.c
+++ b/applications/mp4box/main.c
@@ -4167,7 +4167,7 @@ Bool mp4box_parse_args(int argc, char **argv)
 int mp4boxMain(int argc, char **argv)
 {
 	u32 i, j;
-	const char *gpac_profile = NULL;
+	const char *gpac_profile = "0";
 	GF_Err e = GF_OK;
 	nb_tsel_acts = nb_add = nb_cat = nb_track_act = nb_sdp_ex = max_ptime = nb_meta_act = rtp_rate = major_brand = nb_alt_brand_add = nb_alt_brand_rem = car_dur = minor_version = 0;
 

--- a/src/utils/os_config_init.c
+++ b/src/utils/os_config_init.c
@@ -771,7 +771,7 @@ static GF_Config *gf_cfg_init(const char *profile)
 	char szPath[GF_MAX_PATH];
 
 	if (profile && !strlen(profile))
-		profile = "0";
+		profile = NULL;
 
 	if (profile && (strchr(profile, '/') || strchr(profile, '\\')) ) {
 		if (!gf_file_exists(profile)) {


### PR DESCRIPTION
[doing this as a PR to be sure we all agree with the change]

In order to get closer behavior between filters and master for MP4Box, this change makes `-p=0` (i.e.: don't use a config file on disk) the default **for MP4Box only** 

I also changed the meaning of `-p=` (empty string) to the previous default (i.e.: write GPAC.cfg in the default dir, not in profiles dir) (`-p=` (empty) used to be synonymous with `-p=0` but undocumented) 


