### PR TITLE
Don't scale duration twice. Fixes #2082

### DIFF
--- a/applications/mp4box/fileimport.c
+++ b/applications/mp4box/fileimport.c
@@ -541,7 +541,6 @@ GF_Err apply_edits(GF_ISOFile *dest, u32 track, char *edits)
 				edur = edit_dur.num;
 				edur *= movie_ts;
 				edur /= edit_dur.den;
-				edur /= movie_time.den;
 				if (edur>media_dur)
 					edur = media_dur;
 			}


### PR DESCRIPTION
As per #2082

removing division movie_time.den fixes the edit duration:

```MP4Box bbb_sunflower_1080p_30fps_normal.mp4 -edits 1=re0.1-5,0.1 -out tmp.mp4```

```
<MovieHeaderBox Size="108" Type="mvhd" Version="0" Flags="0" Specification="p12" Container="moov" CreationTime="3470060679" ModificationTime="3470060679" TimeScale="600" Duration="380520" NextTrackID="4">

...

<EditBox Size="48" Type="edts" Specification="p12" Container="trak" >
<EditListBox Size="40" Type="elst" Version="0" Flags="0" Specification="p12" Container="edts" EntryCount="2">
<EditListEntry Duration="60" MediaTime="-1" MediaRate="1"/>
<EditListEntry Duration="3000" MediaTime="3000" MediaRate="1"/>
</EditListBox>
</EditBox>
```

It is now correct at 5 seconds.