### PR TITLE
src/utils/os_net.c: Include errno.h for windows

### DIFF
--- a/src/utils/os_net.c
+++ b/src/utils/os_net.c
@@ -62,6 +62,8 @@
 
 #endif
 
+#include <errno.h>
+
 #ifndef EISCONN
 /*common win32 redefs*/
 #undef EAGAIN


### PR DESCRIPTION
solves an issue with mingw-w64 clang that shows

```c
D:/ffmpeg-autobuild-clang/build/gpac-git/src/utils/os_net.c:950:9: error: use of undeclared identifier 'EPIPE'
                        case EPIPE:
                             ^
D:/ffmpeg-autobuild-clang/build/gpac-git/src/utils/os_net.c:956:9: error: use of undeclared identifier 'EPROTOTYPE'
                        case EPROTOTYPE:
                             ^
D:/ffmpeg-autobuild-clang/build/gpac-git/src/utils/os_net.c:959:9: error: use of undeclared identifier 'ENOBUFS'
                        case ENOBUFS:
                             ^
3 errors generated.
```
Fixes https://github.com/m-ab-s/media-autobuild_suite/issues/1713


Signed-off-by: Christopher Degawa <ccom@randomderp.com>