### PR TITLE
net: fix multicast IPV6 hops default value

### DIFF
--- a/include/gpac/network.h
+++ b/include/gpac/network.h
@@ -605,10 +605,10 @@ Performs multicast setup (BIND and JOIN) for the socket object
 \param multi_port the multicast port number
 \param TTL the multicast TTL (Time-To-Live)
 \param no_bind if sets, only join the multicast
-\param local_interface_ip the local interface IP address if desired. If NULL, the default interface will be used.
+\param ifce_ip_or_name the local interface IP address or name if desired. If NULL, the default interface will be used.
 \return error if any
  */
-GF_Err gf_sk_setup_multicast(GF_Socket *sock, const char *multi_ip_add, u16 multi_port, u32 TTL, Bool no_bind, const char *local_interface_ip);
+GF_Err gf_sk_setup_multicast(GF_Socket *sock, const char *multi_ip_add, u16 multi_port, u32 TTL, Bool no_bind, const char *ifce_ip_or_name);
 
 /*!
 \brief source-specific multicast setup
@@ -619,14 +619,14 @@ Performs multicast setup (BIND and JOIN) for the socket object using allowed and
 \param multi_port the multicast port number
 \param TTL the multicast TTL (Time-To-Live)
 \param no_bind if sets, only join the multicast
-\param local_interface_ip the local interface IP address if desired. If NULL, the default interface will be used.
+\param ifce_ip_or_name the local interface IP address or name if desired. If NULL, the default interface will be used.
 \param src_ip_inc IP of sources to receive from
 \param nb_src_ip_inc number of sources to receive from
 \param src_ip_exc IP of sources to exclude
 \param nb_src_ip_exc number of sources to exclude
 \return error if any
  */
-GF_Err gf_sk_setup_multicast_ex(GF_Socket *sock, const char *multi_ip_add, u16 multi_port, u32 TTL, Bool no_bind, const char *local_interface_ip, const char **src_ip_inc, u32 nb_src_ip_inc, const char **src_ip_exc, u32 nb_src_ip_exc);
+GF_Err gf_sk_setup_multicast_ex(GF_Socket *sock, const char *multi_ip_add, u16 multi_port, u32 TTL, Bool no_bind, const char *ifce_ip_or_name, const char **src_ip_inc, u32 nb_src_ip_inc, const char **src_ip_exc, u32 nb_src_ip_exc);
 
 /*!
  \brief multicast address test

--- a/include/gpac/network.h
+++ b/include/gpac/network.h
@@ -608,7 +608,7 @@ Performs multicast setup (BIND and JOIN) for the socket object
 \param local_interface_ip the local interface IP address if desired. If NULL, the default interface will be used.
 \return error if any
  */
-GF_Err gf_sk_setup_multicast(GF_Socket *sock, const char *multi_ip_add, u16 multi_port, u32 TTL, Bool no_bind, char *local_interface_ip);
+GF_Err gf_sk_setup_multicast(GF_Socket *sock, const char *multi_ip_add, u16 multi_port, u32 TTL, Bool no_bind, const char *local_interface_ip);
 
 /*!
 \brief source-specific multicast setup
@@ -626,7 +626,7 @@ Performs multicast setup (BIND and JOIN) for the socket object using allowed and
 \param nb_src_ip_exc number of sources to exclude
 \return error if any
  */
