### PR TITLE
Added to fix these errors

### DIFF
--- a/include/gpac/version.h
+++ b/include/gpac/version.h
@@ -22,7 +22,7 @@
  *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
  *
  */
-
+#include "gpac/setup.h"
 #ifndef _GF_VERSION_H
 
 /*!


### PR DESCRIPTION
../include/gpac/version.h:72:1: error: unknown type name 'u32' u32 gf_gpac_abi_major();
^
../include/gpac/version.h:76:1: error: unknown type name 'u32' u32 gf_gpac_abi_minor();
^
../include/gpac/version.h:80:1: error: unknown type name 'u32' u32 gf_gpac_abi_micro();
^
3 errors generated.