### PR TITLE
Arg matching improvements

### DIFF
--- a/applications/gpac/gpac_help.c
+++ b/applications/gpac/gpac_help.c
@@ -1189,6 +1189,7 @@ redo_pass:
 						}
 						continue;
 					}
+
 					if (!gf_sys_word_match(fname, arg->arg_name)) continue;
 
 					if (!first) {
@@ -1197,7 +1198,7 @@ redo_pass:
 							GF_LOG(GF_LOG_ERROR, GF_LOG_APP, ("No such filter %s\n", fname));
 							found = GF_TRUE;
 						}
-						GF_LOG(GF_LOG_WARNING, GF_LOG_APP, ("\nClosest matching filter options:\n", fname));
+						GF_LOG(GF_LOG_WARNING, GF_LOG_APP, ("\nClosest matching filter options:\n"));
 					}
 					gf_sys_format_help(helpout, help_flags | GF_PRINTARG_HIGHLIGHT_FIRST, "%s.%s \n", reg->name, arg->arg_name);
 				}

--- a/include/gpac/tools.h
+++ b/include/gpac/tools.h
@@ -281,7 +281,7 @@ Bool gf_parse_frac(const char *str, GF_Fraction *frac);
 /*!
 \brief search string without case
 
-Search a aubstring in a string witout checking for case
+Search a substring in a string without checking for case
 \param text text to search
 \param subtext string to find
 \param subtext_len length of string to find

--- a/src/utils/os_config_init.c
+++ b/src/utils/os_config_init.c
@@ -2558,7 +2558,7 @@ Bool gf_sys_word_match(const char *orig, const char *dst)
 		return GF_FALSE;
 	}
 
-	if (gf_strnistr(orig, dst, dlen))
+	if ((dlen>=3) && gf_strnistr(orig, dst, dlen))
 		return GF_TRUE;
 
 	run = gf_malloc(sizeof(u32) * olen);

--- a/src/utils/os_config_init.c
+++ b/src/utils/os_config_init.c
@@ -2560,6 +2560,8 @@ Bool gf_sys_word_match(const char *orig, const char *dst)
 
 	if ((dlen>=3) && gf_strnistr(orig, dst, dlen))
 		return GF_TRUE;
+	if ((olen>=3) && gf_strnistr(dst, orig, olen))
+		return GF_TRUE;
 
 	run = gf_malloc(sizeof(u32) * olen);
 	memset(run, 0, sizeof(u32) * olen);


### PR DESCRIPTION
Before (dozens of irrelevent matches):
```
$ gpac -h dolby
No such filter dolby

Closest matching filter options:
...
ffdmx:x11grab.y Initial y coordinate.
ffavin:x11grab.y Initial y coordinate.
ffavf:addroi.y Region distance from top edge of frame.
ffavf:crop.y set the y crop area expression
ffavf:datascope.y set y offset
ffavf:delogo.y set logo y position
ffavf:deshake.y set y for the rectangular search area
ffavf:drawbox.y set vertical position of the top box edge
ffavf:drawgrid.y set vertical offset
ffavf:drawtext.y set y expression
ffavf:feedback.y set top left crop position
ffavf:floodfill.y set pixel y coordinate
ffavf:lut.y set Y expression
ffavf:lutrgb.y set Y expression
ffavf:lutyuv.y set Y expression
ffavf:oscilloscope.y set scope y position
ffavf:overlay.y set the y expression
ffavf:overlay_opencl.y Overlay y position
ffavf:overlay_qsv.y Overlay y position
...
session error Filter not found for the desired type
```

After:
```
$ gpac -h dolby
No such filter dolby

Closest matching filter options:
ffavf:libplacebo.apply_dolbyvision 
session error Filter not found for the desired type
```