### PR TITLE
moved documentation of -udta option to meta section

### DIFF
--- a/share/doc/man/mp4box.1
+++ b/share/doc/man/mp4box.1
@@ -362,27 +362,6 @@ keep UTC timing in the file after edit
 
 .br
 .TP
-.B \-udta  tkID:[OPTS] (string)
-.br
-set udta for given track or movie if tkID is 0. OPTS is a colon separated list of:
-.br
-* type=CODE: 4CC code of the UDTA (not needed for box= option)
-.br
-* box=FILE: location of the udta data, formatted as serialized boxes
-.br
-* box=base64,DATA: base64 encoded udta data, formatted as serialized boxes
-.br
-* src=FILE: location of the udta data (will be stored in a single box of type CODE)
-.br
-* src=base64,DATA: base64 encoded udta data (will be stored in a single box of type CODE)
-.br
-* str=STRING: use the given string as payload for the udta box
-.br
-Note: If no source is set, UDTA of type CODE will be removed
-.br
-
-.br
-.TP
 .B \-patch  [tkID=]FILE (string)
 .br
 apply box patch described in FILE, for given trackID if set
@@ -2157,6 +2136,27 @@ add the given file as HEIF image item, with parameter syntax file_path[:opt1:opt
 .br
 - any other options will be passed as options to the media importer, see .I add
 .br
+
+.TP
+.B \-udta  tkID:[OPTS] (string)
+.br
+set udta (User Data Atoms) for given track or movie if tkID is 0. OPTS is a colon separated list of:
+.br
+* type=CODE: 4CC code of the UDTA (not needed for box= option)
+.br
+* box=FILE: location of the udta data, formatted as serialized boxes
+.br
+* box=base64,DATA: base64 encoded udta data, formatted as serialized boxes
+.br
+* src=FILE: location of the udta data (will be stored in a single box of type CODE)
+.br
+* src=base64,DATA: base64 encoded udta data (will be stored in a single box of type CODE)
+.br
+* str=STRING: use the given string as payload for the udta box
+.br
+Note: If no source is set, UDTA of type CODE will be removed
+.br
+
 .TP
 .B \-rem-item  item_ID[:tk=tkID] (string)
 .br


### PR DESCRIPTION
The documentation for the `-udta` option was under the "File Splitting and Concatenation" options, when it seems more appropriate for this to be under the Meta Options section, so moved it there.