### PR TITLE
filters/reframe_qcp.c: fix potential crash

### DIFF
--- a/src/filters/reframe_qcp.c
+++ b/src/filters/reframe_qcp.c
@@ -85,7 +85,8 @@ GF_Err qcpdmx_configure_pid(GF_Filter *filter, GF_FilterPid *pid, Bool is_remove
 
 	if (is_remove) {
 		ctx->ipid = NULL;
-		gf_filter_pid_remove(ctx->opid);
+		if (ctx->opid)
+			gf_filter_pid_remove(ctx->opid);
 		return GF_OK;
 	}
 	if (! gf_filter_pid_check_caps(pid))


### PR DESCRIPTION
In function qcpdmx_configure_pid() in file filters/reframe_qcp.c, ctx->opid should be checked before passed to gf_filter_pid_remove
in case of potential NULL pointer dereference.