### PR TITLE
added bsd strlcpy function for better string copies

### DIFF
--- a/applications/mp4box/main.c
+++ b/applications/mp4box/main.c
@@ -5665,7 +5665,7 @@ int mp4boxMain(int argc, char **argv)
 		gf_isom_keep_utc_times(file, 1);
 	}
 
-	if ( strlcpy(outfile, outName ? outName : inName, sizeof(outfile)) >= sizeof(outfile) ) {
+	if ( gf_strlcpy(outfile, outName ? outName : inName, sizeof(outfile)) >= sizeof(outfile) ) {
 		GF_LOG(GF_LOG_ERROR, GF_LOG_CORE, ("Filename too long (limit is %d)\n", GF_MAX_PATH));
 		return mp4box_cleanup(1);
 	}

--- a/applications/mp4box/main.c
+++ b/applications/mp4box/main.c
@@ -5665,7 +5665,11 @@ int mp4boxMain(int argc, char **argv)
 		gf_isom_keep_utc_times(file, 1);
 	}
 
-	strcpy(outfile, outName ? outName : inName);
+	if ( strlcpy(outfile, outName ? outName : inName, sizeof(outfile)) >= sizeof(outfile) ) {
+		GF_LOG(GF_LOG_ERROR, GF_LOG_CORE, ("Filename too long (limit is %d)\n", GF_MAX_PATH));
+		return mp4box_cleanup(1);
+	}
+
 	{
 
 		char *szExt = gf_file_ext_start(outfile);

--- a/configure
+++ b/configure
@@ -174,6 +174,7 @@ avcap_ldflags="-lavcap"
 has_opensvc="no"
 has_openhevc="no"
 has_vtb="no"
+has_strlcpy="no"
 
 win32="no"
 mingw32="no"
@@ -1686,6 +1687,23 @@ if docc $CFLAGS_DIR -llzma $LDFLAGS ; then
   fi
 fi
 
+#look for strlcpy support
+cat > $TMPC << EOF
+#include <string.h>
+int main( void ) {
+    char dest[1];
+    strlcpy(dest, "1", 1);
+    return 0;
+}
+EOF
+
+if docc $LDFLAGS ; then
+    has_strlcpy="yes"
+fi
+
+
+
+
 #overwrite detection with manual settings
 for opt do
     case "$opt" in
@@ -2910,6 +2928,11 @@ echo "CONFIG_VTB=$has_vtb" >> config.mak
 if test "$has_vtb" != "no" ; then
     echo "#define GPAC_HAS_VTB" >> $TMPH
     echo "vtb_ldflags=$vtb_ldflags" >> config.mak
+fi
+
+echo "CONFIG_STRLCPY=$has_strlcpy" >> config.mak
+if test "$has_strlcpy" != "no" ; then
+    echo "#define GPAC_HAS_STRLCPY" >> $TMPH
 fi
 
 if test "$has_sock_un" != "no" ; then

--- a/include/gpac/configuration.h
+++ b/include/gpac/configuration.h
@@ -51,7 +51,7 @@ This section documents the base data types of GPAC.
 #define GPAC_HAS_SSL
 
 #define GPAC_HAS_QJS
-//codecs  
+//codecs
 #define GPAC_HAS_JPEG
 #define GPAC_HAS_PNG
 #define GPAC_HAS_LIBA52
@@ -176,6 +176,7 @@ This section documents the base data types of GPAC.
 #define GPAC_HAS_IPV6
 #define GPAC_HAS_SSL
 #define GPAC_DISABLE_OGG
+#define GPAC_HAS_STRLCPY
 
 /*Configuration for Symbian*/
 #elif defined(__SYMBIAN32__)
@@ -335,4 +336,3 @@ this macro is currently defined in setup.h */
 /*! @} */
 
 #endif		/*_GF_CONFIG_H_*/
-

--- a/include/gpac/setup.h
+++ b/include/gpac/setup.h
@@ -730,9 +730,7 @@ void* gf_realloc(void *ptr, size_t size);
 
 /*end GPAC memory tracking*/
 
-#ifndef GPAC_HAS_STRLCPY
-size_t strlcpy(char * dst, const char * src, size_t dsize);
-#endif
+size_t gf_strlcpy(char * dst, const char * src, size_t dsize);
 
 #ifdef __cplusplus
 }

--- a/include/gpac/setup.h
+++ b/include/gpac/setup.h
@@ -730,6 +730,9 @@ void* gf_realloc(void *ptr, size_t size);
 
 /*end GPAC memory tracking*/
 
+#ifndef GPAC_HAS_STRLCPY
+size_t strlcpy(char * dst, const char * src, size_t dsize);
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/export.cpp
+++ b/src/export.cpp
@@ -170,9 +170,7 @@
 #pragma comment (linker, EXPORT_SYMBOL(gf_strdup) )
 #endif /*GPAC_MEMORY_TRACKING*/
 
-#ifndef GPAC_HAS_STRLCPY
-#pragma comment (linker, EXPORT_SYMBOL(strlcpy) )
-#endif
+#pragma comment (linker, EXPORT_SYMBOL(gf_strlcpy) )
 
 /* Sound */
 #ifndef GPAC_DISABLE_PLAYER

--- a/src/export.cpp
+++ b/src/export.cpp
@@ -170,6 +170,10 @@
 #pragma comment (linker, EXPORT_SYMBOL(gf_strdup) )
 #endif /*GPAC_MEMORY_TRACKING*/
 
