### PR TITLE
Again don't write vpcc->level as hex (#1114)

### DIFF
--- a/src/media_tools/isom_tools.c
+++ b/src/media_tools/isom_tools.c
@@ -4016,7 +4016,7 @@ GF_Err rfc_6381_get_codec_av1(char *szCodec, u32 subtype, GF_AV1Config *av1c, CO
 GF_Err rfc_6381_get_codec_vpx(char *szCodec, u32 subtype, GF_VPConfig *vpcc, COLR colr)
 {
 	assert(vpcc);
-	snprintf(szCodec, RFC6381_CODEC_NAME_SIZE_MAX, "%s.%02u.%02x.%02u.%02u.%02u.%02u.%02u.%02u", gf_4cc_to_str(subtype),
+	snprintf(szCodec, RFC6381_CODEC_NAME_SIZE_MAX, "%s.%02u.%02u.%02u.%02u.%02u.%02u.%02u.%02u", gf_4cc_to_str(subtype),
 		vpcc->profile,
 		vpcc->level,
 		vpcc->bit_depth,


### PR DESCRIPTION
A small change to fix writing out the VP9 codec level information to a.o. MPD files.