### PR TITLE
itunes_tags: make the global variables static

### DIFF
--- a/applications/mp4box/main.c
+++ b/applications/mp4box/main.c
@@ -2392,7 +2392,7 @@ GF_SceneDumpFormat dump_mode;
 Double mpd_live_duration = 0;
 Bool HintIt, needSave, FullInter, Frag, HintInter, dump_rtp, regular_iod, remove_sys_tracks, remove_hint, remove_root_od;
 Bool print_sdp, open_edit, dump_cr, force_ocr, encode, do_log, dump_srt, dump_ttxt, do_saf, dump_m2ts, dump_cart, do_hash, verbose, force_cat, align_cat, pack_wgt, single_group, clean_groups, dash_live, no_fragments_defaults, single_traf_per_moof, tfdt_per_traf, hls_clock, do_mpd_rip, merge_vtt_cues, compress_moov, get_nb_tracks;
-char *inName, *outName, *mediaSource, *tmpdir, *input_ctx, *output_ctx, *drm_file, *avi2raw, *cprt, *chap_file, *pes_dump, *itunes_tags, *pack_file, *raw_cat, *seg_name, *dash_ctx_file, *compress_top_boxes, *high_dynamc_range_filename, *use_init_seg, *box_patch_filename;
+static char *inName, *outName, *mediaSource, *tmpdir, *input_ctx, *output_ctx, *drm_file, *avi2raw, *cprt, *chap_file, *pes_dump, *itunes_tags, *pack_file, *raw_cat, *seg_name, *dash_ctx_file, *compress_top_boxes, *high_dynamc_range_filename, *use_init_seg, *box_patch_filename;
 u32 track_dump_type, dump_isom, dump_timestamps, dump_nal_type;
 GF_ISOTrackID trackID;
 u32 do_flat, box_patch_trackID=0, print_info;

--- a/src/utils/constants.c
+++ b/src/utils/constants.c
@@ -1287,7 +1287,7 @@ u32 gf_pixel_get_nb_comp(GF_PixelFormat pixfmt)
 
 
 
-struct _itags {
+static struct _itags {
 	const char *name;
 	u32 itag;
 	u32 id3tag;


### PR DESCRIPTION
Fixes issues such as
```c
S:/media-autobuild_suite-master/msys64/mingw32/bin/../lib/gcc/i686-w64-mingw32/10.1.0/../../../../i686-w64-mingw32/bin/ld.exe: ../../bin/gcc/libgpac_static.a(constants.o):constants.c:(.data+0x0): multiple definition of `itunes_tags'; main.o:main.c:(.bss+0x138): first defined here
```

Closes https://github.com/m-ab-s/media-autobuild_suite/issues/1762