### PR TITLE
Improve the desktop bits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,6 @@ extra_lib/include/
 config.mak
 configure-stamp
 gpac.pc
-share/gpac.desktop
 tests/external_media/
 tests/results/
 tests/hash_refs/

--- a/Makefile
+++ b/Makefile
@@ -156,10 +156,10 @@ endif
 	$(INSTALL) $(INSTFLAGS) -m 644 $(SRC_PATH)/share/default.cfg $(DESTDIR)$(prefix)/share/gpac/
 
 ifneq ($(CONFIG_DARWIN),yes)
-	$(INSTALL) -d "$(DESTDIR)$(prefix)/share/pixmaps"
+	$(INSTALL) -d "$(DESTDIR)$(prefix)/share/icons/hicolor/128x128/apps"
 	$(INSTALL) -d "$(DESTDIR)$(prefix)/share/applications"
 
-	$(INSTALL) $(INSTFLAGS) -m 644 $(SRC_PATH)/share/res/gpac.png "$(DESTDIR)$(prefix)/share/pixmaps/"
+	$(INSTALL) $(INSTFLAGS) -m 644 $(SRC_PATH)/share/res/gpac.png "$(DESTDIR)$(prefix)/share/icons/hicolor/128x128/apps/"
 	$(INSTALL) $(INSTFLAGS) -m 644 $(SRC_PATH)/share/gpac.desktop "$(DESTDIR)$(prefix)/share/applications/"
 endif
 
@@ -213,7 +213,7 @@ else
 	ln -s $(BUILD_PATH)/bin/gcc/ $(DESTDIR)$(prefix)/$(lib_dir)/gpac
 
 	ln -s $(SRC_PATH)/share/ $(DESTDIR)$(prefix)/share/gpac
-	ln -sf $(DESTDIR)$(prefix)/share/gpac/res/gpac.png $(DESTDIR)/usr/share/pixmaps/gpac.png
+	ln -sf $(DESTDIR)$(prefix)/share/gpac/res/gpac.png $(DESTDIR)/usr/share/icons/hicolor/128x128/apps/gpac.png
 	ln -sf $(SRC_PATH)/share/gpac.desktop $(DESTDIR)/usr/share/applications/
 
 ifeq ($(DESTDIR)$(prefix),$(prefix))
@@ -234,7 +234,7 @@ uninstall:
 	rm -rf $(DESTDIR)$(prefix)/$(man_dir)/man1/gpac.1
 	rm -rf $(DESTDIR)$(prefix)/$(man_dir)/man1/gpac-filters.1
 	rm -rf $(DESTDIR)$(prefix)/share/gpac
-	rm -rf $(DESTDIR)$(prefix)/share/pixmaps/gpac.png
+	rm -rf $(DESTDIR)$(prefix)/share/icons/hicolor/128x128/apps/gpac.png
 	rm -rf $(DESTDIR)$(prefix)/share/applications/gpac.desktop
 
 

--- a/configure
+++ b/configure
@@ -3455,7 +3455,7 @@ generate_gpacdesktop () {
 	echo "Terminal=false"
 	echo "X-MultipleArgs=false"
 	echo "Type=Application"
-	echo "Icon=$prefix/share/pixmaps/gpac.png"
+	echo "Icon=gpac"
 	echo "Categories=AudioVideo"
 	echo "MimeType=text/text;text/xml;application/xhtml+xml;application/xml;image/jpeg;image/png;video/webm;video/mp4;video/mpeg;audio/mp4;audio/mpeg;x-scheme-handler/rtsp;x-scheme-handler/rtp;x-scheme-handler/route"
 	echo "StartupNotify=true"

--- a/configure
+++ b/configure
@@ -3444,31 +3444,6 @@ generate_pkgconfig () {
 generate_pkgconfig > gpac.pc
 
 
-generate_gpacdesktop () {
-	echo "[Desktop Entry]"
-	echo "Version=1.0"
-	echo "Name=MP4Client"
-	echo "Comment=GPAC Media Player"
-	echo "GenericName=Media Player"
-	echo "Keywords=Media Player"
-	echo "Exec=MP4Client -gui %u"
-	echo "Terminal=false"
-	echo "X-MultipleArgs=false"
-	echo "Type=Application"
-	echo "Icon=gpac"
-	echo "Categories=AudioVideo"
-	echo "MimeType=text/text;text/xml;application/xhtml+xml;application/xml;image/jpeg;image/png;video/webm;video/mp4;video/mpeg;audio/mp4;audio/mpeg;x-scheme-handler/rtsp;x-scheme-handler/rtp;x-scheme-handler/route"
-	echo "StartupNotify=true"
-	echo "Actions=new-window"
-	echo ""
-	echo "[Desktop Action new-window]"
-	echo "Name=Open a New Window"
-	echo "Exec=MP4Client"
-	echo ""
-}
-
-generate_gpacdesktop > "$source_path/share/gpac.desktop"
-
 if test "$static_bin" = "yes"; then
  if test "$darwin" = "yes" ; then
   echo "\nWarning: static binaries on OSX cannot remove all dependendencies to system libraries\n"

--- a/debian/gpac.install
+++ b/debian/gpac.install
@@ -6,7 +6,7 @@ debian/tmp/usr/share/gpac/res
 debian/tmp/usr/share/gpac/gui
 debian/tmp/usr/share/gpac/shaders
 debian/tmp/usr/share/gpac/scripts
-debian/tmp/usr/share/pixmaps
+debian/tmp/usr/share/icons
 debian/tmp/usr/share/applications
 
 

--- a/share/gpac.desktop
+++ b/share/gpac.desktop
@@ -6,7 +6,6 @@ GenericName=Media Player
 Keywords=Media Player
 Exec=MP4Client -gui %u
 Terminal=false
-X-MultipleArgs=false
 Type=Application
 Icon=gpac
 Categories=AudioVideo

--- a/share/gpac.desktop
+++ b/share/gpac.desktop
@@ -1,0 +1,19 @@
+[Desktop Entry]
+Version=1.0
+Name=MP4Client
+Comment=GPAC Media Player
+GenericName=Media Player
+Keywords=Media Player
+Exec=MP4Client -gui %u
+Terminal=false
+X-MultipleArgs=false
+Type=Application
+Icon=gpac
+Categories=AudioVideo
+MimeType=text/text;text/xml;application/xhtml+xml;application/xml;image/jpeg;image/png;video/webm;video/mp4;video/mpeg;audio/mp4;audio/mpeg;x-scheme-handler/rtsp;x-scheme-handler/rtp;x-scheme-handler/route
+StartupNotify=true
+Actions=new-window
+
+[Desktop Action new-window]
+Name=Open a New Window
+Exec=MP4Client


### PR DESCRIPTION
- install the application icon in the XDG hicolor icon theme, rather than the legacy pixmaps location
- make `gpac.desktop` file static, as it does not change anymore
- drop an extra key in `gpac.desktop`