### PR TITLE
Add a NULL check of variables related to field.far_ptr and com->node

### DIFF
--- a/src/scene_manager/scene_dump.c
+++ b/src/scene_manager/scene_dump.c
@@ -758,6 +758,8 @@ static void gf_dump_vrml_simple_field(GF_SceneDumper *sdump, GF_FieldInfo field,
 		gf_dump_vrml_node(sdump, field.far_ptr ? *(GF_Node **)field.far_ptr : NULL, 0, NULL);
 		return;
 	case GF_SG_VRML_MFNODE:
+		if (!field.far_ptr)
+			return;
 		list = * ((GF_ChildNodeItem **) field.far_ptr);
 		assert( list );
 		sdump->indent++;

--- a/src/scene_manager/scene_dump.c
+++ b/src/scene_manager/scene_dump.c
@@ -2578,7 +2578,7 @@ static GF_Err DumpSceneReplace(GF_SceneDumper *sdump, GF_Command *com)
 	gf_dump_vrml_node(sdump, com->node, 0, NULL);
 	if (!sdump->XMLDump) gf_fprintf(sdump->trace, "\n\n");
 
-	if (com->aggregated) {
+	if (com->aggregated && com->node) {
 		u32 i, count;
 		count = gf_list_count(com->node->sgprivate->scenegraph->Routes);
 		for (i=0; i<count; i++) {

--- a/src/scenegraph/xml_ns.c
+++ b/src/scenegraph/xml_ns.c
@@ -397,6 +397,8 @@ static u32 gf_xml_get_namespace(GF_DOMNode *elt, const char *attribute_name)
 
 static char *gf_xml_get_namespace_qname(GF_DOMNode *elt, u32 ns)
 {
+	if (!elt)
+		return NULL;
 	GF_DOMAttribute *att = elt->attributes;
 	while (att) {
 		if (att->tag==TAG_DOM_ATT_any) {


### PR DESCRIPTION
In the commit c5249ee4b62d, `field.far_ptr` is checked before being used. However, the following code statement misses a NULL check of this variable: 
[1] `list = * ((GF_ChildNodeItem **) field.far_ptr);` in `gf_dump_vrml_simple_field()`.
Thus, a NULL check should be added before this code statement.

In the commit a5a8dbcdd956, `com->node` is checked before being used. However, the following code statements miss NULL checks of this variable:
[1] `count = gf_list_count(com->node->sgprivate->scenegraph->Routes);` in `DumpSceneReplace()`.
[2] `if (!elt->sgprivate->parents) return NULL;` in `gf_xml_get_namespace_qname()`. (elt is introduced from `DumpLSRAddReplaceInsert()` -> call `gf_svg_dump_attribute(com->node, ...)` -> function `gf_svg_dump_attribute(elt, ...)` -> call `gf_svg_get_attribute_name(elt, ...)`).
Thus, NULL checks should be added before these code statements.


