### PR TITLE
Verify JFIF markers before reading

### DIFF
--- a/src/media_tools/img.c
+++ b/src/media_tools/img.c
@@ -81,7 +81,7 @@ void gf_img_parse(GF_BitStream *bs, u32 *codecid, u32 *width, u32 *height, u8 **
 
 		/*get frame header FFC0*/
 		while (gf_bs_available(bs)) {
-			u32 w, h;
+			u32 w, h,length, prec;
 			if (gf_bs_read_u8(bs) != 0xFF) continue;
 			if (!offset) offset = (u32)gf_bs_get_position(bs) - 1;
 
@@ -101,14 +101,16 @@ void gf_img_parse(GF_BitStream *bs, u32 *codecid, u32 *width, u32 *height, u8 **
 			case 0xCD:
 			case 0xCE:
 			case 0xCF:
-				gf_bs_skip_bytes(bs, 3);
+                length = gf_bs_read_u16(bs);
+                prec = gf_bs_read_u8(bs);
 				h = gf_bs_read_int(bs, 16);
 				w = gf_bs_read_int(bs, 16);
+                nb_comp = gf_bs_read_int(bs, 8);
+                if (length != 8 + 3*nb_comp) continue;  //This is not the right marker
 				if ((w > *width) || (h > *height)) {
 					*width = w;
 					*height = h;
 				}
-				nb_comp = gf_bs_read_int(bs, 8);
 				break;
 			}
 		}


### PR DESCRIPTION
On some JPEG files, the 0xFF + 0xC0/C1 markers could be contained before the actual start of frame. This may lead to inconsistency between the size extracted from rfimg filter and the one from imgdec (in my case it crashes the display).

This is a very small fix taken from this description :
http://vip.sugovica.hu/Sardi/kepnezo/JPEG%20File%20Layout%20and%20Format.htm

where Length should be equal "to 8 + components*3 value" in case it could be usefull to you.

Enclosed is a jpeg file to reproduce this error.
![bird](https://user-images.githubusercontent.com/2871591/115463470-22bcee80-a22c-11eb-8db4-8e24cde189fc.JPG)


