### PR TITLE
Added a fuzzer for initial integration with OSS-Fuzz.

### DIFF
--- a/fuzzers/fuzz_parse.c
+++ b/fuzzers/fuzz_parse.c
@@ -1,0 +1,25 @@
+#include <stdio.h>
+#include <unistd.h>
+
+#include <gpac/internal/isomedia_dev.h>
+#include <gpac/constants.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    char filename[256];
+    sprintf(filename, "/tmp/libfuzzer.%d", getpid());
+
+    FILE *fp = fopen(filename, "wb");
+    if (!fp) {
+        return 0;
+    }
+    fwrite(data, size, 1, fp);
+    fclose(fp);
+
+    GF_ISOFile *movie = NULL;
+    movie = gf_isom_open_file(filename, GF_ISOM_OPEN_READ_DUMP, NULL);
+    if (movie != NULL) {
+        gf_isom_close(movie);
+    }
+    unlink(filename);
+    return 0;
+}


### PR DESCRIPTION
Hi Maintainers,

I have worked a bit on setting fuzzing up for gpac by way of OSS-Fuzz. Essentially, OSS-Fuzz is a free service run by Google that performs continuous fuzzing of important open source projects, and it would be great to have gpac integrated. The only expectation of integrating into OSS-Fuzz is that bugs will be fixed. This is not a "hard" requirement in that no one enforces this and the main point is if bugs are not fixed then it is a waste of resources to run the fuzzers, which we would like to avoid.

In this PR https://github.com/google/oss-fuzz/pull/5289 I have done exactly that, namely created the necessary logic from an OSS-Fuzz perspective to integrate gpac. If you would like to integrate, could you please provide a set of email(s) that will get access to the data produced by OSS-Fuzz, such as bug reports, coverage reports and more stats. The emails should be linked to a Google account in order to view the detailed reports and notice the emails affiliated with the project will be public in the OSS-Fuzz repo, as they will be part of a configuration file.

At the moment I stored the fuzzers in the Google OSS-Fuzz repository, but we can move them up here to make maintenance easier.