### PR TITLE
DASH: add trick mode

### DIFF
--- a/include/gpac/mpd.h
+++ b/include/gpac/mpd.h
@@ -714,8 +714,8 @@ typedef struct
 	/*! max number of valid chunks in smooth manifest*/
 	u32 smooth_max_chunks;
 
-	/*! HLS INTRA-ONLY trick mode*/
-	Bool hls_intra_only;
+	/*! INTRA-ONLY trick mode*/
+	Bool intra_only;
 	/*! adaptation set uses HLS LL*/
 	Bool use_hls_ll;
 	/*! target part (cmaf chunk) duration for HLS LL*/

--- a/src/filters/dasher.c
+++ b/src/filters/dasher.c
@@ -1990,6 +1990,14 @@ static void dasher_setup_set_defaults(GF_DasherCtx *ctx, GF_MPD_AdaptationSet *s
 		if (set->max_framerate * ds->fps.den < ds->fps.num) set->max_framerate = (u32) (ds->fps.num / ds->fps.den);
 */
 
+		/*set trick mode*/
+		if (set->intra_only) {
+			char value[256];
+			GF_MPD_Descriptor* desc;
+			sprintf(value, "%d", ds->as_id);
+			desc = gf_mpd_descriptor_new(NULL, "http://dashif.org/guidelines/trickmode", value);
+			gf_list_add(set->essential_properties, desc);
+		}
 		/*set role*/
 		if (ds->p_role) {
 			u32 j, role_count;
@@ -4972,7 +4980,7 @@ static GF_Err dasher_switch_period(GF_Filter *filter, GF_DasherCtx *ctx)
 		ds->owns_set = GF_TRUE;
 		//only set hls intra for visual stream if we have GF_PROP_PID_HAS_SYNC set to false
 		if ((ds->stream_type==GF_STREAM_VISUAL) && gf_filter_pid_get_property(ds->ipid, GF_PROP_PID_HAS_SYNC)) {
-			ds->set->hls_intra_only = !ds->has_sync_points;
+			ds->set->intra_only = !ds->has_sync_points;
 		}
 		if (ctx->llhls) {
 			ds->set->use_hls_ll = GF_TRUE;

--- a/src/media_tools/mpd.c
+++ b/src/media_tools/mpd.c
@@ -3455,7 +3455,7 @@ static GF_Err gf_mpd_write_m3u8_playlist(const GF_MPD *mpd, const GF_MPD_Period 
 
 
 	if (sctx->filename) {
-		if (as->hls_intra_only) {
+		if (as->intra_only) {
 			gf_fprintf(out,"#EXT-X-I-FRAMES-ONLY\n");
 		}
 		if (rep->hls_single_file_name) {
@@ -3606,7 +3606,7 @@ GF_Err gf_mpd_write_m3u8_master_playlist(GF_MPD const * const mpd, FILE *out, co
 	while ( (as = (GF_MPD_AdaptationSet *) gf_list_enum(period->adaptation_sets, &i))) {
 		if (gf_list_count(as->content_protection)) { /*use_crypt = GF_TRUE; */ }
 		if (as->starts_with_sap>2) use_ind_segments = GF_FALSE;
-		if (as->hls_intra_only) use_intra_only = GF_TRUE;
+		if (as->intra_only) use_intra_only = GF_TRUE;
 
 		j=0;
 		while ( (rep = (GF_MPD_Representation *) gf_list_enum(as->representations, &j))) {


### PR DESCRIPTION
Based on DASH-IF IOP 4.3, section 3.2.9
Tested with: gpac -i input:FID=1 reframer:saps=1:FID=2 -o output.m3u8:dual:SID=1,2