### PR TITLE
Add a NULL check of variables related to com->node

### DIFF
--- a/src/scene_manager/scene_dump.c
+++ b/src/scene_manager/scene_dump.c
@@ -2576,7 +2576,7 @@ static GF_Err DumpSceneReplace(GF_SceneDumper *sdump, GF_Command *com)
 	gf_dump_vrml_node(sdump, com->node, 0, NULL);
 	if (!sdump->XMLDump) gf_fprintf(sdump->trace, "\n\n");
 
-	if (com->aggregated) {
+	if (com->aggregated && com->node) {
 		u32 i, count;
 		count = gf_list_count(com->node->sgprivate->scenegraph->Routes);
 		for (i=0; i<count; i++) {

--- a/src/scenegraph/xml_ns.c
+++ b/src/scenegraph/xml_ns.c
@@ -397,7 +397,10 @@ static u32 gf_xml_get_namespace(GF_DOMNode *elt, const char *attribute_name)
 
 static char *gf_xml_get_namespace_qname(GF_DOMNode *elt, u32 ns)
 {
-	GF_DOMAttribute *att = elt->attributes;
+	GF_DOMAttribute *att;
+	if (!elt)
+		return NULL;
+   	att = elt->attributes;
 	while (att) {
 		if (att->tag==TAG_DOM_ATT_any) {
 			GF_DOMFullAttribute *datt = (GF_DOMFullAttribute*)att;


### PR DESCRIPTION
In the commit a5a8dbcdd956, `com->node` is checked before being used. However, the following code statements miss NULL checks of this variable:
[1] `count = gf_list_count(com->node->sgprivate->scenegraph->Routes)` in `DumpSceneReplace()`.
[2] `if (!elt->sgprivate->parents)` in `gf_xml_get_namespace_qname()`. `elt` is introduced from:
&emsp; `DumpLSRAddReplaceInsert()`
&emsp; &emsp;  `gf_svg_dump_attribute(com->node, ...)`
&emsp; &emsp; &emsp; elt = com->node;
&emsp; &emsp; &emsp; `gf_svg_get_attribute_name(elt, ...)`
&emsp; &emsp; &emsp; &emsp; `gf_xml_get_namespace_qname(elt, ...)`
Thus, NULL checks should be added before these code statements.