### PR TITLE
use correct type to allocate GF_VVCConfigurationBox

### DIFF
--- a/src/isomedia/avc_ext.c
+++ b/src/isomedia/avc_ext.c
@@ -3005,7 +3005,7 @@ GF_Err vvcc_box_read(GF_Box *s, GF_BitStream *bs)
 
 GF_Box *vvcc_box_new()
 {
-	ISOM_DECL_BOX_ALLOC(GF_VVCNaluConfigurationBox, GF_ISOM_BOX_TYPE_VVCC);
+	ISOM_DECL_BOX_ALLOC(GF_VVCConfigurationBox, GF_ISOM_BOX_TYPE_VVCC);
 	return (GF_Box *)tmp;
 }
 


### PR DESCRIPTION
This was probably a copy and paste error.