### PR TITLE
Vui timing info rewrite

### DIFF
--- a/include/gpac/internal/media_dev.h
+++ b/include/gpac/internal/media_dev.h
@@ -304,6 +304,8 @@ typedef struct
 
 	//if set all video info is removed
 	Bool remove_video_info;
+	//if set timing info is removed
+	Bool remove_vui_timing_info;
 	//new fullrange, -1 to use info from bitstream
 	s32 fullrange;
 	//new vidformat flag, -1 to use info from bitstream

--- a/src/filters/bsrw.c
+++ b/src/filters/bsrw.c
@@ -54,7 +54,7 @@ struct _bsrw_ctx
 	GF_Fraction sar;
 	s32 m4vpl, prof, lev, pcomp, pidc, pspace, gpcflags;
 	s32 cprim, ctfc, cmx, vidfmt;
-	Bool rmsei, fullrange, novsi;
+	Bool rmsei, fullrange, novsi, novuitiming;
 
 	GF_List *pids;
 	Bool reconfigure;
@@ -421,6 +421,7 @@ static void init_vui(GF_BSRWCtx *ctx, BSRWPid *pctx)
 	pctx->vui.color_prim = ctx->cprim;
 	pctx->vui.fullrange = ctx->fullrange;
 	pctx->vui.remove_video_info = ctx->novsi;
+	pctx->vui.remove_vui_timing_info = ctx->novuitiming;
 	pctx->vui.color_tfc = ctx->ctfc;
 	pctx->vui.video_format = ctx->vidfmt;
 #endif /*GPAC_DISABLE_AV_PARSERS*/
@@ -432,6 +433,7 @@ static void init_vui(GF_BSRWCtx *ctx, BSRWPid *pctx)
 	if (ctx->cprim>-1) return;
 	if (ctx->fullrange) return;
 	if (ctx->novsi) return;
+	if (ctx->novuitiming) return;
 	if (ctx->ctfc>-1) return;
 	if (ctx->vidfmt>-1) return;
 	//all default
@@ -659,6 +661,7 @@ static GF_FilterArgs BSRWArgs[] =
 	{ OFFS(m4vpl), "set ProfileLevel for MPEG-4 video part two", GF_PROP_SINT, "-1", NULL, GF_FS_ARG_UPDATE},
 	{ OFFS(fullrange), "video full range flag", GF_PROP_BOOL, "false", NULL, GF_FS_ARG_UPDATE},
 	{ OFFS(novsi), "remove video_signal_type from VUI in AVC|H264 and HEVC", GF_PROP_BOOL, "false", NULL, GF_FS_ARG_UPDATE},
+	{ OFFS(novuitiming), "remove timing_info from VUI in AVC|H264 and HEVC", GF_PROP_BOOL, "false", NULL, GF_FS_ARG_UPDATE},
 	{ OFFS(prof), "profile indication for AVC|H264", GF_PROP_SINT, "-1", NULL, GF_FS_ARG_UPDATE},
 	{ OFFS(lev), "level indication for AVC|H264, level_idc for VVC", GF_PROP_SINT, "-1", NULL, GF_FS_ARG_UPDATE},
 	{ OFFS(pcomp), "profile compatibility for AVC|H264", GF_PROP_SINT, "-1", NULL, GF_FS_ARG_UPDATE},

--- a/src/media_tools/av_parsers.c
+++ b/src/media_tools/av_parsers.c
@@ -6605,7 +6605,7 @@ static void avc_hevc_vvc_rewrite_vui(GF_VUIInfo *vui_info, GF_BitStream *orig, G
 		}
 	}
 
-	if (codec == GF_CODECID_VVC && vui_chroma_loc_info_present_flag) {
+	if ((codec == GF_CODECID_VVC) && vui_chroma_loc_info_present_flag) {
 		if (progressive_source_flag && !interlaced_source_flag) {
 			final_vvc_payload_size += gf_get_ue_nb_bits(chroma_loc1);
 		} else {

--- a/src/media_tools/av_parsers.c
+++ b/src/media_tools/av_parsers.c
@@ -6481,6 +6481,12 @@ static void avc_hevc_vvc_rewrite_vui(GF_VUIInfo *vui_info, GF_BitStream *orig, G
 				}
 			}
 		} else { //AVC, HEVC
+			vui_chroma_loc_info_present_flag = gf_bs_read_int(orig, 1);
+			if (vui_chroma_loc_info_present_flag) {
+				chroma_loc1 = gf_bs_read_ue(orig); //chroma_sample_loc_type_top_field
+				chroma_loc2 = gf_bs_read_ue(orig); //chroma_sample_loc_type_bottom_field
+			}
+
 			timing_info_present_flag = gf_bs_read_int(orig, 1);
 			if (timing_info_present_flag) {
 				/*num_units_in_tick = */gf_bs_read_int(orig, 32);
@@ -6729,6 +6735,12 @@ static void avc_hevc_vvc_rewrite_vui(GF_VUIInfo *vui_info, GF_BitStream *orig, G
 		}
 		return;
 	} else {
+		gf_bs_write_int(mod, vui_chroma_loc_info_present_flag, 1);
+		if (vui_chroma_loc_info_present_flag) {
+			gf_bs_write_ue(mod, chroma_loc1); //chroma_sample_loc_type_top_field
+			gf_bs_write_ue(mod, chroma_loc2); //chroma_sample_loc_type_bottom_field
+		}
+
 		if (codec == GF_CODECID_HEVC) {
 			gf_bs_write_int(mod, neutral_chroma_indication_flag, 1);
 			gf_bs_write_int(mod, field_seq_flag, 1);
@@ -6749,8 +6761,7 @@ static void avc_hevc_vvc_rewrite_vui(GF_VUIInfo *vui_info, GF_BitStream *orig, G
 
 	/*no VUI in input bitstream but we just inserted one, set all remaining vui flags to 0*/
 	if (!vui_present_flag) {
-		gf_bs_write_int(mod, 0, 1);		/*chroma_location_info_present_flag */
-		gf_bs_write_int(mod, 0, 1);		/*timing_info_present_flag*/
+		assert(codec == GF_CODECID_AVC);
 		gf_bs_write_int(mod, 0, 1);		/*nal_hrd_parameters_present*/
 		gf_bs_write_int(mod, 0, 1);		/*vcl_hrd_parameters_present*/
 		gf_bs_write_int(mod, 0, 1);		/*pic_struct_present*/


### PR DESCRIPTION
To generate a sample with vui timing info (and pic timing sei):

```
gpac -i avgen:dur=2 @ c=avc:r=30/1::x264-params="level=40:nal-hrd=vbr:vbv-bufsize=1000:vbv-maxrate=2000" @ -o avc30.mp4
```