### PR TITLE
Configure: do not overwrite LDFLAGS on Darwin

### DIFF
--- a/configure
+++ b/configure
@@ -775,7 +775,7 @@ EOF
 
     Darwin)
         CFLAGS_DIR="-I$prefix/include"
-        LDFLAGS="-L$prefix/$libdir"
+        LDFLAGS="$LDFLAGS -L$prefix/$libdir"
         if test -d /sw/bin ; then
             alt_macosx_dir="/sw"
             CFLAGS_DIR="-I/sw/include $CFLAGS_DIR"


### PR DESCRIPTION
Preserve user-specified linker flags on Darwin by appending library path instead of overwriting LDFLAGS.

Keeping user-specified flags is the behaviour on other platforms as well, so I assume that overwriting LDFLAGS was unintentional.

This change allows Macports insert its legacy-support library, so that gpac can be built on OS X versions without `clock_gettime` (i.e., 10.11 and earlier).