### PR TITLE
adding Opus packet inspection

### DIFF
--- a/include/gpac/internal/media_dev.h
+++ b/include/gpac/internal/media_dev.h
@@ -1015,6 +1015,33 @@ u32 gf_av1_leb128_size(u64 value);
 u64 gf_av1_leb128_write(GF_BitStream *bs, u64 value);
 GF_Err gf_av1_parse_obu_header(GF_BitStream *bs, ObuType *obu_type, Bool *obu_extension_flag, Bool *obu_has_size_field, u8 *temporal_id, u8 *spatial_id);
 
+/*! OPUS packet header*/
+typedef struct
+{
+    Bool self_delimited;
+
+    // parsed header size
+    u8 size;
+
+    u16 self_delimited_length;
+    u8 TOC_config;
+    u8 TOC_stereo;
+    u8 TOC_code;
+    u16 code2_frame_length;
+    u8 code3_vbr;
+    u8 code3_padding;
+    u16 code3_padding_length;
+
+    u8 nb_frames;
+    // either explicitly coded (e.g. self_delimited) or computer (e.g. cbr)
+    u16 frame_lengths[255];
+
+    // computed packet size
+    u32 packet_size;
+} GF_OpusPacketHeader;
+
+u8 gf_opus_parse_packet_header(u8 *data, u32 data_length, Bool self_delimited, GF_OpusPacketHeader *header);
+
 typedef struct
 {
 	u32 picture_size;

--- a/src/export.cpp
+++ b/src/export.cpp
@@ -1449,9 +1449,9 @@
 
 #pragma comment (linker, EXPORT_SYMBOL(gf_inspect_dump_nalu) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_inspect_dump_obu) )
+#pragma comment (linker, EXPORT_SYMBOL(gf_inspect_dump_opus_packet) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_inspect_dump_prores) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_inspect_format_timecode) )
-
 
 #ifndef GPAC_DISABLE_ISOM_WRITE
 #pragma comment (linker, EXPORT_SYMBOL(gf_media_change_par) )

--- a/src/filters/inspect.c
+++ b/src/filters/inspect.c
@@ -1499,6 +1499,39 @@ void gf_inspect_dump_prores(FILE *dump, u8 *ptr, u64 frame_size, Bool dump_crc)
 {
 	gf_inspect_dump_prores_internal(dump, ptr, frame_size, dump_crc, NULL);
 }
+
+static void gf_inspect_dump_opus_packet_internal(FILE *dump, u8 *ptr, u32 size, u32 pck_offset, GF_OpusPacketHeader pckh, Bool dump_crc, PidCtx *pctx)
+{
+    gf_fprintf(dump, "    <OpusPacket offset=\"%d\" self_delimited=\"%d\"", pck_offset, pckh.self_delimited);
+    gf_fprintf(dump, " header_size=\"%d\" config=\"%d\" stereo=\"%d\" code=\"%d\"", pckh.size, pckh.TOC_config, pckh.TOC_stereo, pckh.TOC_code);
+    if (pckh.TOC_code == 0) {
+        gf_fprintf(dump, " nb_frames=\"%d\" frame_lengths=\"%d\"/>\n", pckh.nb_frames, pckh.frame_lengths[0]);
+    } else if (pckh.TOC_code == 1) {
+        gf_fprintf(dump, " nb_frames=\"%d\" frame_lengths=\"%d %d\"/>\n", pckh.nb_frames, pckh.frame_lengths[0], pckh.frame_lengths[1]);
+    } else if (pckh.TOC_code == 2) {
+        gf_fprintf(dump, " nb_frames=\"%d\" frame_lengths=\"%d %d\"/>\n", pckh.nb_frames, pckh.frame_lengths[0], pckh.frame_lengths[1]);
+    } else if (pckh.TOC_code == 3) {
+        u32 j;
+        gf_fprintf(dump, " vbr=\"%d\" padding=\"%d\" padding_length=\"%d\" nb_frames=\"%d\"", pckh.code3_vbr, pckh.code3_padding, pckh.code3_padding_length, pckh.nb_frames);
+        gf_fprintf(dump, " frame_lengths=\"");
+        for(j=0;j<pckh.nb_frames;j++) {
+            if (j!=0) fprintf(dump, " ");
+            gf_fprintf(dump, "%d", pckh.frame_lengths[j]);
+        }
+        gf_fprintf(dump, "\"");
+        if (dump_crc) {
+            gf_fprintf(dump, " crc=\"%d\"" , gf_crc_32(ptr, (u32) size) );
+        }
+        gf_fprintf(dump, "/>\n");
+    }
+}
+
+GF_EXPORT
+void gf_inspect_dump_opus_packet(FILE *dump, u8 *ptr, u64 size, u32 pck_offset, GF_OpusPacketHeader pckh, Bool dump_crc)
+{
+    gf_inspect_dump_opus_packet_internal(dump, ptr, size, pck_offset, pckh, dump_crc, NULL);
+}
+
 enum {
 	MHAS_FILLER = 0,
 	MHAS_CONFIG,

--- a/src/isomedia/box_dump.c
+++ b/src/isomedia/box_dump.c
@@ -4342,7 +4342,7 @@ GF_Err dimC_box_dump(GF_Box *a, FILE * trace)
 	return GF_OK;
 }
 
-
+GF_EXPORT
 GF_Err dOps_box_dump(GF_Box *a, FILE * trace)
 {
 	GF_OpusSpecificBox *p = (GF_OpusSpecificBox *)a;

--- a/src/isomedia/sample_descs.c
+++ b/src/isomedia/sample_descs.c
@@ -487,6 +487,24 @@ GF_Err gf_isom_opus_config_new(GF_ISOFile *the_file, u32 trackNumber, GF_OpusSpe
 #endif
 
 GF_EXPORT
+GF_OpusSpecificBox *gf_opus_parse_specific_info(u8 *opus_dsi, u32 opus_dsi_size)
+{
+    GF_Err e;
+    GF_BitStream *bs;
+    GF_Box *dOps;
+    bs = gf_bs_new(opus_dsi, opus_dsi_size, GF_BITSTREAM_READ);
+    e = gf_isom_box_parse(&dOps, bs);
+    if (e != GF_OK) {
+        gf_free(dOps);
+        gf_bs_del(bs);
+        GF_LOG(GF_LOG_ERROR, GF_LOG_CODING, ("Error parsing Opus header!\n"));
+        return NULL;
+    }
+    gf_bs_del(bs);
+    return dOps;
+}
+
+GF_EXPORT
 GF_Err gf_isom_opus_config_get(GF_ISOFile *the_file, u32 trackNumber, u32 StreamDescriptionIndex, u8 **dsi, u32 *dsi_size)
 {
 	u32 type;

--- a/src/media_tools/av_parsers.c
+++ b/src/media_tools/av_parsers.c
@@ -9482,6 +9482,366 @@ u32 gf_opus_check_frame(GF_OpusParser *op, u8 *data, u32 data_length)
 	return block_size;
 }
 
+/* return nb bytes read */
+static u8 gf_opus_read_length(u8 *data, u32 data_length, u32 offset, u16 *read_length) {
+    if (!data || !data_length || !read_length) {
+        GF_LOG(GF_LOG_ERROR, GF_LOG_CODING, ("Cannot read Opus length value\n"));
+        return 0;
+    }
+    if (offset >= data_length) {
+        GF_LOG(GF_LOG_ERROR, GF_LOG_CODING, ("Not enough bytes to read Opus length\n"));
+        return 0;
+    }
+    if (data[offset] < 252) {
+        *read_length = data[offset];
+        return 1;
+    } else {
+        if (offset+1 >= data_length) {
+            GF_LOG(GF_LOG_ERROR, GF_LOG_CODING, ("Not enough bytes to read 2-byte Opus length\n"));
+            return 0;
+        }
+        *read_length = data[offset+1]*4+data[offset];
+        return 2;
+    }
+}
+
+GF_EXPORT
+u8 gf_opus_parse_packet_header(u8 *data, u32 data_length, Bool self_delimited, GF_OpusPacketHeader *header)
+{
+    int i;
+    int nb_read_bytes = 0;
+    if (!header)
+        return 0;
+    if (!memcmp(data, "OpusHead", sizeof(char)*8))
+        return 0;
+    if (!memcmp(data, "OpusTags", sizeof(char)*8))
+        return 0;
+
+    GF_LOG(GF_LOG_DEBUG, GF_LOG_CODING, ("Processing Opus packet, self: %d, size %d\n", self_delimited, data_length));
+
+    if (data_length < 1) {
+        GF_LOG(GF_LOG_ERROR, GF_LOG_CODING, ("Opus packet size must be at least one to parse TOC byte\n"));
+        return 0;
+    }
+    memset(header, 0, sizeof(GF_OpusPacketHeader));
+    header->self_delimited = self_delimited;
+    header->TOC_config = (data[0] & 0xf8) >> 3;
+    header->TOC_stereo = (data[0] & 0x4) >> 2;
+    header->TOC_code = data[0] & 0x03;
+    header->size = 1;
+    if (header->TOC_code == 0) {
+        header->nb_frames = 1;
+        if (self_delimited) {
+            nb_read_bytes = gf_opus_read_length(data, data_length, header->size, &header->self_delimited_length);
+            if (nb_read_bytes) {
+                header->size += nb_read_bytes;
+            } else {
+                GF_LOG(GF_LOG_ERROR, GF_LOG_CODING, ("Could not read self delimited length in Opus packet code 0\n"));
+                return 0;
+            }
+//            0                   1                   2                   3
+//            0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+//           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//           | config  |s|0|0| N1 (1-2 bytes):                               |
+//           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+                               |
+//           |               Compressed frame 1 (N1 bytes)...                :
+//           :                                                               |
+//           |                                                               |
+//           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+            header->frame_lengths[0] = header->self_delimited_length;
+        } else {
+//            0                   1                   2                   3
+//            0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+//           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//           | config  |s|0|0|                                               |
+//           +-+-+-+-+-+-+-+-+                                               |
+//           |                    Compressed frame 1 (N-1 bytes)...          :
+//           :                                                               |
+//           |                                                               |
+//           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+            header->frame_lengths[0] = data_length - header->size;
+        }
+        header->packet_size = header->size + header->frame_lengths[0];
+    } else if (header->TOC_code == 1) {
+        header->nb_frames = 2;
+        if (self_delimited) {
+            nb_read_bytes = gf_opus_read_length(data, data_length, header->size, &header->self_delimited_length);
+            if (nb_read_bytes) {
+                header->size += nb_read_bytes;
+            } else {
+                GF_LOG(GF_LOG_ERROR, GF_LOG_CODING, ("Could not read self delimited length in Opus packet code 1\n"));
+                return 0;
+            }
+//            0                   1                   2                   3
+//            0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+//           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//           | config  |s|0|1| N1 (1-2 bytes):                               |
+//           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+                               :
+//           |               Compressed frame 1 (N1 bytes)...                |
+//           :                               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//           |                               |                               |
+//           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+                               :
+//           |               Compressed frame 2 (N1 bytes)...                |
+//           :                                               +-+-+-+-+-+-+-+-+
+//           |                                               |
+//           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+            header->frame_lengths[0] = header->self_delimited_length;
+            header->frame_lengths[1] = header->self_delimited_length;
+        } else {
+//            0                   1                   2                   3
+//            0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+//           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//           | config  |s|0|1|                                               |
+//           +-+-+-+-+-+-+-+-+                                               :
+//           |             Compressed frame 1 ((N-1)/2 bytes)...             |
+//           :                               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//           |                               |                               |
+//           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+                               :
+//           |             Compressed frame 2 ((N-1)/2 bytes)...             |
+//           :                                               +-+-+-+-+-+-+-+-+
+//           |                                               |
+//           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+            if ((data_length-header->size) % 2) {
+                GF_LOG(GF_LOG_ERROR, GF_LOG_CODING, ("Size of non-self-delimited Opus packet with code 2 must be even but is %d\n",data_length-header->size));
+                return 0;
+            }
+            header->frame_lengths[0] = (data_length-header->size)/2;
+            header->frame_lengths[1] = (data_length-header->size)/2;
+        }
+        header->packet_size = header->size + header->frame_lengths[0] + header->frame_lengths[1];
+    } else if (header->TOC_code == 2) {
+        header->nb_frames = 2;
+        if (self_delimited) {
+            nb_read_bytes = gf_opus_read_length(data, data_length, header->size, &header->self_delimited_length);
+            if (nb_read_bytes) {
+                header->size += nb_read_bytes;
+            } else {
+                GF_LOG(GF_LOG_ERROR, GF_LOG_CODING, ("Could not read self delimited length in Opus packet code 2\n"));
+                return 0;
+            }
+        }
+        nb_read_bytes = gf_opus_read_length(data, data_length, header->size, &header->code2_frame_length);
+        if (nb_read_bytes) {
+            header->size += nb_read_bytes;
+        } else {
+            GF_LOG(GF_LOG_ERROR, GF_LOG_CODING, ("Could not read frame length in Opus packet code 2\n"));
+            return 0;
+        }
+        if (self_delimited) {
+//            0                   1                   2                   3
+//            0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+//           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//           | config  |s|1|0| N1 (1-2 bytes): N2 (1-2 bytes :               |
+//           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+               :
+//           |               Compressed frame 1 (N1 bytes)...                |
+//           :                               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//           |                               |                               |
+//           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+                               |
+//           |               Compressed frame 2 (N2 bytes)...                :
+//           :                                                               |
+//           |                                                               |
+//           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+            header->frame_lengths[0] = header->self_delimited_length;
+            header->frame_lengths[1] = header->code2_frame_length;
+        } else {
+//            0                   1                   2                   3
+//            0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+//           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//           | config  |s|1|0| N1 (1-2 bytes):                               |
+//           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+                               :
+//           |               Compressed frame 1 (N1 bytes)...                |
+//           :                               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//           |                               |                               |
+//           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+                               |
+//           |                     Compressed frame 2...                     :
+//           :                                                               |
+//           |                                                               |
+//           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+            header->frame_lengths[0] = header->code2_frame_length;
+            header->frame_lengths[1] = data_length - header->size - header->code2_frame_length;
+        }
+        header->packet_size = header->size + header->frame_lengths[0] + header->frame_lengths[1];
+    } else if (header->TOC_code == 3) {
+        u32 sum = 0;
+        if (data_length <= header->size) {
+            GF_LOG(GF_LOG_ERROR, GF_LOG_CODING, ("Not enough data to parse TOC code 3 data\n"));
+            return 0;
+        }
+        header->code3_vbr = (data[header->size] & 0x80) >> 7;
+        header->code3_padding = (data[header->size] & 0x40) >> 6;
+        header->nb_frames = data[header->size] & 0x3f;
+        header->size++;
+        if (header->code3_padding) {
+            if (data_length <= header->size) {
+                GF_LOG(GF_LOG_ERROR, GF_LOG_CODING, ("Not enough data to parse TOC code 3 padding length\n"));
+                return 0;
+            }
+            if (data[header->size] == 255) {
+                header->code3_padding_length = 254 + data[header->size+1];
+                header->size += 2;
+            } else {
+                header->code3_padding_length = data[header->size];
+                header->size++;
+            }
+        } else {
+            header->code3_padding_length = 0;
+        }
+        if (self_delimited) {
+            nb_read_bytes = gf_opus_read_length(data, data_length, header->size, &header->self_delimited_length);
+            if (nb_read_bytes) {
+                header->size += nb_read_bytes;
+            } else {
+                GF_LOG(GF_LOG_ERROR, GF_LOG_CODING, ("Could not read self delimited length in Opus packet code 3\n"));
+                return 0;
+            }
+        }
+        if (header->code3_vbr) {
+            u32 max;
+            u32 min;
+            if (self_delimited) {
+//                0                   1                   2                   3
+//                0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//               | config  |s|1|1|1|p|     M     | Padding length (Optional)     :
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//               : N1 (1-2 bytes):     ...       :     N[M-1]    |     N[M]      :
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//               |                                                               |
+//               :               Compressed frame 1 (N1 bytes)...                :
+//               |                                                               |
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//               |                                                               |
+//               :               Compressed frame 2 (N2 bytes)...                :
+//               |                                                               |
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//               |                                                               |
+//               :                              ...                              :
+//               |                                                               |
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//               |                                                               |
+//               :              Compressed frame M (N[M] bytes)...               :
+//               |                                                               |
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//               :                  Opus Padding (Optional)...                   |
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+                header->frame_lengths[0] = header->self_delimited_length;
+                min = 1;
+                max = header->nb_frames;
+                sum += header->frame_lengths[0];
+            } else {
+//                0                   1                   2                   3
+//                0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//               | config  |s|1|1|1|p|     M     | Padding length (Optional)     :
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//               : N1 (1-2 bytes): N2 (1-2 bytes):     ...       :     N[M-1]    |
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//               |                                                               |
+//               :               Compressed frame 1 (N1 bytes)...                :
+//               |                                                               |
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//               |                                                               |
+//               :               Compressed frame 2 (N2 bytes)...                :
+//               |                                                               |
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//               |                                                               |
+//               :                              ...                              :
+//               |                                                               |
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//               |                                                               |
+//               :                     Compressed frame M...                     :
+//               |                                                               |
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//               :                  Opus Padding (Optional)...                   |
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+                min = 0;
+                max = header->nb_frames-1;
+            }
+            for (i = min; i < max; i++) {
+                if (data_length <= header->size) {
+                    GF_LOG(GF_LOG_ERROR, GF_LOG_CODING, ("Not enough data to parse TOC code 3 length\n"));
+                    return 0;
+                }
+                nb_read_bytes = gf_opus_read_length(data, data_length, header->size, &(header->frame_lengths[i]));
+                if (nb_read_bytes) {
+                    header->size += nb_read_bytes;
+                } else {
+                    GF_LOG(GF_LOG_ERROR, GF_LOG_CODING, ("Could not read frame length in Opus packet code 3\n"));
+                    return 0;
+                }
+                sum += header->frame_lengths[i];
+            }
+            if (!self_delimited) {
+                header->frame_lengths[header->nb_frames-1] = data_length - header->size - header->code3_padding_length - sum;
+                sum += header->frame_lengths[header->nb_frames-1];
+            }
+        } else {
+            u32 cbr_length;
+            if (self_delimited) {
+//                0                   1                   2                   3
+//                0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//               | config  |s|1|1|0|p|     M     | Pad len (Opt) : N1 (1-2 bytes):
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//               |                                                               |
+//               :               Compressed frame 1 (N1 bytes)...                :
+//               |                                                               |
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//               |                                                               |
+//               :               Compressed frame 2 (N1 bytes)...                :
+//               |                                                               |
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//               |                                                               |
+//               :                              ...                              :
+//               |                                                               |
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//               |                                                               |
+//               :               Compressed frame M (N1 bytes)...                :
+//               |                                                               |
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//               :                  Opus Padding (Optional)...                   |
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+                cbr_length = header->self_delimited_length;
+            } else {
+//                0                   1                   2                   3
+//                0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//               | config  |s|1|1|0|p|     M     |  Padding length (Optional)    :
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//               |                                                               |
+//               :               Compressed frame 1 (R/M bytes)...               :
+//               |                                                               |
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//               |                                                               |
+//               :               Compressed frame 2 (R/M bytes)...               :
+//               |                                                               |
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//               |                                                               |
+//               :                              ...                              :
+//               |                                                               |
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//               |                                                               |
+//               :               Compressed frame M (R/M bytes)...               :
+//               |                                                               |
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//               :                  Opus Padding (Optional)...                   |
+//               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+                if ((data_length - header->size - header->code3_padding_length) % header->nb_frames) {
+                    GF_LOG(GF_LOG_ERROR, GF_LOG_CODING, ("Sum of frame lengths is not a multiple of the number of frames\n"));
+                    return 0;
+                }
+                cbr_length = (data_length - header->size - header->code3_padding_length)/header->nb_frames;
+            }
+            for (i = 0; i < header->nb_frames; i++) {
+                header->frame_lengths[i] = cbr_length;
+                sum += header->frame_lengths[i];
+            }
+        }
+        header->packet_size = header->size + header->code3_padding_length + sum;
+    }
+    return 1;
+}
+
 #endif /*!defined(GPAC_DISABLE_AV_PARSERS) && !defined (GPAC_DISABLE_OGG)*/
 
 u64 gf_mpegh_escaped_value(GF_BitStream *bs, u32 nBits1, u32 nBits2, u32 nBits3)


### PR DESCRIPTION
This currently only works with `-dxml` and `-dnal`. I need to better understand the inspector architecture to add general inspection. 
Use it as follows:
1. encode some (multichannel) streams with `opusenc` (playing with `framesize` and `hard-cbr` produces different packet configurations):
```
opusenc --framesize 40 --hard-cbr FOA_music.wav FOA_music_framesize_40_hardcbr.opus 
opusenc --framesize 10 FOA_music.wav FOA_music_framesize_10.opus
...
```
2. Import to MP4 with FFmpeg:
```
ffmpeg -i file.opus -acodec copy file.mp4
```
3. Inspect with MP4Box
```
MP4Box -dxml file.mp4
```
You should see sample structures such as:
```
  <Sample number="22" DTS="10080" CTS="10080" size="347" RAP="1" >
    <OpusPacket offset="0" self_delimited="1" header_size="2" config="30" stereo="1" code="0" nb_frames="1" frame_lengths="175"/>
    <OpusPacket offset="177" self_delimited="0" header_size="1" config="30" stereo="1" code="0" nb_frames="1" frame_lengths="169"/>
  </Sample>
```

or 
```
  <Sample number="4" DTS="8640" CTS="8640" size="1440" RAP="1" >
    <OpusPacket offset="0" self_delimited="1" header_size="3" config="31" stereo="1" code="3" vbr="0" padding="0" padding_length="0" nb_frames="3" frame_lengths="238 238 238"/>
    <OpusPacket offset="717" self_delimited="0" header_size="3" config="31" stereo="1" code="3" vbr="0" padding="1" padding_length="6" nb_frames="3" frame_lengths="238 238 238"/>
  </Sample>
```
