### PR TITLE
fix: fix missing symbol gf_props_reset_single

### DIFF
--- a/src/filter_core/filter_props.c
+++ b/src/filter_core/filter_props.c
@@ -812,6 +812,7 @@ GF_PropertyMap * gf_props_new(GF_Filter *filter)
 	return map;
 }
 
+GF_EXPORT
 void gf_props_reset_single(GF_PropertyValue *p)
 {
 	if (p->type==GF_PROP_STRING) {


### PR DESCRIPTION
This is the only symbol that is missing when using libgpac. My use-case is specifically to use it from Node using the NAPI bindings in `share/nodejs`, but that missing symbol prevented the library from being loaded properly.

Note that I compile with those options, on Alpine 3.18.3 in a container:
```
./configure --disable-3d --disable-svg --disable-vrml --disable-x3d --disable-qtvr --disable-swf --disable-nvdec --disable-qjs --disable-qjs-libc
```

The `ldd` output before the fix, besides a loading error from Node was the following:
<details>
  <summary>LDD output</summary>

```
/workspaces/edifice $ ldd '/workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node'
        /lib/ld-musl-x86_64.so.1 (0x7f533d7b5000)
        libgpac.so.12 => /usr/lib/libgpac.so.12 (0x7f533d1b0000)
        libc.musl-x86_64.so.1 => /lib/ld-musl-x86_64.so.1 (0x7f533d7b5000)
        libz.so.1 => /lib/libz.so.1 (0x7f533d196000)
        libavcodec.so.60 => /usr/lib/libavcodec.so.60 (0x7f533bdb1000)
        libavformat.so.60 => /usr/lib/libavformat.so.60 (0x7f533bb35000)
        libswscale.so.7 => /usr/lib/libswscale.so.7 (0x7f533baa0000)
        libavutil.so.58 => /usr/lib/libavutil.so.58 (0x7f533b898000)
        libavdevice.so.60 => /usr/lib/libavdevice.so.60 (0x7f533b879000)
        libavfilter.so.9 => /usr/lib/libavfilter.so.9 (0x7f533b456000)
        libswresample.so.5 => /usr/lib/libswresample.so.5 (0x7f533b437000)
        libvpx.so.8 => /usr/lib/libvpx.so.8 (0x7f533b172000)
        libwebpmux.so.3 => /usr/lib/libwebpmux.so.3 (0x7f533b167000)
        libwebp.so.7 => /usr/lib/libwebp.so.7 (0x7f533b112000)
        libdav1d.so.6 => /usr/lib/libdav1d.so.6 (0x7f533af2d000)
        libaom.so.3 => /usr/lib/libaom.so.3 (0x7f533a7cf000)
        libjxl.so.0.8 => /usr/lib/libjxl.so.0.8 (0x7f533a3c4000)
        libjxl_threads.so.0.8 => /usr/lib/libjxl_threads.so.0.8 (0x7f533a3be000)
        libmp3lame.so.0 => /usr/lib/libmp3lame.so.0 (0x7f533a353000)
        libopus.so.0 => /usr/lib/libopus.so.0 (0x7f533a2f5000)
        libSvtAv1Enc.so.1 => /usr/lib/libSvtAv1Enc.so.1 (0x7f5339b65000)
        libtheoraenc.so.1 => /usr/lib/libtheoraenc.so.1 (0x7f5339b2d000)
        libtheoradec.so.1 => /usr/lib/libtheoradec.so.1 (0x7f5339b14000)
        libvorbis.so.0 => /usr/lib/libvorbis.so.0 (0x7f5339aed000)
        libvorbisenc.so.2 => /usr/lib/libvorbisenc.so.2 (0x7f5339a56000)
        libx264.so.164 => /usr/lib/libx264.so.164 (0x7f533972e000)
        libx265.so.199 => /usr/lib/libx265.so.199 (0x7f53384b2000)
        libxvidcore.so.4 => /usr/lib/libxvidcore.so.4 (0x7f53383e6000)
        libva.so.2 => /usr/lib/libva.so.2 (0x7f53383bd000)
        libvpl.so.2 => /usr/lib/libvpl.so.2 (0x7f5338384000)
        libxml2.so.2 => /usr/lib/libxml2.so.2 (0x7f5338271000)
        libbz2.so.1 => /usr/lib/libbz2.so.1 (0x7f533825e000)
        libopenmpt.so.0 => /usr/lib/libopenmpt.so.0 (0x7f533808c000)
        libbluray.so.2 => /usr/lib/libbluray.so.2 (0x7f533803d000)
        libgnutls.so.30 => /usr/lib/libgnutls.so.30 (0x7f5337e6e000)
        librist.so.4 => /usr/lib/librist.so.4 (0x7f5337e49000)
        libsrt.so.1.5 => /usr/lib/libsrt.so.1.5 (0x7f5337d5d000)
        libssh.so.4 => /usr/lib/libssh.so.4 (0x7f5337d03000)
        libzmq.so.5 => /usr/lib/libzmq.so.5 (0x7f5337c51000)
        libva-drm.so.2 => /usr/lib/libva-drm.so.2 (0x7f5337c4c000)
        libva-x11.so.2 => /usr/lib/libva-x11.so.2 (0x7f5337c45000)
        libvdpau.so.1 => /usr/lib/libvdpau.so.1 (0x7f5337c40000)
        libX11.so.6 => /usr/lib/libX11.so.6 (0x7f5337b22000)
        libdrm.so.2 => /usr/lib/libdrm.so.2 (0x7f5337b0c000)
        libxcb.so.1 => /usr/lib/libxcb.so.1 (0x7f5337ae5000)
        libxcb-shm.so.0 => /usr/lib/libxcb-shm.so.0 (0x7f5337ae0000)
        libxcb-shape.so.0 => /usr/lib/libxcb-shape.so.0 (0x7f5337adb000)
        libxcb-xfixes.so.0 => /usr/lib/libxcb-xfixes.so.0 (0x7f5337ad2000)
        libasound.so.2 => /usr/lib/libasound.so.2 (0x7f53379f1000)
        libpulse.so.0 => /usr/lib/libpulse.so.0 (0x7f53379a7000)
        libSDL2-2.0.so.0 => /usr/lib/libSDL2-2.0.so.0 (0x7f533782f000)
        libv4l2.so.0 => /usr/lib/libv4l2.so.0 (0x7f5337820000)
        libpostproc.so.57 => /usr/lib/libpostproc.so.57 (0x7f533780c000)
        libfribidi.so.0 => /usr/lib/libfribidi.so.0 (0x7f53377ef000)
        libplacebo.so.264 => /usr/lib/libplacebo.so.264 (0x7f5337727000)
        libass.so.9 => /usr/lib/libass.so.9 (0x7f53376fa000)
        libvidstab.so.1.2 => /usr/lib/libvidstab.so.1.2 (0x7f53376e6000)
        libzimg.so.2 => /usr/lib/libzimg.so.2 (0x7f5337629000)
        libfontconfig.so.1 => /usr/lib/libfontconfig.so.1 (0x7f53375ea000)
        libfreetype.so.6 => /usr/lib/libfreetype.so.6 (0x7f5337537000)
        libsoxr.so.0 => /usr/lib/libsoxr.so.0 (0x7f53374d7000)
        libsharpyuv.so.0 => /usr/lib/libsharpyuv.so.0 (0x7f53374cf000)
        libhwy.so.1 => /usr/lib/libhwy.so.1 (0x7f53374c5000)
        libbrotlidec.so.1 => /usr/lib/libbrotlidec.so.1 (0x7f53374b7000)
        libbrotlienc.so.1 => /usr/lib/libbrotlienc.so.1 (0x7f5337425000)
        liblcms2.so.2 => /usr/lib/liblcms2.so.2 (0x7f53373d3000)
        libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x7f5337185000)
        libogg.so.0 => /usr/lib/libogg.so.0 (0x7f533717b000)
        libnuma.so.1 => /usr/lib/libnuma.so.1 (0x7f533716f000)
        libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x7f5337151000)
        liblzma.so.5 => /usr/lib/liblzma.so.5 (0x7f533711a000)
        libmpg123.so.0 => /usr/lib/libmpg123.so.0 (0x7f53370de000)
        libvorbisfile.so.3 => /usr/lib/libvorbisfile.so.3 (0x7f53370d5000)
        libp11-kit.so.0 => /usr/lib/libp11-kit.so.0 (0x7f5336ff0000)
        libidn2.so.0 => /usr/lib/libidn2.so.0 (0x7f5336fbe000)
        libunistring.so.5 => /usr/lib/libunistring.so.5 (0x7f5336e18000)
        libtasn1.so.6 => /usr/lib/libtasn1.so.6 (0x7f5336e06000)
        libnettle.so.8 => /usr/lib/libnettle.so.8 (0x7f5336dbd000)
        libhogweed.so.6 => /usr/lib/libhogweed.so.6 (0x7f5336d77000)
        libgmp.so.10 => /usr/lib/libgmp.so.10 (0x7f5336d10000)
        libmbedcrypto.so.7 => /usr/lib/libmbedcrypto.so.7 (0x7f5336ca8000)
        libcjson.so.1 => /usr/lib/libcjson.so.1 (0x7f5336c9e000)
        libcrypto.so.3 => /lib/libcrypto.so.3 (0x7f533688b000)
        libsodium.so.23 => /usr/lib/libsodium.so.23 (0x7f533683a000)
        libXext.so.6 => /usr/lib/libXext.so.6 (0x7f5336829000)
        libXfixes.so.3 => /usr/lib/libXfixes.so.3 (0x7f5336821000)
        libX11-xcb.so.1 => /usr/lib/libX11-xcb.so.1 (0x7f533681c000)
        libxcb-dri3.so.0 => /usr/lib/libxcb-dri3.so.0 (0x7f5336816000)
        libXau.so.6 => /usr/lib/libXau.so.6 (0x7f5336811000)
        libXdmcp.so.6 => /usr/lib/libXdmcp.so.6 (0x7f5336809000)
        libpulsecommon-16.1.so => /usr/lib/pulseaudio/libpulsecommon-16.1.so (0x7f5336790000)
        libdbus-1.so.3 => /usr/lib/libdbus-1.so.3 (0x7f533674a000)
        libintl.so.8 => /usr/lib/libintl.so.8 (0x7f533673c000)
        libv4lconvert.so.0 => /usr/lib/libv4lconvert.so.0 (0x7f53366c3000)
        libshaderc_shared.so.1 => /usr/lib/libshaderc_shared.so.1 (0x7f53366b0000)
        libglslang-default-resource-limits.so.12 => /usr/lib/libglslang-default-resource-limits.so.12 (0x7f53366a8000)
        libSPIRV.so.12 => /usr/lib/libSPIRV.so.12 (0x7f5335d98000)
        libvulkan.so.1 => /usr/lib/libvulkan.so.1 (0x7f5335d25000)
        libharfbuzz.so.0 => /usr/lib/libharfbuzz.so.0 (0x7f5335c2b000)
        libunibreak.so.5 => /usr/lib/libunibreak.so.5 (0x7f5335c09000)
        libgomp.so.1 => /usr/lib/libgomp.so.1 (0x7f5335bc2000)
        libexpat.so.1 => /usr/lib/libexpat.so.1 (0x7f5335ba1000)
        libpng16.so.16 => /usr/lib/libpng16.so.16 (0x7f5335b71000)
        libbrotlicommon.so.1 => /usr/lib/libbrotlicommon.so.1 (0x7f5335b4e000)
        libffi.so.8 => /usr/lib/libffi.so.8 (0x7f5335b44000)
        libbsd.so.0 => /usr/lib/libbsd.so.0 (0x7f5335b2f000)
        libsndfile.so.1 => /usr/lib/libsndfile.so.1 (0x7f5335ac7000)
        libasyncns.so.0 => /usr/lib/libasyncns.so.0 (0x7f5335ac0000)
        libjpeg.so.8 => /usr/lib/libjpeg.so.8 (0x7f5335a3e000)
        libSPIRV-Tools.so => /usr/lib/libSPIRV-Tools.so (0x7f533594a000)
        libSPIRV-Tools-opt.so => /usr/lib/libSPIRV-Tools-opt.so (0x7f53357f7000)
        libglib-2.0.so.0 => /usr/lib/libglib-2.0.so.0 (0x7f53356ad000)
        libgraphite2.so.3 => /usr/lib/libgraphite2.so.3 (0x7f533568e000)
        libmd.so.0 => /usr/lib/libmd.so.0 (0x7f5335682000)
        libFLAC.so.12 => /usr/lib/libFLAC.so.12 (0x7f533563e000)
        libpcre2-8.so.0 => /usr/lib/libpcre2-8.so.0 (0x7f533559c000)
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_set_instance_data: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_get_value_uint32: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_make_callback: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_create_object: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_reference_unref: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: gf_props_reset_single: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_create_external_arraybuffer: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_create_array_with_length: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_detach_arraybuffer: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_close_handle_scope: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_create_int32: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_set_named_property: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_async_init: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_call_function: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_create_bigint_uint64: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_create_string_utf8: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_get_instance_data: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_get_value_string_utf8: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_get_reference_value: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_define_class: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_create_array: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_type_tag_object: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_get_value_int32: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_unwrap: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_create_buffer: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_async_destroy: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_throw_error: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_create_reference: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_get_boolean: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_get_value_int64: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_define_properties: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_delete_reference: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_create_function: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_check_object_type_tag: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_get_array_length: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_get_element: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_create_arraybuffer: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_get_value_double: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_has_named_property: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_create_uint32: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_set_element: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_is_array: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_create_typedarray: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_reference_ref: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_create_double: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_get_value_bool: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_get_cb_info: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_get_global: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_is_arraybuffer: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_get_named_property: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_get_null: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_get_property: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_create_int64: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_open_handle_scope: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_get_arraybuffer_info: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_wrap: symbol not found
Error relocating /workspaces/edifice/node_modules/gpac/prebuilds/linux-x64/node.napi.node: napi_typeof: symbol not found
```
</details>