### PR TITLE
Disabled config

### DIFF
--- a/applications/mp4box/fileimport.c
+++ b/applications/mp4box/fileimport.c
@@ -1226,6 +1226,7 @@ GF_Err import_file(GF_ISOFile *dest, char *inName, u32 import_flags, GF_Fraction
 			//TODO - merge, temporal sublayers
 		}
 	}
+#ifndef GPAC_DISABLE_HEVC
 	if (check_track_for_hevc) {
 		if (split_tile_mode) {
 			e = gf_media_split_hevc_tiles(dest, split_tile_mode - 1);
@@ -1237,6 +1238,7 @@ GF_Err import_file(GF_ISOFile *dest, char *inName, u32 import_flags, GF_Fraction
 			if (e) goto exit;
 		}
 	}
+#endif
 
 	if (tc_fps_num) {
 		u32 desc_index=0;

--- a/src/Makefile
+++ b/src/Makefile
@@ -21,8 +21,9 @@ LIBGPAC_UTILS+=utils/sha1.o utils/base_encoding.o utils/math.o utils/os_net.o ut
 endif
 
 ifeq ($(DISABLE_PLAYER), no)
-LIBGPAC_UTILS+=utils/os_module.o utils/path2d.o utils/path2d_stroker.o utils/module.o utils/uni_bidi.o utils/unicode.o
+LIBGPAC_UTILS+=utils/uni_bidi.o utils/unicode.o
 endif
+LIBGPAC_UTILS+=utils/os_module.o utils/module.o utils/path2d.o utils/path2d_stroker.o 
 
 ## libgpac objects gathering: src/ietf
 LIBGPAC_IETF=
@@ -189,6 +190,7 @@ LIBGPAC_COMPOSITOR=compositor/audio_input.o compositor/audio_mixer.o compositor/
 ifeq ($(DISABLE_PLAYER), yes)
 LIBGPAC_COMPOSITOR=
 LIBGPAC_TERMINAL=
+LIBGPAC_EVG=
 endif
 ifeq ($(DISABLE_SCENEGRAPH), yes)
 LIBGPAC_SCENE=

--- a/src/filter_core/filter_session.c
+++ b/src/filter_core/filter_session.c
@@ -31,8 +31,10 @@
 #endif
 //#define CHECK_TASK_LIST_INTEGRITY
 
+#ifndef GPAC_DISABLE_PLAYER
 struct _gf_ft_mgr *gf_font_manager_new();
 void gf_font_manager_del(struct _gf_ft_mgr *fm);
+#endif
 
 
 static GFINLINE void gf_fs_sema_io(GF_FilterSession *fsess, Bool notify, Bool main)
@@ -625,7 +627,9 @@ void gf_fs_del(GF_FilterSession *fsess)
 	gf_fs_unload_script(fsess, NULL);
 
 	if (fsess->download_manager) gf_dm_del(fsess->download_manager);
+#ifndef GPAC_DISABLE_PLAYER
 	if (fsess->font_manager) gf_font_manager_del(fsess->font_manager);
+#endif
 
 	if (fsess->registry) {
 		while (gf_list_count(fsess->registry)) {
@@ -2753,6 +2757,9 @@ GF_DownloadManager *gf_filter_get_download_manager(GF_Filter *filter)
 GF_EXPORT
 struct _gf_ft_mgr *gf_filter_get_font_manager(GF_Filter *filter)
 {
+#ifdef GPAC_DISABLE_PLAYER
+	return NULL;
+#else
 	GF_FilterSession *fsess;
 	if (!filter) return NULL;
 	fsess = filter->session;
@@ -2761,6 +2768,7 @@ struct _gf_ft_mgr *gf_filter_get_font_manager(GF_Filter *filter)
 		fsess->font_manager = gf_font_manager_new();
 	}
 	return fsess->font_manager;
+#endif
 }
 
 void gf_fs_cleanup_filters(GF_FilterSession *fsess)

--- a/src/filters/bsrw.c
+++ b/src/filters/bsrw.c
@@ -213,6 +213,8 @@ static GF_Err avc_rewrite_pid_config(GF_BSRWCtx *ctx, BSRWPid *pctx)
 	return GF_OK;
 }
 
+#ifndef GPAC_DISABLE_HEVC
+
 static GF_Err hevc_rewrite_packet(GF_BSRWCtx *ctx, BSRWPid *pctx, GF_FilterPacket *pck)
 {
 	u32 size, pck_size, final_size;
@@ -310,6 +312,7 @@ static GF_Err hevc_rewrite_pid_config(GF_BSRWCtx *ctx, BSRWPid *pctx)
 	}
 	return GF_OK;
 }
+#endif // GPAC_DISABLE_HEVC
 
 static GF_Err none_rewrite_pid_config(GF_BSRWCtx *ctx, BSRWPid *pctx)
 {
@@ -471,11 +474,13 @@ static GF_Err bsrw_configure_pid(GF_Filter *filter, GF_FilterPid *pid, Bool is_r
 	case GF_CODECID_MVC:
 		pctx->rewrite_pid_config = avc_rewrite_pid_config;
 		break;
+#ifndef GPAC_DISABLE_HEVC
 	case GF_CODECID_HEVC:
 	case GF_CODECID_HEVC_TILES:
 	case GF_CODECID_LHVC:
 		pctx->rewrite_pid_config = hevc_rewrite_pid_config;
 		break;
+#endif
 	case GF_CODECID_MPEG4_PART2:
 		pctx->rewrite_pid_config = m4v_rewrite_pid_config;
 		break;

--- a/src/filters/compose.c
+++ b/src/filters/compose.c
@@ -29,6 +29,7 @@
 //to set caps in filter session, to cleanup!
 #include "../filter_core/filter_session.h"
 
+#ifndef GPAC_DISABLE_PLAYER
 
 GF_Err compose_bifs_dec_config_input(GF_Scene *scene, GF_FilterPid *pid, u32 oti, Bool is_remove);
 GF_Err compose_bifs_dec_process(GF_Scene *scene, GF_FilterPid *pid);
@@ -986,4 +987,10 @@ const GF_FilterRegister *compose_filter_register(GF_FilterSession *session)
 	}
 	return &CompositorFilterRegister;
 }
+#else
+const GF_FilterRegister *compose_filter_register(GF_FilterSession *session)
+{
+	return NULL;
+}
+#endif // GPAC_DISABLE_PLAYER
 

--- a/src/filters/dasher.c
+++ b/src/filters/dasher.c
@@ -29,6 +29,7 @@
 #include <gpac/mpd.h>
 #include <gpac/internal/media_dev.h>
 #include <gpac/base_coding.h>
+#include <gpac/network.h>
 
 #define DEFAULT_PERIOD_ID	 "_gf_dash_def_period"
 
@@ -770,8 +771,9 @@ static GF_Err dasher_configure_pid(GF_Filter *filter, GF_FilterPid *pid, Bool is
 					gf_odf_hevc_cfg_del(hevccfg);
 				}
 			}
