### PR TITLE
Dolby vision

### DIFF
--- a/include/gpac/constants.h
+++ b/include/gpac/constants.h
@@ -642,7 +642,12 @@ enum
 	/*! SVC slice*/
 	GF_AVC_NALU_SVC_SLICE = 20,
 	/*! View and dependency representation delimiter */
-	GF_AVC_NALU_VDRD = 24
+	GF_AVC_NALU_VDRD = 24,
+
+	/*! Dolby Vision RPU */
+	GF_AVC_NALU_DV_RPU = 28,
+	/*! Dolby Vision EL */
+	GF_AVC_NALU_DV_EL = 30
 };
 
 
@@ -736,6 +741,11 @@ enum
 	GF_HEVC_NALU_SEI_PREFIX = 39,
 	/*! suffix SEI message*/
 	GF_HEVC_NALU_SEI_SUFFIX = 40,
+
+	/*! Dolby Vision RPU */
+	GF_HEVC_NALU_DV_RPU = 62,
+	/*! Dolby Vision EL */
+	GF_HEVC_NALU_DV_EL = 63
 };
 
 

--- a/include/gpac/internal/isomedia_dev.h
+++ b/include/gpac/internal/isomedia_dev.h
@@ -1347,17 +1347,6 @@ typedef struct {
 } GF_VPContentLightLevelBox;
 
 typedef struct {
-	u8 dv_version_major;
-	u8 dv_version_minor;
-	u8 dv_profile; //7 bits
-	u8 dv_level;   //6 bits
-	Bool rpu_present_flag;
-	Bool el_present_flag;
-	Bool bl_present_flag;
-	//const unsigned int (32)[5] reserved = 0;
-} GF_DOVIDecoderConfigurationRecord;
-
-typedef struct {
 	GF_ISOM_BOX
 	GF_DOVIDecoderConfigurationRecord DOVIConfig;
 } GF_DOVIConfigurationBox;
@@ -1396,6 +1385,8 @@ typedef struct
 	GF_AV1ConfigurationBox *av1_config;
 	/*vp8-9 extension*/
 	GF_VPConfigurationBox *vp_config;
+	/*dolbyvision extension*/
+	GF_DOVIConfigurationBox *dovi_config;
 
 
 	/*ext descriptors*/

