### PR TITLE
Fix HEVC SPS parsing

### DIFF
--- a/src/media_tools/av_parsers.c
+++ b/src/media_tools/av_parsers.c
@@ -8252,8 +8252,8 @@ static s32 gf_hevc_read_sps_bs_internal(GF_BitStream *bs, HEVCState *hevc, u8 la
 	}
 	sps->ptl = ptl;
 	vps = &hevc->vps[vps_id];
-	sps->max_sub_layers_minus1 = 0;
-	sps->sps_ext_or_max_sub_layers_minus1 = 0;
+	sps->max_sub_layers_minus1 = max_sub_layers_minus1;
+	sps->sps_ext_or_max_sub_layers_minus1 = sps_ext_or_max_sub_layers_minus1;
 
 	/* default values */
 	sps->colour_primaries = 2;


### PR DESCRIPTION
HEVC SPS parsing fails when sps_sub_layer_ordering_info _present_flag is set, and sps_max_sub_layers_minus1 is greater than 0. The result was three arrays weren’t being fully read. 