### PR TITLE
Fix strnicmp lens on some fileimport comparisons

### DIFF
--- a/applications/mp4box/fileimport.c
+++ b/applications/mp4box/fileimport.c
@@ -1226,10 +1226,10 @@ GF_Err import_file(GF_ISOFile *dest, char *inName, u32 import_flags, GF_Fraction
 				GOTO_EXIT("invalid format for fullrange")
 			}
 		}
-		else if (!strnicmp(ext+1, "videofmt=", 10)) {
+		else if (!strnicmp(ext+1, "videofmt=", 9)) {
 			u32 idx, count = GF_ARRAY_LENGTH(videofmt_names);
 			for (idx=0; idx<count; idx++) {
-				if (!strcmp(ext+11, videofmt_names[idx])) {
+				if (!strcmp(ext+10, videofmt_names[idx])) {
 					videofmt = idx;
 					break;
 				}
@@ -1253,8 +1253,8 @@ GF_Err import_file(GF_ISOFile *dest, char *inName, u32 import_flags, GF_Fraction
 				GOTO_EXIT("invalid format for colortfc")
 			}
 		}
-		else if (!strnicmp(ext+1, "colormx=", 10)) {
-			colormx = gf_cicp_parse_color_matrix(ext+11);
+		else if (!strnicmp(ext+1, "colormx=", 8)) {
+			colormx = gf_cicp_parse_color_matrix(ext+9);
 			if (colormx==-1) {
 				e = GF_BAD_PARAM;
 				GOTO_EXIT("invalid format for colormx")


### PR DESCRIPTION
I was trying to use `colormx` overrides today using mp4box and it refused to be parsed on the commandline. I dug in and noticed that these string comparisons were checking the wrong lengths, so I figured I'd contribute the few I noticed to be wrong. There might be others hiding in there (this fixed my `colormx` usage, at least)!

While I'm at it, thanks for mp4box; it is great stuff.