--- a/include/gpac/internal/media_dev.h
+++ b/include/gpac/internal/media_dev.h
@@ -224,6 +224,11 @@ typedef struct
 
 typedef struct
 {
+	Bool rpu_flag;
+} AVCSeiItuTT35DolbyVision;
+
+typedef struct
+{
 	AVCSeiRecoveryPoint recovery_point;
 	AVCSeiPicTiming pic_timing;
 	/*to be eventually completed by other sei*/
@@ -429,7 +434,7 @@ typedef struct
 {
 	AVCSeiRecoveryPoint recovery_point;
 	AVCSeiPicTiming pic_timing;
-
+	AVCSeiItuTT35DolbyVision dovi;
 } HEVC_SEI;
 
 typedef struct
@@ -499,6 +504,8 @@ void gf_media_hevc_parse_ps(GF_HEVCConfig* hevccfg, HEVCState* hevc, u32 nal_typ
 
 GF_Err gf_hevc_get_sps_info_with_state(HEVCState *hevc_state, char *sps_data, u32 sps_size, u32 *sps_id, u32 *width, u32 *height, s32 *par_n, s32 *par_d);
 
+/*parses HEVC SEI and fill state accordingly*/
+void gf_media_hevc_parse_sei(char* buffer, u32 nal_size, HEVCState *hevc);
 
 
 GF_Err gf_media_parse_ivf_file_header(GF_BitStream *bs, int *width, int *height, u32 *codec_fourcc, u32 *frame_rate, u32 *time_scale, u32 *num_frames);

--- a/include/gpac/internal/media_dev.h
+++ b/include/gpac/internal/media_dev.h
@@ -483,6 +483,10 @@ typedef struct _hevc_state
 	s32 last_parsed_vps_id;
 	s32 last_parsed_sps_id;
 	s32 last_parsed_pps_id;
+
+	// Dolby Vision
+	Bool dv_rpu;
+	Bool dv_el;
 } HEVCState;
 
 enum

--- a/include/gpac/isomedia.h
+++ b/include/gpac/isomedia.h
@@ -322,6 +322,9 @@ enum
 	GF_ISOM_SUBTYPE_VP08 = GF_4CC('v', 'p', '0', '8'),
 	GF_ISOM_SUBTYPE_VP09 = GF_4CC('v', 'p', '0', '9'),
 
+	/* Dolby Vision */
+	GF_ISOM_SUBTYPE_DVHE = GF_4CC('d', 'v', 'h', 'e'),
+
 	/*3GPP(2) extension subtypes*/
 	GF_ISOM_SUBTYPE_3GP_H263	= GF_4CC( 's', '2', '6', '3' ),
 	GF_ISOM_SUBTYPE_3GP_AMR		= GF_4CC( 's', 'a', 'm', 'r' ),
@@ -2068,6 +2071,9 @@ GF_AV1Config *gf_isom_av1_config_get(GF_ISOFile *the_file, u32 trackNumber, u32 
 
 /*gets VP config - user is responsible for deleting it*/
 GF_VPConfig *gf_isom_vp_config_get(GF_ISOFile *the_file, u32 trackNumber, u32 DescriptionIndex);
+
+/*gets DOVI config - user is responsible for deleting it*/
+GF_DOVIDecoderConfigurationRecord* gf_isom_dovi_config_get(GF_ISOFile* the_file, u32 trackNumber, u32 DescriptionIndex);
 
 /*return true if track dependencies implying extractors or implicit reconstruction are found*/
 Bool gf_isom_needs_layer_reconstruction(GF_ISOFile *file);

--- a/include/gpac/mpeg4_odf.h
+++ b/include/gpac/mpeg4_odf.h
@@ -1046,6 +1046,19 @@ typedef struct
 	int RefFrameHeight[VP9_NUM_REF_FRAMES];
 } GF_VPConfig;
 
+
+/*! DolbyVision config dvcC */
+typedef struct {
+	u8 dv_version_major;
+	u8 dv_version_minor;
+	u8 dv_profile; //7 bits
+	u8 dv_level;   //6 bits
+	Bool rpu_present_flag;
+	Bool el_present_flag;
+	Bool bl_present_flag;
+	//const unsigned int (32)[5] reserved = 0;
+} GF_DOVIDecoderConfigurationRecord;
+
 /*! Media Segment Descriptor used for Media Control Extensions*/
 typedef struct
 {

--- a/src/isomedia/avc_ext.c
+++ b/src/isomedia/avc_ext.c
@@ -1292,6 +1292,23 @@ void AV1_RewriteESDescriptor(GF_MPEGVisualSampleEntryBox *av1)
 }
 
 
+static GF_DOVIDecoderConfigurationRecord* DOVI_DuplicateConfig(GF_DOVIDecoderConfigurationRecord *cfg)
+{
+	GF_DOVIDecoderConfigurationRecord* out = NULL;
+	GF_SAFEALLOC(out, GF_DOVIDecoderConfigurationRecord);
+	if (!out) return NULL;
+
+	out->dv_version_major = cfg->dv_version_major;
+	out->dv_version_minor = cfg->dv_version_minor;
+	out->dv_profile = cfg->dv_profile;
+	out->dv_level = cfg->dv_level;
+	out->rpu_present_flag = cfg->rpu_present_flag;
+	out->el_present_flag = cfg->el_present_flag;
+	out->bl_present_flag = cfg->bl_present_flag;
+
+	return out;
+}
+
 
 static GF_VPConfig* VP_DuplicateConfig(GF_VPConfig const * const cfg)
 {
@@ -2219,6 +2236,17 @@ GF_HEVCConfig *gf_isom_lhvc_config_get(GF_ISOFile *the_file, u32 trackNumber, u3
 	return lhvc;
 }
 
+GF_EXPORT
+GF_DOVIDecoderConfigurationRecord *gf_isom_dovi_config_get(GF_ISOFile* the_file, u32 trackNumber, u32 DescriptionIndex)
+{
+	GF_TrackBox* trak;
+	GF_MPEGVisualSampleEntryBox *entry;
+	trak = gf_isom_get_track_from_file(the_file, trackNumber);
+	if (!trak || !trak->Media || !DescriptionIndex) return NULL;
+	entry = (GF_MPEGVisualSampleEntryBox*)gf_list_get(trak->Media->information->sampleTable->SampleDescription->other_boxes, DescriptionIndex - 1);
+	if (!entry || !entry->dovi_config) return NULL;
+	return DOVI_DuplicateConfig(&entry->dovi_config->DOVIConfig);
+}
 
 void btrt_del(GF_Box *s)
 {

--- a/src/isomedia/box_code_base.c
+++ b/src/isomedia/box_code_base.c
@@ -4327,6 +4327,7 @@ void video_sample_entry_del(GF_Box *s)
 	if (ptr->lhvc_config) gf_isom_box_del((GF_Box *) ptr->lhvc_config);
 	if (ptr->av1_config) gf_isom_box_del((GF_Box *)ptr->av1_config);
 	if (ptr->vp_config) gf_isom_box_del((GF_Box *)ptr->vp_config);
+	if (ptr->dovi_config) gf_isom_box_del((GF_Box*)ptr->dovi_config);
 	if (ptr->cfg_3gpp) gf_isom_box_del((GF_Box *)ptr->cfg_3gpp);
 
 	if (ptr->descr) gf_isom_box_del((GF_Box *) ptr->descr);
@@ -4388,6 +4389,10 @@ GF_Err video_sample_entry_AddBox(GF_Box *s, GF_Box *a)
 	case GF_ISOM_BOX_TYPE_VPCC:
 		if (ptr->vp_config) ERROR_ON_DUPLICATED_BOX(a, ptr)
 			ptr->vp_config = (GF_VPConfigurationBox *)a;
+		break;
+	case GF_ISOM_BOX_TYPE_DVCC:
+		if (ptr->dovi_config) ERROR_ON_DUPLICATED_BOX(a, ptr)
+			ptr->dovi_config = (GF_DOVIConfigurationBox*)a;
 		break;
 	case GF_ISOM_BOX_TYPE_M4DS:
 		if (ptr->descr) ERROR_ON_DUPLICATED_BOX(a, ptr)
@@ -4533,6 +4538,10 @@ GF_Err video_sample_entry_Write(GF_Box *s, GF_BitStream *bs)
 			e = gf_isom_box_write((GF_Box *)ptr->vp_config, bs);
 			if (e) return e;
 		}
+		if (ptr->dovi_config) {
+			e = gf_isom_box_write((GF_Box*)ptr->dovi_config, bs);
+			if (e) return e;
+		}
 	}
 	if (ptr->clap) {
 		e = gf_isom_box_write((GF_Box*)ptr->clap, bs);
@@ -4625,6 +4634,11 @@ GF_Err video_sample_entry_Size(GF_Box *s)
 				return GF_ISOM_INVALID_FILE;
 			}
 			break;
+		case GF_ISOM_BOX_TYPE_DVHE:
+			if (!ptr->dovi_config) {
+				return GF_ISOM_INVALID_FILE;
+			}
+			break;
 		default:
 			break;
 		}
