### PR TITLE
os_thread: Fix compiling with clang mingw

### DIFF
--- a/src/utils/os_thread.c
+++ b/src/utils/os_thread.c
@@ -222,7 +222,11 @@ exit:
 
 	if (t->no_kill) {
 		t->no_kill = 0;
+#ifdef WIN32
+		return ret;
+#else
 		return (void *)ret;
+#endif
 	}
 #ifndef GPAC_DISABLE_LOG
 	GF_LOG(GF_LOG_INFO, GF_LOG_MUTEX, ("[Thread %s] At %d Exiting thread proc, return code %d\n", t->log_name, gf_sys_clock(), ret));


### PR DESCRIPTION

    This matches the return variable type with function prototype.
    Otherwise, clang in mingw shows the following error

    os_thread.c:225:10: error: incompatible pointer to integer
    conversion returning 'void *' from a function with result type
    'DWORD' (aka 'unsigned long') [-Wint-conversion]

