### PR TITLE
Add a NULL check of field.far_ptr in gf_dump_vrml_simple_field()

### DIFF
--- a/src/scene_manager/scene_dump.c
+++ b/src/scene_manager/scene_dump.c
@@ -758,6 +758,8 @@ static void gf_dump_vrml_simple_field(GF_SceneDumper *sdump, GF_FieldInfo field,
 		gf_dump_vrml_node(sdump, field.far_ptr ? *(GF_Node **)field.far_ptr : NULL, 0, NULL);
 		return;
 	case GF_SG_VRML_MFNODE:
+		if (!field.far_ptr)
+			return;
 		list = * ((GF_ChildNodeItem **) field.far_ptr);
 		assert( list );
 		sdump->indent++;


### PR DESCRIPTION
In the commit c5249ee4b62d, `field.far_ptr` is checked before being used. However, the following code statement misses a NULL check of this variable: 
`list = * ((GF_ChildNodeItem **) field.far_ptr);` in `gf_dump_vrml_simple_field()`.
Thus, a NULL check should be added before this code statement.