@@ -4669,6 +4683,12 @@ GF_Err video_sample_entry_Size(GF_Box *s)
 			e = gf_isom_box_size((GF_Box *)ptr->vp_config);
 			if (e) return e;
 			ptr->size += ptr->vp_config->size;
+		}
+
+		if (ptr->dovi_config) {
+			e = gf_isom_box_size((GF_Box*)ptr->dovi_config);
+			if (e) return e;
+			ptr->size += ptr->dovi_config->size;
 		}
 
 		if (ptr->ipod_ext) {

--- a/src/media_tools/av_parsers.c
+++ b/src/media_tools/av_parsers.c
@@ -5556,6 +5556,17 @@ static s32 avc_parse_pic_timing_sei(GF_BitStream *bs, AVCState *avc)
 	return 0;
 }
 
+static void avc_parse_itu_t_t35_sei(GF_BitStream* bs, AVCSeiItuTT35DolbyVision *dovi)
+{
+	u8 itu_t_t35_country_code = gf_bs_read_u8(bs);
+	u16 terminal_provider_code = gf_bs_read_u16(bs);
+	u32 user_id = gf_bs_read_u32(bs);
+	u8 data_type_code = gf_bs_read_u8(bs);
+	if (itu_t_t35_country_code == 0xB5 && terminal_provider_code == 0x31 && user_id == 0x47413934 && (data_type_code == 0x8 || data_type_code == 0x9)) {
+		dovi->rpu_flag = GF_TRUE;
+	}
+}
+
 
 static void avc_compute_poc(AVCSliceInfo *si)
 {
@@ -5964,6 +5975,64 @@ u32 gf_media_avc_reformat_sei(char *buffer, u32 nal_size, AVCState *avc)
 
 	/*if only hdr written ignore*/
 	return (written>1) ? written : 0;
+}
+
+void gf_media_hevc_parse_sei(char *buffer, u32 nal_size, HEVCState *hevc)
+{
+	u32 ptype, psize, hdr;
+	u64 start;
+	GF_BitStream *bs;
+	char *sei_without_emulation_bytes = NULL;
+	u32 sei_without_emulation_bytes_size = 0;
+
+	hdr = buffer[0];
+	if (((hdr & 0x7e) >> 1) != GF_HEVC_NALU_SEI_PREFIX) return;
+
+	/*PPS still contains emulation bytes*/
+	sei_without_emulation_bytes = gf_malloc(nal_size + 1/*for SEI null string termination*/);
+	sei_without_emulation_bytes_size = gf_media_nalu_remove_emulation_bytes(buffer, sei_without_emulation_bytes, nal_size);
+
+	bs = gf_bs_new(sei_without_emulation_bytes, sei_without_emulation_bytes_size, GF_BITSTREAM_READ);
+	gf_bs_read_int(bs, 16);
+
+	/*parse SEI*/
+	while (gf_bs_available(bs)) {
+		ptype = 0;
+		while (gf_bs_peek_bits(bs, 8, 0)==0xFF) {
+			gf_bs_read_int(bs, 8);
+			ptype += 255;
+		}
+		ptype += gf_bs_read_int(bs, 8);
+		psize = 0;
+		while (gf_bs_peek_bits(bs, 8, 0)==0xFF) {
+			gf_bs_read_int(bs, 8);
+			psize += 255;
+		}
+		psize += gf_bs_read_int(bs, 8);
+
+		start = gf_bs_get_position(bs);
+		if (start+psize >= nal_size) {
+			GF_LOG(GF_LOG_WARNING, GF_LOG_CODING, ("[hevc-h265] SEI user message type %d size error (%d but %d remain), skipping SEI message\n", ptype, psize, nal_size-start));
+			break;
+		}
+
+		switch (ptype) {
+		case 4: /*user registered ITU-T t35*/
+		{
+			GF_BitStream * itu_t_t35_bs = gf_bs_new(sei_without_emulation_bytes + start, psize, GF_BITSTREAM_READ);
+			avc_parse_itu_t_t35_sei(itu_t_t35_bs, &hevc->sei.dovi);
+			gf_bs_del(itu_t_t35_bs);
+		}
+		default: break;
+		}
+
+		gf_bs_skip_bytes(bs, (u64) psize);
+		gf_bs_align(bs);
+		if (gf_bs_available(bs) <= 2)
+			break;
+	}
+	gf_bs_del(bs);
+	gf_free(sei_without_emulation_bytes);
 }
 
 #ifndef GPAC_DISABLE_ISOM

