### PR TITLE
Add nix flake to help builds with nix packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ gpac.pc
 tests/external_media/
 tests/results/
 tests/hash_refs/
+
+# nix output
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1687130670,
+        "narHash": "sha256-VKTdfsJe7sVTTqxTd3eRGPoUgEeJKD+kwS86B6TY874=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c1bca7fe84c646cfd4ebf3482c0e6317a0b13f22",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,18 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1687130670,
-        "narHash": "sha256-VKTdfsJe7sVTTqxTd3eRGPoUgEeJKD+kwS86B6TY874=",
+        "lastModified": 1686960236,
+        "narHash": "sha256-AYCC9rXNLpUWzD9hm+askOfpliLEC9kwAo7ITJc4HIw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c1bca7fe84c646cfd4ebf3482c0e6317a0b13f22",
+        "rev": "04af42f3b31dba0ef742d254456dc4c14eedac86",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,45 +1,54 @@
 {
   description = "GPAC Multimedia Open Source Project";
-
-  outputs = { self, nixpkgs }: {
-
+  inputs =  {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+  outputs = { self, nixpkgs }@inputs: 
+  let
+    pkgs = nixpkgs.legacyPackages.x86_64-linux;
+    buildInputs = with pkgs; [ 
+      zlib 
+      git
+      freetype 
+      libjpeg_turbo 
+      libpng 
+      libmad 
+      faad2 
+      libogg 
+      libvorbis 
+      libtheora
+      a52dec
+      ffmpeg
+      xorg.libX11
+      xorg.libXv
+      xorg.xorgproto
+      mesa
+      xvidcore
+      openssl
+      alsa-lib
+      jack2
+      pulseaudio
+      SDL2
+      mesa-demos
+      swig4
+    ];
+    nativeBuildInputs = with pkgs; [ pkg-config ];
+ in
+  with pkgs; {  
+    devShells.x86_64-linux.default = mkShell {
+        inherit buildInputs nativeBuildInputs;
+    };
     packages.x86_64-linux.default =  with import nixpkgs { system = "x86_64-linux"; };
       stdenv.mkDerivation {
         name = "gpac";
         src = self;
-        nativeBuildInputs = [ pkg-config ];
-        buildInputs = [ 
-          zlib 
-          git
-          freetype 
-          libjpeg_turbo 
-          libpng 
-          libmad 
-          faad2 
-          libogg 
-          libvorbis 
-          libtheora
-          a52dec
-          ffmpeg
-          xorg.libX11
-          xorg.libXv
-          xorg.xorgproto
-          mesa
-          xvidcore
-          openssl
-          alsa-lib
-          jack2
-          pulseaudio
-          SDL2
-          mesa-demos
-        ];
-
+        inherit buildInputs nativeBuildInputs;
         configurePhase = ''
           runHook preConfigure
           ./configure --prefix=$out
           runHook postConfigure
         '';
-        buildPhase = "make";
+        buildPhase = "make -j $NIX_BUILD_CORES";
         installPhase = "make install";
       }; 
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,47 @@
+{
+  description = "GPAC Multimedia Open Source Project";
+
+  outputs = { self, nixpkgs }: {
+
+    packages.x86_64-linux.default =  with import nixpkgs { system = "x86_64-linux"; };
+      stdenv.mkDerivation {
+        name = "gpac";
+        src = self;
+        nativeBuildInputs = [ pkg-config ];
+        buildInputs = [ 
+          zlib 
+          git
+          freetype 
+          libjpeg_turbo 
+          libpng 
+          libmad 
+          faad2 
+          libogg 
+          libvorbis 
+          libtheora
+          a52dec
+          ffmpeg
+          xorg.libX11
+          xorg.libXv
+          xorg.xorgproto
+          mesa
+          xvidcore
+          openssl
+          alsa-lib
+          jack2
+          pulseaudio
+          SDL2
+          mesa-demos
+        ];
+
+        configurePhase = ''
+          runHook preConfigure
+          ./configure --prefix=$out
+          runHook postConfigure
+        '';
+        buildPhase = "make";
+        installPhase = "make install";
+      }; 
+
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,6 @@
       pulseaudio
       SDL2
       mesa-demos
-      swig4
     ];
     nativeBuildInputs = with pkgs; [ pkg-config ];
  in


### PR DESCRIPTION
Hello,

This PR exists to add a nix flake in the repository to build GPAC (without the extra deps).

It integrates with https://nixos.org/ and allows you to build gpac (and get its dependencies) using ```ǹix build``` or just spawn an isolated development shell using ```nix develop```.

So far, only 64bit linux is supported, but mac and windows support could be enabled in the future. As well as 32bit linux.