### PR TITLE
VVC: Fix CTS for non-POC 0 IDR

### DIFF
--- a/src/filters/reframe_nalu.c
+++ b/src/filters/reframe_nalu.c
@@ -3728,7 +3728,7 @@ naldmx_flush:
 				if (!ctx->poc_diff || (ctx->poc_diff >= (s32) pdiff ) ) {
 					ctx->poc_diff = pdiff;
 					ctx->poc_probe_done = GF_FALSE;
-				} else if (first_in_au) {
+				} else if (first_in_au && ctx->last_temporal_id == 0) {
 					//second frame with the same poc diff, we should be able to properly recompute CTSs
 					ctx->poc_probe_done = GF_TRUE;
 				}


### PR DESCRIPTION
This is my fix for #2716 

As mentioned in the bug report it uses a heuristic to determine the `min_poc` after an IDR frame and delays dispatching of the packets accordingly. A proper fix should probably parse the SPS and use the `dpb_max_num_reorder_pics` syntax element from the contained `dpb_parameters`-structure to delay dispatching of the packets.

Also the patch sets the `ctx->poc_shift` which was previously set to 0 for IDR frames.