--- a/src/media_tools/dash_segmenter.c
+++ b/src/media_tools/dash_segmenter.c
@@ -730,6 +730,19 @@ GF_Err gf_media_get_rfc_6381_codec_name(GF_ISOFile *movie, u32 track, char *szCo
 		return GF_OK;
 	}
 
+	case GF_ISOM_SUBTYPE_DVHE:
+	{
+		GF_DOVIDecoderConfigurationRecord *dovi = gf_isom_dovi_config_get(movie, track, 1);
+		if (!dovi) {
+			GF_LOG(GF_LOG_DEBUG, GF_LOG_AUTHOR, ("[ISOM Tools] No config found for Dolby Vision file (\"%s\") when computing RFC6381.\n", gf_4cc_to_str(subtype)));
+			return GF_BAD_PARAM;
+		}
+
+		snprintf(szCodec, RFC6381_CODEC_NAME_SIZE_MAX, "%s.%02u.%02u", gf_4cc_to_str(subtype),
+			dovi->dv_profile, dovi->dv_level);
+		return GF_OK;
+	}
+
 	default:
 		GF_LOG(GF_LOG_DEBUG, GF_LOG_AUTHOR, ("[ISOM Tools] codec parameters not known - setting codecs string to default value \"%s\"\n", gf_4cc_to_str(subtype) ));
 		snprintf(szCodec, RFC6381_CODEC_NAME_SIZE_MAX, "%s", gf_4cc_to_str(subtype));

