### PR TITLE
memtracker: add hex dump and remove unprintable chars

### DIFF
--- a/src/utils/alloc.c
+++ b/src/utils/alloc.c
@@ -841,7 +841,7 @@ void gf_memory_print()
 		assert(!gpac_allocations_lock);
 		gf_memory_log(GF_MEMORY_INFO, "[MemTracker] gf_memory_print(): the memory tracker is not initialized, some file handles are not closed.\n");
 	} else {
-		int i=0, j;
+		int i=0;
 		assert(gpac_allocations_lock);
 		const char *enum_open_handles(u32 *idx);
 		u32 nb_handles = gf_file_handles_count();
@@ -856,11 +856,11 @@ void gf_memory_print()
 			while (curr_element) {
 				char szVal[51];
 				char szHexVal[101];
-				u32 size;
+				u32 size, j;
 				next_element = curr_element->next;
 				size = curr_element->size>=50 ? 50 : curr_element->size;
 				for (j=0 ; j<size ; j++) {
-					unsigned char byte = *(unsigned char*)(curr_element->ptr + j);
+					unsigned char byte = *((unsigned char*)(curr_element->ptr) + j);
 					szVal[j] = (byte > 31 && byte < 127) ? byte : '.';
 					sprintf(szHexVal+2*j, "%02X", byte);
 				}

--- a/src/utils/alloc.c
+++ b/src/utils/alloc.c
@@ -841,7 +841,7 @@ void gf_memory_print()
 		assert(!gpac_allocations_lock);
 		gf_memory_log(GF_MEMORY_INFO, "[MemTracker] gf_memory_print(): the memory tracker is not initialized, some file handles are not closed.\n");
 	} else {
-		int i=0;
+		int i=0, j;
 		assert(gpac_allocations_lock);
 		const char *enum_open_handles(u32 *idx);
 		u32 nb_handles = gf_file_handles_count();
@@ -855,14 +855,21 @@ void gf_memory_print()
 			memory_element *curr_element = memory_add[i], *next_element;
 			while (curr_element) {
 				char szVal[51];
+				char szHexVal[101];
 				u32 size;
 				next_element = curr_element->next;
 				size = curr_element->size>=50 ? 50 : curr_element->size;
-				memcpy(szVal, curr_element->ptr, sizeof(char)*size);
+				for (j=0 ; j<size ; j++) {
+					unsigned char byte = *(unsigned char*)(curr_element->ptr + j);
+					szVal[j] = (byte > 31 && byte < 127) ? byte : '.';
+					sprintf(szHexVal+2*j, "%02X", byte);
+				}
 				szVal[size] = 0;
+				szHexVal[2*size] = 0;
 				gf_memory_log(GF_MEMORY_INFO, "[MemTracker] Memory Block %p (size %d) allocated in:\n", curr_element->ptr, curr_element->size);
 				log_backtrace(GF_MEMORY_INFO, curr_element);
 				gf_memory_log(GF_MEMORY_INFO, "             string dump: %s\n", szVal);
+				gf_memory_log(GF_MEMORY_INFO, "             hex dump: %s\n", szHexVal);
 				curr_element = next_element;
 			}
 		}


### PR DESCRIPTION
hey all, 

doing this as a PR since it's just one possibility

currently when the mem tracker detects a leak it will dump the leaked object as a string, which will very probably include non printable characters

this poses some problems with terminals and also with our tests results interface (python refuses to display logs that are not proper utf-8)

the solution I chose here is to replace non-printable characters with dots and to add a hex dump

before: 

```
[MemTracker] Printing the current state of allocations (0 open file handles) :
[MemTracker] Memory Block 0x558f450779a0 (size 32) allocated in:
file isomedia/drm_sample.c at line 1130
             string dump: 
avˈ
ȼf
[MemTracker] Memory Block 0x558f45077af0 (size 8) allocated in:
file isomedia/drm_sample.c at line 1139
             string dump: [MemTracker] Memory Block 0x558f45085220 (size 32) allocated in:
file isomedia/drm_sample.c at line 1130
             string dump: 1&@
[MemTracker] Memory Block 0x558f45085270 (size 8) allocated in:
file isomedia/drm_sample.c at line 1139
             string dump: 
[MemTracker] Total: 80 bytes allocated in 4 blocks
```

after

```
[MemTracker] Printing the current state of allocations (0 open file handles) :
[MemTracker] Memory Block 0x56210041f9a0 (size 32) allocated in:
file isomedia/drm_sample.c at line 1130
             string dump: ..a.v........f.9..........A.!V..
             hex dump: 100A610676CB88F302D10AC8BC66E039ED00010000000000F0FA410021560000
[MemTracker] Memory Block 0x56210041faf0 (size 8) allocated in:
file isomedia/drm_sample.c at line 1139
             string dump: .... ...
             hex dump: C901000020000000
[MemTracker] Memory Block 0x56210042d220 (size 32) allocated in:
file isomedia/drm_sample.c at line 1130
             string dump: .1.Q...../&@............p.B.!V..
             hex dump: 1031A8518DC7F719BB2F2640D1D4D6C8130001000000000070D2420021560000
[MemTracker] Memory Block 0x56210042d270 (size 8) allocated in:
file isomedia/drm_sample.c at line 1139
             string dump: ........
             hex dump: 11000000C00C0000
[MemTracker] Total: 80 bytes allocated in 4 blocks
```

Obviously there are a lot of other possibilities about what to display and how to convert so I'm not committed to this specific solution but I think the idea of only producing printable logs is valid. 

