### PR TITLE
fix 64 bit chunk offsets when appending

### DIFF
--- a/src/isomedia/stbl_write.c
+++ b/src/isomedia/stbl_write.c
@@ -1730,6 +1730,7 @@ GF_Err stbl_AppendChunk(GF_SampleTableBox *stbl, u64 offset)
 	if (!co64->offsets) return GF_OUT_OF_MEM;
 	co64->offsets[co64->nb_entries] = offset;
 	co64->alloc_size = co64->nb_entries;
+        co64->nb_entries += 1;
 	return GF_OK;
 }
 


### PR DESCRIPTION
I noticed that when [merging tracks](https://github.com/gpac/gpac/blob/master/src/isomedia/track.c#L468), gpac gave up after 2^32 bytes.

Looks to me like a small bug in `stbl_AppendChunk`. One line got lost in the 64-bit codepath. The PR adds that line and now gpac works as expected when merging many tracks.