### PR TITLE
fix POC reset for IDR with leading pics (#1913)

### DIFF
--- a/include/gpac/internal/media_dev.h
+++ b/include/gpac/internal/media_dev.h
@@ -691,6 +691,7 @@ typedef struct
 	u32 frame_num, poc_lsb, slice_type;
 
 	u8 poc_msb_cycle_present_flag;
+	u8 poc_msb_reset;
 	s32 poc;
 	u32 poc_msb, poc_msb_cycle, poc_msb_prev, poc_lsb_prev, frame_num_prev;
 

--- a/src/filters/mux_isom.c
+++ b/src/filters/mux_isom.c
@@ -3777,6 +3777,8 @@ static GF_Err mp4_mux_process_sample(GF_MP4MuxCtx *ctx, TrackWriter *tkw, GF_Fil
 	}
 	if (sap_type==GF_FILTER_SAP_1)
 		tkw->sample.IsRAP = SAP_TYPE_1;
+	else if (sap_type==GF_FILTER_SAP_2)
+		tkw->sample.IsRAP = SAP_TYPE_2;
 	else if ( (sap_type == GF_FILTER_SAP_4) && (tkw->stream_type != GF_STREAM_VISUAL) )
 		tkw->sample.IsRAP = SAP_TYPE_1;
 

--- a/src/filters/reframe_nalu.c
+++ b/src/filters/reframe_nalu.c
@@ -3239,6 +3239,7 @@ naldmx_flush:
 					if( au_sap_type == GF_FILTER_SAP_2 && ctx->max_last_poc < ctx->last_poc){
 						ctx->max_last_b_poc = 0;
 						ctx->max_last_poc = ctx->last_poc;
+						ctx->poc_shift = ctx->last_poc;
 					}
 					else {
 						ctx->max_last_poc = ctx->last_poc = ctx->max_last_b_poc = 0;

--- a/src/filters/reframe_nalu.c
+++ b/src/filters/reframe_nalu.c
@@ -1823,7 +1823,7 @@ static void naludmx_finalize_au_flags(GF_NALUDmxCtx *ctx)
 		return;
 	if (ctx->au_sap) {
 		gf_filter_pck_set_sap(ctx->first_pck_in_au, ctx->au_sap);
-		if (ctx->au_sap == GF_FILTER_SAP_1) {
+		if (ctx->au_sap == GF_FILTER_SAP_1 || ctx->au_sap == GF_FILTER_SAP_2) {
 			ctx->dts_last_IDR = gf_filter_pck_get_dts(ctx->first_pck_in_au);
 			if (ctx->is_paff)
 				ctx->dts_last_IDR *= 2;
@@ -3034,8 +3034,11 @@ naldmx_flush:
 					slice_is_idr = 0;
 					break;
 				case GF_VVC_NALU_SLICE_IDR_N_LP:
-				case GF_VVC_NALU_SLICE_IDR_W_RADL:
 					au_sap_type = GF_FILTER_SAP_1;
+					break;
+				case GF_VVC_NALU_SLICE_IDR_W_RADL:
+					au_sap_type = GF_FILTER_SAP_2;
+					slice_is_idr = 0;
 					break;
 				}
 			} else {

--- a/src/filters/reframe_nalu.c
+++ b/src/filters/reframe_nalu.c
@@ -3038,7 +3038,7 @@ naldmx_flush:
 					break;
 				case GF_VVC_NALU_SLICE_IDR_W_RADL:
 					au_sap_type = GF_FILTER_SAP_2;
-					slice_is_idr = 0;
+					slice_is_idr = 1;
 					break;
 				}
 			} else {
@@ -3236,10 +3236,16 @@ naldmx_flush:
 					//new ref frame, dispatch all pending packets
 					naludmx_enqueue_or_dispatch(ctx, NULL, GF_TRUE);
 
-					ctx->max_last_poc = ctx->last_poc = ctx->max_last_b_poc = 0;
-					ctx->poc_shift = 0;
-					//force probing of POC diff, this will prevent dispatching frames with wrong CTS until we have a clue of min poc_diff used
-					ctx->poc_probe_done = 0;
+					if( au_sap_type == GF_FILTER_SAP_2 && ctx->max_last_poc < ctx->last_poc){
+						ctx->max_last_b_poc = 0;
+						ctx->max_last_poc = ctx->last_poc;
+					}
+					else {
+						ctx->max_last_poc = ctx->last_poc = ctx->max_last_b_poc = 0;
+						ctx->poc_shift = 0;
+						//force probing of POC diff, this will prevent dispatching frames with wrong CTS until we have a clue of min poc_diff used
+						ctx->poc_probe_done = 0;
+					}
 					ctx->last_frame_is_idr = GF_TRUE;
 					if (temp_poc_diff)
 						ctx->poc_diff = 0;

--- a/src/isomedia/media.c
+++ b/src/isomedia/media.c
@@ -1047,7 +1047,7 @@ GF_Err Media_AddSample(GF_MediaBox *mdia, u64 data_offset, const GF_ISOSample *s
 	//The first non sync sample we see must create a syncTable
 	if (sample->IsRAP) {
 		//insert it only if we have a sync table and if we have an IDR slice
-		if (stbl->SyncSample && (sample->IsRAP == RAP)) {
+		if (stbl->SyncSample && (sample->IsRAP == RAP || sample->IsRAP == SAP_TYPE_2)) {
 			e = stbl_AddRAP(stbl->SyncSample, sampleNumber);
 			if (e) return e;
 		}

--- a/src/media_tools/av_parsers.c
+++ b/src/media_tools/av_parsers.c
@@ -9825,7 +9825,10 @@ static void vvc_compute_poc(VVCSliceInfo *si)
 	u32 max_poc_lsb = 1 << (si->sps->log2_max_poc_lsb);
 
 	if (si->poc_msb_cycle_present_flag) {
-		si->poc_msb = si->poc_msb_cycle;
+		si->poc_msb = si->poc_msb_cycle * max_poc_lsb;
+	}
+	else if (si->poc_msb_reset) {
+		si->poc_msb = 0;
 	} else {
 		if ((si->poc_lsb < si->poc_lsb_prev) && (si->poc_lsb_prev - si->poc_lsb >= max_poc_lsb / 2))
 			si->poc_msb = si->poc_msb_prev + max_poc_lsb;
@@ -9879,8 +9882,10 @@ s32 gf_media_vvc_parse_nalu_bs(GF_BitStream *bs, VVCState *vvc, u8 *nal_unit_typ
 			is_slice = GF_TRUE;
 			n_state.compute_poc_defer = 0;
 			if (poc_reset) {
-				n_state.poc_lsb_prev = 0;
-				n_state.poc_msb_prev = 0;
+				n_state.poc_msb_reset = 1;
+			}
+			else{
+				n_state.poc_msb_reset = 0;
 			}
 
 			vvc_compute_poc(&n_state);


### PR DESCRIPTION
I needed to set `slice_is_idr = 0` for IDR_W_LP slices, also. I am not sure if that is correct or produces any other problems, but it fixed the CTS calculation for me.