### PR TITLE
add support for building mp4box on windows xp

### DIFF
--- a/include/gpac/setup.h
+++ b/include/gpac/setup.h
@@ -169,6 +169,13 @@ typedef unsigned int size_t;
 
 #define snprintf _snprintf
 
+/*	the _USING_V110_SDK71_ macro will be defined when using
+	msvc toolsets like v140_xp, v141_xp, etc.
+*/
+#if (WINVER <= 0x0502 || _USING_V110_SDK71_)
+#define GPAC_BUILD_FOR_WINXP
+#endif
+
 #endif	/*END WIN32 non win-ce*/
 /*end WIN32 config*/
 

--- a/src/utils/os_net.c
+++ b/src/utils/os_net.c
@@ -92,7 +92,6 @@ static int wsa_init = 0;
 
 #include <gpac/network.h>
 
-
 /*end-win32*/
 
 #else
@@ -135,6 +134,185 @@ typedef s32 SOCKET;
 #define closesocket(v) close(v)
 
 #endif /*WIN32||_WIN32_WCE*/
+
+#ifdef GPAC_BUILD_FOR_WINXP
+
+/* Added by M. Lackner to ensure Windows XP & XP x64 compatibility */
+/* Adding PlibC's inet_ntop() function in a very slightly modified
+and renamed variant for IPv6 address conversion support on Win XP's,
+which is called by gf_sk_get_remote_address() further below.
+The renamed function is called inet_ntop_xp().
+Original source code taken from here:
+https://sourceforge.net/projects/plibc/
+
+This inet_ntop() implementation is (C) 1996-2001 Internet Software
+Consortium and is licensed under the ISC license.
+License text: https://opensource.org/licenses/ISC */
+#define NS_INT16SZ   2
+#define NS_IN6ADDRSZ  16
+
+/*
+* WARNING: Don't even consider trying to compile this on a system where
+* sizeof(int) < 4.  sizeof(int) > 4 is fine; all the world's not a VAX.
+*/
+
+static const char *inet_ntop4(const unsigned char *src, char *dst, size_t size);
+
+#ifdef AF_INET6
+static const char *inet_ntop6(const unsigned char *src, char *dst, size_t size);
+#endif
+
+/* char *
+* isc_net_ntop(af, src, dst, size)
+*  convert a network format address to presentation format.
+* return:
+*  pointer to presentation format address (`dst'), or NULL (see errno).
+* author:
+*  Paul Vixie, 1996.
+*/
+const char * inet_ntop_xp(int af, const void *src, char *dst, size_t size)
+{
+	switch (af) {
+	case AF_INET:
+		return (inet_ntop4(src, dst, size));
+#ifdef AF_INET6
+	case AF_INET6:
+		return (inet_ntop6(src, dst, size));
+#endif
+	default:
+		errno = EAFNOSUPPORT;
+		return (NULL);
+	}
+	/* NOTREACHED */
+}
+
+/* const char *
+* inet_ntop4(src, dst, size)
+*  format an IPv4 address
+* return:
+*  `dst' (as a const)
+* notes:
+*  (1) uses no statics
+*  (2) takes a unsigned char* not an in_addr as input
+* author:
+*  Paul Vixie, 1996.
+*/
+static const char * inet_ntop4(const unsigned char *src, char *dst, size_t size)
+{
+	static const char *fmt = "%u.%u.%u.%u";
+	char tmp[sizeof "255.255.255.255"];
+	size_t len;
+
+	len = snprintf(tmp, sizeof tmp, fmt, src[0], src[1], src[2], src[3]);
+	if (len >= size) {
+		errno = ENOSPC;
+		return (NULL);
+	}
+	memcpy(dst, tmp, len + 1);
+
+	return (dst);
+}
+
+/* const char *
+* isc_inet_ntop6(src, dst, size)
+*  convert IPv6 binary address into presentation (printable) format
+* author:
+*  Paul Vixie, 1996.
+*/
+#ifdef AF_INET6
+static const char * inet_ntop6(const unsigned char *src, char *dst, size_t size)
+{
+	/*
+	* Note that int32_t and int16_t need only be "at least" large enough
+	* to contain a value of the specified size.  On some systems, like
+	* Crays, there is no such thing as an integer variable with 16 bits.
+	* Keep this in mind if you think this function should have been coded
+	* to use pointer overlays.  All the world's not a VAX.
+	*/
+	char tmp[sizeof "ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255"], *tp;
+	struct { int base, len; } best, cur;
+	unsigned int words[NS_IN6ADDRSZ / NS_INT16SZ];
+	int i, inc;
+
+	/*
+	* Preprocess:
+	*  Copy the input (bytewise) array into a wordwise array.
+	*  Find the longest run of 0x00's in src[] for :: shorthanding.
+	*/
+	memset(words, '\0', sizeof words);
+	for (i = 0; i < NS_IN6ADDRSZ; i++)
+		words[i / 2] |= (src[i] << ((1 - (i % 2)) << 3));
+	best.base = -1;
+	best.len = 0;
+	cur.base = -1;
+	cur.len = 0;
+	for (i = 0; i < (NS_IN6ADDRSZ / NS_INT16SZ); i++) {
+		if (words[i] == 0) {
+			if (cur.base == -1)
+				cur.base = i, cur.len = 1;
+			else
+				cur.len++;
+		}
+		else {
+			if (cur.base != -1) {
+				if (best.base == -1 || cur.len > best.len)
+					best = cur;
+				cur.base = -1;
+			}
+		}
+	}
+	if (cur.base != -1) {
+		if (best.base == -1 || cur.len > best.len)
+			best = cur;
+	}
+	if (best.base != -1 && best.len < 2)
+		best.base = -1;
+
+	/*
+	* Format the result.
+	*/
+	tp = tmp;
+	for (i = 0; i < (NS_IN6ADDRSZ / NS_INT16SZ); i++) {
+		/* Are we inside the best run of 0x00's? */
+		if (best.base != -1 && i >= best.base && i < (best.base + best.len)) {
+			if (i == best.base)
+				*tp++ = ':';
+			continue;
+		}
+		/* Are we following an initial run of 0x00s or any real hex? */
+		if (i != 0)
+			*tp++ = ':';
+		/* Is this address an encapsulated IPv4? */
+		if (i == 6 && best.base == 0 && (best.len == 6 || (best.len == 5 && words[5] == 0xffff))) {
+			if (!inet_ntop4(src + 12, tp, sizeof tmp - (tp - tmp)))
+				return (NULL);
+			tp += strlen(tp);
+			break;
+		}
+		inc = snprintf(tp, 5, "%x", words[i]);
+		tp += inc;
+	}
+	/* Was it a trailing run of 0x00's? */
+	if (best.base != -1 && (best.base + best.len) == (NS_IN6ADDRSZ / NS_INT16SZ))
+		*tp++ = ':';
+	*tp++ = '\0';
+
+	/*
+	* Check for overflow, copy, and we're done.
+	*/
+	if ((size_t)(tp - tmp) > size) {
+		errno = ENOSPC;
+		return (NULL);
+	}
+	memcpy(dst, tmp, tp - tmp);
+	return (dst);
+}
+#endif /* AF_INET6 */
+/* End of inet_ntop() reimplementation */
+
+
+#endif //winxp
+
 
 
 #ifdef GPAC_HAS_IPV6
