### PR TITLE
uncvg: fix bad pixel map value parsing

### DIFF
--- a/share/scripts/jsf/uncvg.js
+++ b/share/scripts/jsf/uncvg.js
@@ -281,14 +281,14 @@ filter.initialize = function()
 			if (c.indexOf('r')==0) {
 				bad_rows.push( parseInt(c.slice(1) ) );
 			}
-			if (c.indexOf('c')==0) {
+			else if (c.indexOf('c')==0) {
 				bad_cols.push( parseInt(c.slice(1) ) );
 			}
 			else {
 				let s = c.indexOf('x');
 				if (s>0) {
-					let x = parseInt(c.slice(0, x-1) );
-					let y = parseInt(c.slice(x+1) );
+					let x = parseInt(c.slice(0, s) );
+					let y = parseInt(c.slice(s+1) );
 					bad_pix.push({x: x, y: y});
 				}
 			}


### PR DESCRIPTION
As written, it uses `x` without defining it, and it drops the final column digit since `slice(begin,end)` does not include `end`.

I'm not sure I completely understand the expected format, but assuming it is something like:

```
./bin/gcc/gpac uncvg:vsize=1000x2000:bpm=r300,r350,c200,c240,c280,100x120,130x150:fps=0 -o ~/uncompressed_sbpm.heif
```

then this PR should fix the parsing.

(also, I see the sbpm box included even if it is the bpm is not specified in the filter. Is that intended?)