### PR TITLE
Fix nix flake for macOS

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,30 @@
 {
   "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686960236,
-        "narHash": "sha256-AYCC9rXNLpUWzD9hm+askOfpliLEC9kwAo7ITJc4HIw=",
+        "lastModified": 1694422566,
+        "narHash": "sha256-lHJ+A9esOz9vln/3CJG23FV6Wd2OoOFbDeEs4cMGMqc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "04af42f3b31dba0ef742d254456dc4c14eedac86",
+        "rev": "3a2786eea085f040a66ecde1bc3ddc7099f6dbeb",
         "type": "github"
       },
       "original": {
@@ -18,7 +36,23 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,55 +1,54 @@
 {
   description = "GPAC Multimedia Open Source Project";
-  inputs =  {
+  inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
   };
-  outputs = { self, nixpkgs }@inputs: 
-  let
-    pkgs = nixpkgs.legacyPackages.x86_64-linux;
-    buildInputs = with pkgs; [ 
-      zlib 
-      git
-      freetype 
-      libjpeg_turbo 
-      libpng 
-      libmad 
-      faad2 
-      libogg 
-      libvorbis 
-      libtheora
-      a52dec
-      ffmpeg
-      xorg.libX11
-      xorg.libXv
-      xorg.xorgproto
-      mesa
-      xvidcore
-      openssl
-      alsa-lib
-      jack2
-      pulseaudio
-      SDL2
-      mesa-demos
-    ];
-    nativeBuildInputs = with pkgs; [ pkg-config ];
- in
-  with pkgs; {  
-    devShells.x86_64-linux.default = mkShell {
-        inherit buildInputs nativeBuildInputs;
-    };
-    packages.x86_64-linux.default =  with import nixpkgs { system = "x86_64-linux"; };
-      stdenv.mkDerivation {
-        name = "gpac";
-        src = self;
-        inherit buildInputs nativeBuildInputs;
-        configurePhase = ''
-          runHook preConfigure
-          ./configure --prefix=$out
-          runHook postConfigure
-        '';
-        buildPhase = "make -j $NIX_BUILD_CORES";
-        installPhase = "make install";
-      }; 
-
-  };
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+        buildInputs = with pkgs; [
+          zlib
+          freetype
+          libjpeg_turbo
+          libpng
+          libmad
+          faad2
+          libaom
+          libogg
+          libvorbis
+          libtheora
+          a52dec
+          ffmpeg
+          xvidcore
+          openssl
+          SDL2
+        ] ++ (lib.optionals stdenv.isLinux [
+          xorg.libX11
+          xorg.libXv
+          xorg.xorgproto
+          mesa
+          alsa-lib
+          jack2
+          pulseaudio
+          mesa-demos
+        ]) ++ (lib.optionals stdenv.isDarwin [
+          darwin.apple_sdk_11_0.frameworks.Carbon
+        ]);
+        nativeBuildInputs = with pkgs; [ pkg-config git ];
+      in
+      with pkgs; {
+        devShells.default = mkShell {
+          inherit buildInputs nativeBuildInputs;
+        };
+        packages.default = stdenv.mkDerivation {
+          name = "gpac";
+          src = self;
+          enableParallelBuilding = true;
+          inherit buildInputs nativeBuildInputs;
+        };
+      });
 }

--- a/src/Makefile
+++ b/src/Makefile
@@ -374,16 +374,22 @@ crypto/g_crypt_openssl.o: crypto/g_crypt_openssl.c
 
 ifeq ($(CONFIG_DARWIN),yes)
 
+ifeq ($(STATIC_MODULES),yes)
 	$(LIBTOOL) -s -o ../bin/gcc/libgpac_static.a $(OBJS)
 	$(RANLIB) ../bin/gcc/libgpac_static.a
+endif
+
 ifneq ($(STATIC_BUILD),yes)
 	$(CC) $(SHFLAGS) $(LD_SONAME) -o $@ $(OBJS) $(ALL_LIBS) $(LDFLAGS)
 endif
 
 else
 
+ifeq ($(STATIC_MODULES),yes)
 	$(AR) cr ../bin/gcc/libgpac_static.a $(OBJS)
 	$(RANLIB) ../bin/gcc/libgpac_static.a
+endif
+
 ifneq ($(STATIC_BUILD),yes)
 	$(CC) $(SHFLAGS) $(LD_SONAME) -o $@ $(OBJS) $(ALL_LIBS) $(LDFLAGS)
 	mv $@ $@.$(VERSION_SONAME)


### PR DESCRIPTION
1. Generate outputs for all systems through flake-utils (x86_64 and aarch64 linux and darwin)
2. Add Carbon framework as build input on darwin (required by https://github.com/gpac/gpac/blob/d5dd620add58df9546d58211975943434364c060/applications/gpac/carbon_hook.c#L27)
3. Make some build inputs Linux specific: X11, mesa, alsa, jack2, pulseaudio
4. Move git to native build inputs (only relevant for cross compiling; native build inputs are specific to the host system, build inputs for the target system)
5. Only generate the static library `libgpac_static.a` if `STATIC_MODULES` is set. Nix prefers dynamic libraries (and actually passes a `--disable-static` to configure by default) and the static library adds unnecessary bloat. Furthermore, the presence of the static library seems to break the final binary (both gpac and MP4Box) in the Nix flake output for reasons I don't know yet (crashes immediately with `[1]    4966 killed     result/bin/gpac`), but with the static library disabled, everything is fine.
6. Remove the custom build phases as the default ones defined by Nix do the same (as long as `enableParallelBuilding = true` is defined).