--- a/src/media_tools/media_import.c
+++ b/src/media_tools/media_import.c
@@ -6573,7 +6573,7 @@ restart_import:
 				copy_size = 0;
 			} else {
 				if (hevc.sps_active_idx != -1) {
-					//todo: inspect SEI and decide what we import
+					gf_media_hevc_parse_sei(buffer, nal_size, &hevc);
 					copy_size = nal_size;
 				} else {
 					//if no state yet, import SEI

--- a/src/media_tools/media_import.c
+++ b/src/media_tools/media_import.c
@@ -6646,8 +6646,13 @@ restart_import:
 		case GF_HEVC_NALU_END_OF_STREAM:
 			break;
 
+		//parsing is partial, see https://github.com/DolbyLaboratories/dlb_mp4base/blob/70a2e1d4d99a8439b7b8087bf50dd503eeea2291/src/esparser/parser_hevc.c#L1233
 		case GF_HEVC_NALU_DV_RPU:
+			hevc.dv_rpu = GF_TRUE;
+			copy_size = nal_size;
+			break;
 		case GF_HEVC_NALU_DV_EL:
+			hevc.dv_el = GF_TRUE;
 			copy_size = nal_size;
 			break;
 

--- a/src/media_tools/media_import.c
+++ b/src/media_tools/media_import.c
@@ -5322,10 +5322,14 @@ restart_import:
 			}
 			break;
 
-		case GF_AVC_NALU_SLICE_AUX:
+		case GF_AVC_NALU_DV_RPU:
+		case GF_AVC_NALU_DV_EL:
+			copy_size = nal_size;
+			break;
 
+		case GF_AVC_NALU_SLICE_AUX:
 		default:
-			gf_import_message(import, GF_OK, "WARNING: NAL Unit type %d not handled - adding", nal_type);
+			gf_import_message(import, GF_OK, "Warning: AVC/H264 NAL Unit type %d not handled - adding", nal_type);
 			copy_size = nal_size;
 			break;
 		}
@@ -6642,8 +6646,13 @@ restart_import:
 		case GF_HEVC_NALU_END_OF_STREAM:
 			break;
 
+		case GF_HEVC_NALU_DV_RPU:
+		case GF_HEVC_NALU_DV_EL:
+			copy_size = nal_size;
+			break;
+
 		default:
-			gf_import_message(import, GF_OK, "WARNING: NAL Unit type %d not handled - adding", nal_unit_type);
+			gf_import_message(import, GF_OK, "Warning: HEVC NAL Unit type %d not handled - adding", nal_unit_type);
 			copy_size = nal_size;
 			break;
 		}


### PR DESCRIPTION
DolbyVision support:
 -  [X] RFC8361
 -  [X] DASH (ok)
 -  [X] Encryption (ok)
 -  [ ] "Dolby recommends including a separate adaptation set that refers to an SDR version of the same content as the Dolby Vision stream." => filters only: put an "alt_codecs" on AS and force a  duplication in the MPD serializer by patchin the AS ID when serializing
 - [ ] Raw import: multiple stream structure reversed-engineered. Clarification with new streams needed.
 - [ ] Add test