-GF_Err gf_sk_setup_multicast_ex(GF_Socket *sock, const char *multi_ip_add, u16 multi_port, u32 TTL, Bool no_bind, char *local_interface_ip, const char **src_ip_inc, u32 nb_src_ip_inc, const char **src_ip_exc, u32 nb_src_ip_exc);
+GF_Err gf_sk_setup_multicast_ex(GF_Socket *sock, const char *multi_ip_add, u16 multi_port, u32 TTL, Bool no_bind, const char *local_interface_ip, const char **src_ip_inc, u32 nb_src_ip_inc, const char **src_ip_exc, u32 nb_src_ip_exc);
 
 /*!
  \brief multicast address test

--- a/src/utils/os_net.c
+++ b/src/utils/os_net.c
@@ -3227,9 +3227,9 @@ GF_Err gf_sk_setup_multicast_ex(GF_Socket *sock, const char *multi_IPAdd, u16 Mu
 }
 
 GF_EXPORT
-GF_Err gf_sk_setup_multicast(GF_Socket *sock, const char *multi_IPAdd, u16 MultiPortNumber, u32 TTL, Bool NoBind, const char *local_interface_ip)
+GF_Err gf_sk_setup_multicast(GF_Socket *sock, const char *multi_IPAdd, u16 MultiPortNumber, u32 TTL, Bool NoBind, const char *ifce_ip_or_name)
 {
-	return gf_sk_setup_multicast_ex(sock, multi_IPAdd, MultiPortNumber, TTL, NoBind, local_interface_ip, NULL, 0, NULL, 0);
+	return gf_sk_setup_multicast_ex(sock, multi_IPAdd, MultiPortNumber, TTL, NoBind, ifce_ip_or_name, NULL, 0, NULL, 0);
 
 }
 

--- a/src/utils/os_net.c
+++ b/src/utils/os_net.c
@@ -3102,8 +3102,11 @@ GF_Err gf_sk_setup_multicast_ex(GF_Socket *sock, const char *multi_IPAdd, u16 Mu
 		}
 
 		/*set TTL*/
-		ret = setsockopt(sock->socket, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, (char *) &TTL, sizeof(TTL));
-		if (ret == SOCKET_ERROR) return GF_IP_CONNECTION_FAILURE;
+		if (TTL != 0) {
+			ret = setsockopt(sock->socket, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, (char *) &TTL, sizeof(TTL));
+			if (ret == SOCKET_ERROR) return GF_IP_CONNECTION_FAILURE;
+		}
+
 		/*enable loopback*/
 		optval = 1;
 		ret = setsockopt(sock->socket, IPPROTO_IPV6, IPV6_MULTICAST_LOOP, (char *) &optval, sizeof(optval));

--- a/src/utils/os_net.c
+++ b/src/utils/os_net.c
@@ -2828,7 +2828,7 @@ Bool gf_net_enum_interfaces(gf_net_ifce_enum do_enum, void *enum_cbk)
 }
 
 GF_EXPORT
-GF_Err gf_sk_setup_multicast_ex(GF_Socket *sock, const char *multi_IPAdd, u16 MultiPortNumber, u32 TTL, Bool NoBind, char *ifce_ip_or_name,
+GF_Err gf_sk_setup_multicast_ex(GF_Socket *sock, const char *multi_IPAdd, u16 MultiPortNumber, u32 TTL, Bool NoBind, const char *ifce_ip_or_name,
 	const char **src_ip_inc, u32 nb_src_ip_inc, const char **src_ip_exc, u32 nb_src_ip_exc)
 {
 	s32 ret;
@@ -3227,7 +3227,7 @@ GF_Err gf_sk_setup_multicast_ex(GF_Socket *sock, const char *multi_IPAdd, u16 Mu
 }
 
 GF_EXPORT
-GF_Err gf_sk_setup_multicast(GF_Socket *sock, const char *multi_IPAdd, u16 MultiPortNumber, u32 TTL, Bool NoBind, char *local_interface_ip)
+GF_Err gf_sk_setup_multicast(GF_Socket *sock, const char *multi_IPAdd, u16 MultiPortNumber, u32 TTL, Bool NoBind, const char *local_interface_ip)
 {
 	return gf_sk_setup_multicast_ex(sock, multi_IPAdd, MultiPortNumber, TTL, NoBind, local_interface_ip, NULL, 0, NULL, 0);
 


### PR DESCRIPTION
Forcing the HOPS to zero when not specified is quite confusing to the user. We let the IPV4 implementation to default when TTL isn't specified, let's make IPV6 have the same behavior.