+			else
 #endif
-			else if (ds->codec_id == GF_CODECID_AVC || ds->codec_id == GF_CODECID_SVC || ds->codec_id == GF_CODECID_MVC) {
+			if (ds->codec_id == GF_CODECID_AVC || ds->codec_id == GF_CODECID_SVC || ds->codec_id == GF_CODECID_MVC) {
 				AVCState avc;
 				GF_AVCConfig* avccfg = gf_odf_avc_cfg_read(dsi->value.data.ptr, dsi->value.data.size);
 				GF_AVCConfigSlot *sl = (GF_AVCConfigSlot *)gf_list_get(avccfg->sequenceParameterSets, 0);

--- a/src/filters/dec_bifs.c
+++ b/src/filters/dec_bifs.c
@@ -29,6 +29,8 @@
 #include <gpac/compositor.h>
 #include <gpac/internal/compositor_dev.h>
 
+#ifndef GPAC_DISABLE_BIFS
+
 
 typedef struct
 {
@@ -39,8 +41,6 @@ typedef struct
 	Bool is_playing;
 	GF_FilterPid *out_pid;
 } GF_BIFSDecCtx;
-
-#ifndef GPAC_DISABLE_BIFS
 
 static GF_Err bifs_dec_configure_bifs_dec(GF_BIFSDecCtx *ctx, GF_FilterPid *pid)
 {

--- a/src/filters/dec_odf.c
+++ b/src/filters/dec_odf.c
@@ -27,6 +27,8 @@
 #include <gpac/constants.h>
 #include <gpac/compositor.h>
 
+#ifndef GPAC_DISABLE_PLAYER
+
 typedef struct
 {
 	GF_ObjectManager *odm;
@@ -472,4 +474,9 @@ const GF_FilterRegister *odf_dec_register(GF_FilterSession *session)
 {
 	return &ODFDecRegister;
 }
-
+#else
+const GF_FilterRegister *odf_dec_register(GF_FilterSession *session)
+{
+	return NULL;
+}
+#endif // GPAC_DISABLE_PLAYER

--- a/src/filters/dmx_gsf.c
+++ b/src/filters/dmx_gsf.c
@@ -217,6 +217,7 @@ static Bool gsfdmx_process_event(GF_Filter *filter, const GF_FilterEvent *evt)
 
 static void gsfdmx_decrypt(GSF_DemuxCtx *ctx, char *data, u32 size)
 {
+#ifndef GPAC_DISABLE_CRYPTO
 	u32 pos=0;
 	u32 clear_tail = size%16;
 	u32 bytes_crypted = size - clear_tail;
@@ -239,6 +240,7 @@ static void gsfdmx_decrypt(GSF_DemuxCtx *ctx, char *data, u32 size)
 	} else {
 		gf_crypt_decrypt(ctx->crypt, data, bytes_crypted);
 	}
+#endif
 }
 
 static GFINLINE u32 gsfdmx_read_vlen(GF_BitStream *bs)
@@ -474,6 +476,9 @@ static GF_Err gsfdmx_tune(GF_Filter *filter, GSF_DemuxCtx *ctx, char *pck_data, 
 		return GF_NOT_SUPPORTED;
 	}
 	if (is_crypted) {
+#ifdef GPAC_DISABLE_CRYPTO
+		return GF_NOT_SUPPORTED;
+#else
 		if (pck_size<25) {
 			GF_LOG(GF_LOG_ERROR, GF_LOG_CONTAINER, ("[GSFDemux] Wrong serialized header size %d, should be at least 25 bytes for encrypted streams\n", pck_size ));
 			ctx->tune_error = GF_TRUE;
@@ -497,6 +502,7 @@ static GF_Err gsfdmx_tune(GF_Filter *filter, GSF_DemuxCtx *ctx, char *pck_data, 
 		gf_crypt_init(ctx->crypt, ctx->key.ptr, ctx->crypt_IV);
 
 		gsfdmx_decrypt(ctx, pck_data+25, pck_size - 25);
+#endif
 	}
 	ctx->use_seq_num = gf_bs_read_int(bs, 1);
 	gf_bs_read_int(bs, 7);
@@ -1216,7 +1222,9 @@ static void gsfdmx_finalize(GF_Filter *filter)
 	}
 	gf_list_del(ctx->pck_res);
 
+#ifndef GPAC_DISABLE_CRYPTO
 	if (ctx->crypt) gf_crypt_close(ctx->crypt);
+#endif
 	if (ctx->buffer) gf_free(ctx->buffer);
 	if (ctx->bs_r) gf_bs_del(ctx->bs_r);
 	if (ctx->bs_pck) gf_bs_del(ctx->bs_pck);
@@ -1238,7 +1246,9 @@ static const GF_FilterCapability GSFDemuxCaps[] =
 #define OFFS(_n)	#_n, offsetof(GSF_DemuxCtx, _n)
 static const GF_FilterArgs GSFDemuxArgs[] =
 {
+#ifndef GPAC_DISABLE_CRYPTO
 	{ OFFS(key), "key for decrypting packets", GF_PROP_DATA, NULL, NULL, GF_FS_ARG_HINT_ADVANCED},
+#endif
 	{ OFFS(magic), "magic string to check in setup packet", GF_PROP_STRING, NULL, NULL, GF_FS_ARG_HINT_ADVANCED},
 	{ OFFS(mq), "set max packet queue length for loss detection. 0 will flush incomplete packet when a new one starts", GF_PROP_UINT, "4", NULL, GF_FS_ARG_HINT_ADVANCED},
 	{ OFFS(pad), "byte value used to pad lost packets", GF_PROP_UINT, "0", "0-255", GF_FS_ARG_HINT_ADVANCED},
@@ -1253,7 +1263,10 @@ GF_FilterRegister GSFDemuxRegister = {
 			"It deserializes the stream states (config/reconfig/info update/remove/eos) and packets of input PIDs.\n"
 			"This allows either reading a session saved to file, or receiving the state/data of streams from another instance of GPAC using either pipes or sockets\n"
 			"\n"
-			"The stream format can be encrypted in AES 128 CBC mode, in which case the demux filters must be given a 128 bit key.")
+#ifndef GPAC_DISABLE_CRYPTO
+			"The stream format can be encrypted in AES 128 CBC mode, in which case the demux filters must be given a 128 bit key."
+#endif
+			)
 	.private_size = sizeof(GSF_DemuxCtx),
 	.max_extra_pids = (u32) -1,
 	.args = GSFDemuxArgs,

--- a/src/filters/hevcmerge.c
+++ b/src/filters/hevcmerge.c
@@ -32,7 +32,7 @@
 #include <gpac/internal/media_dev.h>
 #include <math.h>
 
-#ifndef GPAC_DISABLE_AV_PARSERS
+#if !defined(GPAC_DISABLE_HEVC) && !defined(GPAC_DISABLE_AV_PARSERS)
 
 typedef struct
 {

--- a/src/filters/hevcsplit.c
+++ b/src/filters/hevcsplit.c
@@ -31,7 +31,7 @@
 #include <gpac/constants.h>
 #include <gpac/internal/media_dev.h>
 
-#ifndef GPAC_DISABLE_AV_PARSERS
+#if !defined(GPAC_DISABLE_HEVC) && !defined(GPAC_DISABLE_AV_PARSERS)
 
 typedef struct
 {

--- a/src/filters/in_sock.c
+++ b/src/filters/in_sock.c
@@ -296,7 +296,7 @@ static GF_Err sockin_read_client(GF_Filter *filter, GF_SockInCtx *ctx, GF_SockIn
 #ifndef GPAC_DISABLE_STREAMING
 				sock_c->rtp_reorder = gf_rtp_reorderer_new(ctx->reorder_pck, ctx->reorder_delay);
 #else
-			ctx-	>is_rtp = GF_TRUE;
+				sock_c->is_rtp = GF_TRUE;
 #endif
 				mime = "video/mp2t";
 			} else if (ctx->buffer[0] == 0x47) {

--- a/src/filters/load_bt_xmt.c
+++ b/src/filters/load_bt_xmt.c
@@ -862,8 +862,6 @@ static const char *ctxload_probe_data(const u8 *probe_data, u32 size, GF_FilterP
 	return NULL;
 }
 
-#endif //defined(GPAC_DISABLE_VRML) && !defined(GPAC_DISABLE_SCENEGRAPH)
-
 static const GF_FilterCapability CTXLoadCaps[] =
 {
 	CAP_UINT(GF_CAPS_INPUT, GF_PROP_PID_STREAM_TYPE, GF_STREAM_FILE),
@@ -897,6 +895,8 @@ GF_FilterRegister CTXLoadRegister = {
 	.process_event = ctxload_process_event,
 	.probe_data = ctxload_probe_data,
 };
+
+#endif //defined(GPAC_DISABLE_VRML) && !defined(GPAC_DISABLE_SCENEGRAPH)
 
 
 const GF_FilterRegister *ctxload_register(GF_FilterSession *session)

--- a/src/filters/mux_gsf.c
+++ b/src/filters/mux_gsf.c
@@ -154,6 +154,7 @@ static GFINLINE u32 gsfmx_get_header_size(GSFMxCtx *ctx, GSFStream *gst, Bool us
 
 static void gsfmx_encrypt(GSFMxCtx *ctx, char *data, u32 nb_crypt_bytes)
 {
+#ifndef GPAC_DISABLE_CRYPTO
 	u32 clear_trail;
 
 	clear_trail = nb_crypt_bytes % 16;
@@ -177,6 +178,7 @@ static void gsfmx_encrypt(GSFMxCtx *ctx, char *data, u32 nb_crypt_bytes)
 	} else {
 		gf_crypt_encrypt(ctx->crypt, data, nb_crypt_bytes);
 	}
+#endif // GPAC_DISABLE_CRYPTO
 }
 
 static void gsfmx_send_packets(GSFMxCtx *ctx, GSFStream *gst, GF_GSFPacketType pck_type, Bool is_end, Bool is_redundant, u32 frame_size, u32 frame_hdr_size)
@@ -1002,6 +1004,9 @@ static GF_Err gsfmx_initialize(GF_Filter *filter)
 	gf_rand_init(GF_FALSE);
 
 	if (ctx->key.size==16) {
+#ifdef GPAC_DISABLE_CRYPTO
+		return GF_NOT_SUPPORTED;
+#else
 		GF_Err e;
 		if (ctx->IV.size==16) {
 			memcpy(ctx->crypt_IV, ctx->IV.ptr, 16);
@@ -1033,6 +1038,7 @@ static GF_Err gsfmx_initialize(GF_Filter *filter)
 			GF_LOG(GF_LOG_ERROR, GF_LOG_CONTAINER, ("[GSFMux] Failed to setup encryption: %s\n", gf_error_to_string(e) ));
 			return GF_IO_ERR;
 		}
+#endif
 	} else if (ctx->key.size) {
 		GF_LOG(GF_LOG_ERROR, GF_LOG_CONTAINER, ("[GSFMux] Wrong key value, size %d expecting 16\n", ctx->key.size));
 		return GF_BAD_PARAM;
@@ -1057,7 +1063,9 @@ static void gsfmx_finalize(GF_Filter *filter)
 
 	if (ctx->bs_w) gf_bs_del(ctx->bs_w);
 	if (ctx->buffer) gf_free(ctx->buffer);
+#ifndef GPAC_DISABLE_CRYPTO
 	if (ctx->crypt) gf_crypt_close(ctx->crypt);
+#endif
 }
 
 static const GF_FilterCapability GSFMxCaps[] =
@@ -1083,9 +1091,11 @@ static const GF_FilterArgs GSFMxArgs[] =
 	"- no: disable debug\n"
 	"- nodata: force packet size to 0\n"
 	"- nopck: skip packet", GF_PROP_UINT, "no", "no|nodata|nopck", GF_FS_ARG_HINT_EXPERT},
+#ifndef GPAC_DISABLE_CRYPTO
 	{ OFFS(key), "encrypt packets using given key - see filter helps", GF_PROP_DATA, NULL, NULL, 0},
 	{ OFFS(IV), "set IV for encryption - a constant IV is used to keep packet overhead small (cbcs-like)", GF_PROP_DATA, NULL, NULL, 0},
 	{ OFFS(pattern), "set nb crypt / nb_skip block pattern. default is all encrypted", GF_PROP_FRACTION, "1/0", NULL, GF_FS_ARG_HINT_ADVANCED},
+#endif // GPAC_DISABLE_CRYPTO
 	{ OFFS(mpck), "set max packet size. 0 means no fragmentation (each AU is sent in one packet)", GF_PROP_UINT, "0", NULL, GF_FS_ARG_HINT_ADVANCED},
 	{ OFFS(magic), "magic string to append in setup packet", GF_PROP_STRING, NULL, NULL, GF_FS_ARG_HINT_ADVANCED},
 	{ OFFS(skp), "comma separated list of pid property names to skip - see filter help", GF_PROP_STRING, NULL, NULL, GF_FS_ARG_HINT_ADVANCED},
@@ -1106,6 +1116,7 @@ GF_FilterRegister GSFMxRegister = {
 			"The default behaviour does not insert sequence numbers. When running over general protocols not ensuring packet order, this should be inserted.\n"
 			"The serializer sends tune-in packets (global and per pid) at the requested carousel rate - if 0, no carousel. These packets are marked as redundant so that they can be discarded by output filters if needed.\n"
 			"\n"
+#ifndef GPAC_DISABLE_CRYPTO
 			"The stream format can be encrypted in AES 128 CBC mode. For all packets, the packet header (header, size, frame size/block offset and optional seq num) are in the clear "
 			"and the followings byte until the last byte of the last multiple of block size (16) fitting in the payload are encrypted.\n"
 			"For data packets, each fragment is encrypted individually to avoid error propagation in case of losses.\n"
@@ -1113,7 +1124,8 @@ GF_FilterRegister GSFMxRegister = {
 			"For header/tunein packets, the first 25 bytes after the header are in the clear (signature,version,IV and pattern).\n"
 			"The [-IV]() is constant to avoid packet overhead, randomly generated if not set and sent in the initial stream header. "
 			"Pattern mode can be used (cf CENC cbcs) to encrypt K block and leave N blocks in the clear.\n"
-			"\n"\
+			"\n"
+#endif
 			"The header/tunein packet may get quite big when all pid properties are kept. In order to help reduce its size, the [-minp]() option can be used: "
 			"this will remove all built-in properties marked as dropable (cf property help) as well as all non built-in properties.\n"
 			"The [-skp]() option may also be used to specify which property to drop:\n"

--- a/src/filters/out_video.c
+++ b/src/filters/out_video.c
@@ -29,6 +29,7 @@
 #include <gpac/modules/video_out.h>
 #include <gpac/color.h>
 
+#ifndef GPAC_DISABLE_PLAYER
 
 //#define GPAC_DISABLE_3D
 
@@ -1545,3 +1546,9 @@ const GF_FilterRegister *vout_register(GF_FilterSession *session)
 {
 	return &VideoOutRegister;
 }
+#else
+const GF_FilterRegister *vout_register(GF_FilterSession *session)
+{
+	return NULL;
+}
+#endif // GPAC_DISABLE_PLAYER

--- a/src/filters/resample_audio.c
+++ b/src/filters/resample_audio.c
@@ -28,6 +28,8 @@
 #include <gpac/filters.h>
 #include <gpac/internal/compositor_dev.h>
 
+#ifndef GPAC_DISABLE_PLAYER
+
 typedef struct
 {
 	//opts
@@ -392,3 +394,11 @@ const GF_FilterRegister *resample_register(GF_FilterSession *session)
 {
 	return &ResamplerRegister;
 }
+#else
+
+const GF_FilterRegister *resample_register(GF_FilterSession *session)
+{
+	return NULL;
+}
+
+#endif // GPAC_DISABLE_PLAYER

--- a/src/isomedia/iff.c
+++ b/src/isomedia/iff.c
@@ -981,7 +981,7 @@ static GF_Err gf_isom_iff_create_image_item_from_track_internal(GF_ISOFile *movi
 		char sz_item_name[256];
 		GF_TileItemMode orig_tile_mode;
 
-#ifndef GPAC_DISABLE_AV_PARSERS
+#if !defined(GPAC_DISABLE_HEVC) && !defined(GPAC_DISABLE_AV_PARSERS)
 		e = gf_media_split_hevc_tiles(movie, 0);
 #else
 		e = GF_NOT_SUPPORTED;

--- a/src/media_tools/isom_tools.c
+++ b/src/media_tools/isom_tools.c
@@ -2415,7 +2415,7 @@ exit:
 GF_EXPORT
 GF_Err gf_media_split_lhvc(GF_ISOFile *file, u32 track, Bool for_temporal_sublayers, Bool splitAll, GF_LHVCExtractoreMode extractor_mode)
 {
-#ifndef GPAC_DISABLE_AV_PARSERS
+#if !defined(GPAC_DISABLE_HEVC) && !defined(GPAC_DISABLE_AV_PARSERS)
 	LHVCTrackInfo sti[64];
 	GF_HEVCConfig *hevccfg, *lhvccfg;
 	u32 sample_num, count, cur_extract_mode, j, k, max_layer_id;


### PR DESCRIPTION
Compiling at RHEL7 and configure some disable options, compile error has occurred.
The configure options are as follows:
```
./configure \
--strip \
--disable-ipv6 \
--disable-platinum \
--disable-alsa \
--disable-oss-audio \
--disable-jack \
--disable-pulseaudio \
--disable-x11 \
--disable-x11-shm \
--disable-x11-xv \
--disable-ssl \
--disable-3d \
--disable-svg \
--disable-vrml \
--disable-x3d \
--disable-odf \
--disable-bifs \
--disable-bifs-enc \
--disable-laser \
--disable-saf \
--disable-seng \
--disable-qtvr \
--disable-avi \
--disable-ogg \
--disable-dvb4linux \
--disable-swf \
--disable-scene-stats \
--disable-scene-dump \
--disable-scene-encode \
--disable-loader-isoff \
--disable-loader-bt \
--disable-loader-xmt \
--disable-od-dump \
--disable-crypt \
--disable-isoff-hds \
--disable-streaming \
--disable-dvbx \
--disable-vobsub \
--disable-sman \
--disable-ttxt \
--disable-player \
--disable-scenegraph \
--disable-hevc \
--disable-atsc \
--disable-crypto \
--use-ft=no \
--use-zlib=no \
--use-jpeg=no \
--use-png=no \
--use-faad=no \
--use-mad=no \
--use-xvid=no \
--use-ffmpeg=no \
--use-ogg=no \
--use-vorbis=no \
--use-theora=no \
--use-openjpeg=no \
--use-a52=no \
```