+#ifndef GPAC_HAS_STRLCPY
+#pragma comment (linker, EXPORT_SYMBOL(strlcpy) )
+#endif
+
 /* Sound */
 #ifndef GPAC_DISABLE_PLAYER
 #pragma comment (linker, EXPORT_SYMBOL(gf_mixer_set_config) )
@@ -2595,4 +2599,3 @@
 #pragma comment (linker, EXPORT_SYMBOL(gf_cicp_color_primaries_all_names) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_cicp_color_transfer_all_names) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_cicp_color_matrix_all_names) )
-

--- a/src/utils/alloc.c
+++ b/src/utils/alloc.c
@@ -947,3 +947,36 @@ int gf_asprintf(char **strp, const char *fmt, ...)
 }
 
 #endif //unused
+
+#ifndef GPAC_HAS_STRLCPY
+/*
+ * FROM: https://github.com/freebsd/freebsd-src/blob/master/sys/libkern/strlcpy.c
+ * Copy string src to buffer dst of size dsize.  At most dsize-1
+ * chars will be copied.  Always NUL terminates (unless dsize == 0).
+ * Returns strlen(src); if retval >= dsize, truncation occurred.
+ */
+GF_EXPORT
+size_t strlcpy(char * dst, const char * src, size_t dsize)
+{
+	const char *osrc = src;
+	size_t nleft = dsize;
+
+	/* Copy as many bytes as will fit. */
+	if (nleft != 0) {
+		while (--nleft != 0) {
+			if ((*dst++ = *src++) == '\0')
+				break;
+		}
+	}
+
+	/* Not enough room in dst, add NUL and traverse rest of src. */
+	if (nleft == 0) {
+		if (dsize != 0)
+			*dst = '\0';		/* NUL-terminate dst */
+		while (*src++)
+			;
+	}
+
+	return(src - osrc - 1);	/* count does not include NUL */
+}
+#endif

--- a/src/utils/alloc.c
+++ b/src/utils/alloc.c
@@ -948,15 +948,23 @@ int gf_asprintf(char **strp, const char *fmt, ...)
 
 #endif //unused
 
-#ifndef GPAC_HAS_STRLCPY
 /*
  * FROM: https://github.com/freebsd/freebsd-src/blob/master/sys/libkern/strlcpy.c
+ *
+ * Copyright (c) 1998, 2015 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ */
+/*
  * Copy string src to buffer dst of size dsize.  At most dsize-1
  * chars will be copied.  Always NUL terminates (unless dsize == 0).
  * Returns strlen(src); if retval >= dsize, truncation occurred.
  */
 GF_EXPORT
-size_t strlcpy(char * dst, const char * src, size_t dsize)
+size_t gf_strlcpy(char * dst, const char * src, size_t dsize)
 {
 	const char *osrc = src;
 	size_t nleft = dsize;
@@ -979,4 +987,3 @@ size_t strlcpy(char * dst, const char * src, size_t dsize)
 
 	return(src - osrc - 1);	/* count does not include NUL */
 }
-#endif


### PR DESCRIPTION
hi all, 

[ I'm doing this as a PR to keep a record of some info ]

**TL;DR:** I added `strlcpy` and we should probably use it instead of `str[n]cpy` in most cases

I had previously mentioned [here](https://github.com/gpac/gpac/issues/1474#issuecomment-728248865) that `str[n]cpy` causes some issues and that there are discussions about good alternatives.

To add to this, I'll paste an email I wrote elsewhere (in french, sorry) with more info : 

<hr />

* pour strncpy c'est toute une saga ...

En gros souvent quand on l'utilise ce qu'on veut qu'il fasse c'est :

1. copie ce que tu peux de source vers destination
2. si tu dois tronquer fais le
3. assure un \0 à la fin

Et strncpy ne fait pas ca. En particulier il ne garantis pas 3. Il ajoute aussi du padding inutile avec des 0 quand dest>src.  Et du coup gcc rajoute en plus des warnings s'il détecte des cas possibles de truncation (le cas classique est quand on passe strlen(src) comme limite, il gueule parce que si c'est trop grand blablabla) c'est le bordel.


Il se trouve qu'il existe une fonction qui fais exactement ces 3 choses et qui s'appelle **strlcpy** (https://linux.die.net/man/3/strlcpy).

Problème : elle vient du monde BSD et il y a des discussions depuis août 2000 (!) pour savoir si oui ou non il faut l'intégrer à la glibc et les camps pour et contre se font la guerre depuis (le monde de l'open-source est incroyable parfois).


Du coup il en existe plein d'implémentations et les gens intègrent ca à leurs projets quand ils en ont besoin. Je pense qu'on pourrait faire ca aussi et créer une gf_strlcpy en prenant par exemple l'implémentation de freebsd: https://github.com/freebsd/freebsd/blob/master/sys/libkern/strlcpy.c

L'idée c'est de l'utiliser avec

```c
strlcpy(dest, src, sizeof(dest))  // copie au max sizeof(dest)-1 caractères et ajoute toujours un \0 à la fin
```

et si on veut être propre et gérer les truncations on peut faire :

```c
if ( strlcpy(dest, src, sizeof(dest)) >= sizeof(dest) )
    // warning
```


<hr />


So I added the freebsd implementation and a configure check so that if it's ever added to the glibc it should just be a drop-in replacement. 

It's actually not a big thing but since there are endless debates around these things I thought I'd keep track of the reasoning.

I haven't started to use strlcpy in gpac apart for one specific overflow case in mp4box main() but there are probably a few places that would benefit from it. 


