### PR TITLE
ff_dec: avoid double unref when EAGAINed twice

### DIFF
--- a/src/filters/ff_dec.c
+++ b/src/filters/ff_dec.c
@@ -302,8 +302,8 @@ restart:
 	switch (res) {
 	case AVERROR(EAGAIN):
 		if (pck_src) {
-			gf_list_del_item(ctx->src_packets, pck_src);
-			gf_filter_pck_unref(pck_src);
+			if (gf_list_del_item(ctx->src_packets, pck_src) >= 0)
+				gf_filter_pck_unref(pck_src);
 		}
 		FF_RELEASE_PCK(pkt);
 		//input full but output available, go on but don't discard input


### PR DESCRIPTION
Initial crash can be reproduced with ```gpac -vbench av1.mp4```.

https://github.com/gpac/gpac/assets/1917976/87e736f7-70f2-47d5-882f-fd6155debdac

