### PR TITLE
fix DASH channel layout configuration for EAC-3 streams with 6 channels

### DIFF
--- a/applications/gpac/gpac.c
+++ b/applications/gpac/gpac.c
@@ -2475,7 +2475,7 @@ static u32 gpac_unit_tests(GF_MemTrackerType mem_track)
 	gf_filter_reconnect_output(NULL);
 	gf_filter_pid_get_udta_flags(NULL);
 
-	gf_audio_fmt_get_cicp_layout(2, 1, 1);
+	gf_audio_fmt_get_cicp_layout(4, 1, 1);
 	gf_audio_fmt_get_layout_from_cicp(3);
 	gf_audio_fmt_get_layout_name_from_cicp(3);
 	gf_audio_fmt_get_cicp_from_layout(GF_AUDIO_CH_FRONT_LEFT|GF_AUDIO_CH_FRONT_RIGHT);

--- a/applications/mp4box/filedump.c
+++ b/applications/mp4box/filedump.c
@@ -3254,7 +3254,7 @@ static void DumpStsdInfo(GF_ISOFile *file, u32 trackNum, Bool full_dump, Bool du
 #ifndef GPAC_DISABLE_AV_PARSERS
 		GF_AC3Config *ac3 = gf_isom_ac3_config_get(file, trackNum, stsd_idx);
 		if (ac3) {
-			nb_ch = gf_ac3_get_channels(ac3->streams[0].acmod);
+			nb_ch = gf_ac3_get_total_channels(ac3->streams[0].acmod);
 			if (ac3->streams[0].nb_dep_sub) {
 				nb_ch += gf_eac3_get_chan_loc_count(ac3->streams[0].chan_loc);
 			}

--- a/include/gpac/avparse.h
+++ b/include/gpac/avparse.h
@@ -684,11 +684,16 @@ Bool gf_eac3_parser_bs(GF_BitStream *bs, GF_AC3Config *hdr, Bool full_parse);
 */
 u32 gf_eac3_get_chan_loc_count(u32 chan_loc);
 
-/*! gets the number of channels in an AC3 frame
+/*! gets the total number of channels in an AC3 frame, including surround but not lfe
 \param acmod acmod of the associated frame header
 \return number of channels
 */
-u32 gf_ac3_get_channels(u32 acmod);
+u32 gf_ac3_get_total_channels(u32 acmod);
+/*! gets the number of surround channels in an AC3 frame
+\param acmod acmod of the associated frame header
+\return number of surround channels
+*/
+u32 gf_ac3_get_surround_channels(u32 acmod);
 /*! gets the bitrate of an AC3 frame
 \param brcode brcode of the associated frame header
 \return bitrate in bps

--- a/include/gpac/constants.h
+++ b/include/gpac/constants.h
@@ -913,7 +913,7 @@ u32 gf_audio_fmt_to_isobmf(GF_AudioFormat afmt);
 GF_AudioFormat gf_audio_fmt_enum(u32 *idx, const char **name, const char **fileext, const char **desc);
 
 /*! get CICP layout code point from audio configuration
-\param nb_chan number of channels
+\param nb_chan total number of channels
 \param nb_surr number of surround channels
 \param nb_lfe number of LFE channels
 \return CICP layout code point format or 0 if unknown

--- a/include/gpac/mpeg4_odf.h
+++ b/include/gpac/mpeg4_odf.h
@@ -1581,8 +1581,10 @@ typedef struct __ec3_stream
 	u8 lfon;
 	/*! asvc mode, only for EC3*/
 	u8 asvc;
-	/*! number of channels, including lfe*/
+	/*! number of channels, including lfe and surround channels */
 	u8 channels;
+	/*! number of surround channels */
+	u8 surround_channels;
 	/*! number of dependent substreams, only for EC3*/
 	u8 nb_dep_sub;
 	/*! channel locations for dependent substreams, only for EC3*/

--- a/src/export.cpp
+++ b/src/export.cpp
@@ -1550,7 +1550,8 @@
 #pragma comment (linker, EXPORT_SYMBOL(gf_ac3_parser_bs) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_eac3_parser_bs) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_eac3_parser) )
-#pragma comment (linker, EXPORT_SYMBOL(gf_ac3_get_channels) )
+#pragma comment (linker, EXPORT_SYMBOL(gf_ac3_get_total_channels) )
+#pragma comment (linker, EXPORT_SYMBOL(gf_ac3_get_surround_channels) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_ac3_get_bitrate) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_eac3_get_chan_loc_count) )
 

--- a/src/filters/dasher.c
+++ b/src/filters/dasher.c
@@ -1341,12 +1341,14 @@ static GF_Err dasher_configure_pid(GF_Filter *filter, GF_FilterPid *pid, Bool is
 					gf_odf_ac3_config_parse(dsi->value.data.ptr, dsi->value.data.size, (ds->codec_id==GF_CODECID_EAC3) ? GF_TRUE : GF_FALSE, &ac3);
 
 					ds->nb_lfe = ac3.streams[0].lfon ? 1 : 0;
+					ds->nb_surround = gf_ac3_get_surround_channels(ac3.streams[0].acmod);
 					ds->atmos_complexity_type = ac3.is_ec3 ? ac3.complexity_index_type : 0;
-					_nb_ch = gf_ac3_get_channels(ac3.streams[0].acmod);
+					_nb_ch = gf_ac3_get_total_channels(ac3.streams[0].acmod);
 					for (i=0; i<ac3.streams[0].nb_dep_sub; ++i) {
 						assert(ac3.streams[0].nb_dep_sub == 1);
-						_nb_ch += gf_ac3_get_channels(ac3.streams[0].chan_loc);
+						_nb_ch += gf_eac3_get_chan_loc_count(ac3.streams[0].chan_loc);
 					}
+                    if (ds->nb_lfe) _nb_ch++;
 				}
 				break;
 			}

--- a/src/utils/constants.c
+++ b/src/utils/constants.c
@@ -789,7 +789,9 @@ u32 gf_audio_fmt_to_isobmf(GF_AudioFormat afmt)
 GF_EXPORT
 u32 gf_audio_fmt_get_cicp_layout(u32 nb_chan, u32 nb_surr, u32 nb_lfe)
 {
-	if ( !nb_chan && !nb_surr && !nb_lfe) return 0;
+	if (nb_chan <= nb_surr+nb_lfe) return 0;
+	else nb_chan -= nb_surr+nb_lfe;
+	if (!nb_chan && !nb_surr && !nb_lfe) return 0;
 	else if ((nb_chan==1) && !nb_surr && !nb_lfe) return 1;
 	else if ((nb_chan==2) && !nb_surr && !nb_lfe) return 2;
 	else if ((nb_chan==3) && !nb_surr && !nb_lfe) return 3;


### PR DESCRIPTION
`MP4Box -info file.eac3`
```
Import probing results for file.eac3:
File has 1 tracks
- Track 1 type: Audio - Codec Enhanced AC3 Audio
	SampleRate 48000 - 6 channels
```

`MP4Box -add file.eac3 -new a.mp4`
```
Track Importing EAC-3 - SampleRate 48000 Num Channels 6
Saving a.mp4: 0.500 secs Interleaving0)

MP4Box -info a.mp4
# Movie Info - 1 track - TimeScale 600
Duration 00:00:04.223
Fragmented: no
Progressive (moov before mdat)
Major Brand isom - version 1 - compatible brands: isom
Created: GMT Tue Nov  1 23:45:23 2022


Meta-Data Tags:
	tool: GPAC-2.1-DEV-rev431-g2db3785b3-eac3_cicp

# Track 1 Info - ID 1 - TimeScale 48000
Media Duration 00:00:04.224
Track flags: Enabled In Movie In Preview
Media Samples: 132
Alternate Group ID 1
Media Type: soun:ec-3
	EC-3 stream - Sample Rate 48000 - 5.1 channel(s) - bitrate 192000
	RFC6381 Codec Parameters: ec-3
	All samples are sync
	Max sample duration: 1536 / 48000
```

`MP4Box -dash 1000 file.eac3 -out test.mpd`
```
[Dasher] No template assigned, using $File$_dash$FS$$Number$
[MPD] Generating MPD at time 2022-11-01T23:46:09.342Zs 92 %%
[Dasher] End of Period
[Dasher] End of MPD (no more active streams)
```
The MPD contains:
```
    <AudioChannelConfiguration schemeIdUri="urn:mpeg:mpegB:cicp:ChannelConfiguration" value="6"/>
```