### PR TITLE
fix Null Pointer Dereference in function BS_ReadByte

### DIFF
--- a/src/utils/bitstream.c
+++ b/src/utils/bitstream.c
@@ -455,6 +455,9 @@ static u8 BS_ReadByte(GF_BitStream *bs)
 			if (!bs->overflow_state) bs->overflow_state = 1;
 			return 0;
 		}
+
+		if (!bs->original)
+			return 0;
 		res = bs->original[bs->position++];
 
 		if (bs->remove_emul_prevention_byte) {


### PR DESCRIPTION
fix #2550: Null Pointer Dereference in function BS_ReadByte