@@ -1653,7 +1831,11 @@ GF_Err gf_sk_get_remote_address(GF_Socket *sock, char *buf)
 	char servname[NI_MAXHOST];
 	struct sockaddr_in6 * addrptr = (struct sockaddr_in6 *)(&sock->dest_addr);
 	if (!sock || !sock->socket) return GF_BAD_PARAM;
+#ifdef GPAC_BUILD_FOR_WINXP
+	inet_ntop_xp(AF_INET, addrptr, clienthost, NI_MAXHOST);
+#else
 	inet_ntop(AF_INET, addrptr, clienthost, NI_MAXHOST);
+#endif
 	strcpy(buf, clienthost);
 	if (getnameinfo((struct sockaddr *)addrptr, sock->dest_addr_len, clienthost, NI_MAXHOST, servname, NI_MAXHOST, NI_NUMERICHOST) == 0) {
 		strcpy(buf, clienthost);


### PR DESCRIPTION
this is based on the article at http://wp.xin.at/archives/5810

see also previous discussion about xp support here: https://github.com/gpac/gpac/issues/1490#issuecomment-649519836

this allows building the "mp4box only" profile with xp compatible toolsets v140_xp or v141_xp

(it doesn't allow for a full build on xp, nor does it makes the official installers xp compatible)

tested with v140_xp on VS2015 and x141_xp on VS2019 on a xp sp3 x86 vm

<hr />

the added support for inet_ntop on xp might be overkill, we might just want to undefine GPAC_HAS_IPV6 on xp and not bother with the extra code, but it's debatable

