### PR TITLE
fix parsing of layered AV1 streams with varying tile config

### DIFF
--- a/include/gpac/internal/media_dev.h
+++ b/include/gpac/internal/media_dev.h
@@ -859,6 +859,9 @@ typedef struct
 	AV1GMParams SavedGmParams[AV1_NUM_REF_FRAMES];
 	u8 RefFrameType[AV1_NUM_REF_FRAMES];
 
+	u32 RefUpscaledWidth[AV1_NUM_REF_FRAMES];
+	u32 RefFrameHeight[AV1_NUM_REF_FRAMES];
+
 	/*frame parsing state*/
 	AV1StateFrame frame_state;
 } AV1State;

--- a/src/filters/inspect.c
+++ b/src/filters/inspect.c
@@ -1201,8 +1201,8 @@ static u64 gf_inspect_dump_obu_internal(FILE *dump, AV1State *av1, u8 *obu, u64 
 	switch (obu_type) {
 	case OBU_SEQUENCE_HEADER:
 		if (full_dump) break;
-		DUMP_OBU_INT(width)
-		DUMP_OBU_INT(height)
+		DUMP_OBU_INT(sequence_width)
+		DUMP_OBU_INT(sequence_height)
 		DUMP_OBU_INT(bit_depth)
 		DUMP_OBU_INT(still_picture)
 		DUMP_OBU_INT(OperatingPointIdc)
@@ -1233,6 +1233,8 @@ static u64 gf_inspect_dump_obu_internal(FILE *dump, AV1State *av1, u8 *obu, u64 
 
 				DUMP_OBU_INT2("show_frame", av1->frame_state.show_frame);
 				DUMP_OBU_INT2("show_existing_frame", av1->frame_state.show_existing_frame);
+				DUMP_OBU_INT(width);
+				DUMP_OBU_INT(height);
 			}
 			if (obu_type==OBU_FRAME_HEADER)
 				break;

--- a/src/media_tools/av_parsers.c
+++ b/src/media_tools/av_parsers.c
@@ -3417,7 +3417,7 @@ static void av1_parse_uncompressed_header(GF_BitStream *bs, AV1State *state)
 	else
 		frame_size_override_flag = gf_bs_read_int_log(bs, 1, "frame_size_override_flag");
 
-	frame_state->order_hint = gf_bs_read_int(bs, state->OrderHintBits);
+	frame_state->order_hint = gf_bs_read_int_log(bs, state->OrderHintBits, "order_hint");
 	if (FrameIsIntra || error_resilient_mode) {
 		primary_ref_frame = AV1_PRIMARY_REF_NONE;
 	}
@@ -3553,7 +3553,7 @@ static void av1_parse_uncompressed_header(GF_BitStream *bs, AV1State *state)
 
 	av1_parse_tile_info(bs, state);
 	//quantization_params( ):
-	u8 base_q_idx = gf_bs_read_int(bs, 8);
+	u8 base_q_idx = gf_bs_read_int_log(bs, 8, "base_q_idx");
 	s32 DeltaQUDc = 0;
 	s32 DeltaQUAc = 0;
 	s32 DeltaQVDc = 0;
@@ -3562,7 +3562,7 @@ static void av1_parse_uncompressed_header(GF_BitStream *bs, AV1State *state)
 	if (!state->config->monochrome) {
 		u8 diff_uv_delta = 0;
 		if (state->separate_uv_delta_q)
-			diff_uv_delta = gf_bs_read_int(bs, 1);
+			diff_uv_delta = gf_bs_read_int_log(bs, 1, "diff_uv_delta");
 
 		DeltaQUDc = av1_delta_q(bs, "DeltaQUDc_coded", "DeltaQUDc");
 		DeltaQUAc = av1_delta_q(bs, "DeltaQUAc_coded", "DeltaQUAc");
@@ -4003,7 +4003,7 @@ static GF_Err av1_parse_tile_group(GF_BitStream *bs, AV1State *state, u64 obu_st
 	Bool tile_start_and_end_present_flag = GF_FALSE;
 	GF_Err e = GF_OK;
 	if (numTiles > 1)
-		tile_start_and_end_present_flag = gf_bs_read_int(bs, 1);
+		tile_start_and_end_present_flag = gf_bs_read_int_log(bs, 1, "tile_start_and_end_present_flag");
 
 	if (numTiles == 1 || !tile_start_and_end_present_flag) {
 		tg_start = 0;
@@ -4013,8 +4013,8 @@ static GF_Err av1_parse_tile_group(GF_BitStream *bs, AV1State *state, u64 obu_st
 	}
 	else {
 		u32 tileBits = state->tileColsLog2 + state->tileRowsLog2;
-		/*state->frame_state.tg[state->frame_state.tg_idx].start_idx*/ tg_start = gf_bs_read_int(bs, tileBits);
-		/*state->frame_state.tg[state->frame_state.tg_idx].end_idx*/ tg_end = gf_bs_read_int(bs, tileBits);
+		/*state->frame_state.tg[state->frame_state.tg_idx].start_idx*/ tg_start = gf_bs_read_int_log(bs, tileBits, "tg_start");
+		/*state->frame_state.tg[state->frame_state.tg_idx].end_idx*/ tg_end = gf_bs_read_int_log(bs, tileBits, "tg_end");
 	}
 	/*state->frame_state.tg_idx++;*/
 


### PR DESCRIPTION
Current MP4Box cannot parse multi-layered streams where the resolution and tiling changes. This fixes the bug.