### PR TITLE
Fix: Do Not Skip Overlapping LCT Fragments

### DIFF
--- a/src/media_tools/route_dmx.c
+++ b/src/media_tools/route_dmx.c
@@ -23,7 +23,6 @@
  *
  */
 
-#include <math.h>
 #include <gpac/route.h>
 
 #if !defined(GPAC_DISABLE_ROUTE)
@@ -960,8 +959,8 @@ static GF_Err gf_route_service_gather_object(GF_ROUTEDmx *routedmx, GF_ROUTEServ
 	} else {
 		int old_size = obj->frags[start_frag].size;
 
-		int end = fmax(start_offset+size, obj->frags[end_frag-1].offset+obj->frags[end_frag-1].size);
-		obj->frags[start_frag].offset = fmin(obj->frags[start_frag].offset, start_offset);
+		int end = MAX(start_offset+size, obj->frags[end_frag-1].offset+obj->frags[end_frag-1].size);
+		obj->frags[start_frag].offset = MIN(obj->frags[start_frag].offset, start_offset);
 		obj->frags[start_frag].size = end - obj->frags[start_frag].offset;
 
 		if(end_frag == start_frag + 1) {

--- a/src/media_tools/route_dmx.c
+++ b/src/media_tools/route_dmx.c
@@ -763,7 +763,7 @@ static GF_Err gf_route_service_flush_object(GF_ROUTEService *s, GF_LCTObject *ob
 
 static GF_Err gf_route_service_gather_object(GF_ROUTEDmx *routedmx, GF_ROUTEService *s, u32 tsi, u32 toi, u32 start_offset, char *data, u32 size, u32 total_len, Bool close_flag, Bool in_order, GF_ROUTELCTChannel *rlct, GF_LCTObject **gather_obj)
 {
-	Bool /*inserted,*/ done;
+	Bool done;
 	u32 i, count;
     Bool do_push = GF_FALSE;
 	GF_LCTObject *obj = s->last_active_obj;
@@ -928,8 +928,6 @@ static GF_Err gf_route_service_gather_object(GF_ROUTEDmx *routedmx, GF_ROUTEServ
     }
 	obj->nb_recv_bytes += size;
 
-	//inserted = GF_FALSE;
-
 	int start_frag = -1;
 	int end_frag = -1;
 	for (i=0; (i < obj->nb_frags) && (start_frag==-1 || end_frag==-1); i++) {
@@ -959,8 +957,6 @@ static GF_Err gf_route_service_gather_object(GF_ROUTEDmx *routedmx, GF_ROUTEServ
 		obj->frags[start_frag].size = size;
 		obj->nb_bytes += size;
 		obj->nb_frags++;
-		//inserted = GF_TRUE;
-
 	} else {
 		int old_size = obj->frags[start_frag].size;
 
@@ -986,64 +982,12 @@ static GF_Err gf_route_service_gather_object(GF_ROUTEDmx *routedmx, GF_ROUTEServ
 				obj->nb_bytes += obj->frags[i].size;
 			}
 		}
-		//inserted = GF_TRUE;
 	}
 
 	if (!start_frag) {
 		do_push = start_offset ? GF_FALSE : routedmx->progressive_dispatch;
 	}
-	/*
-	for (i=0; i<obj->nb_frags; i++) {
-		if ((obj->frags[i].offset <= start_offset) && (obj->frags[i].offset + obj->frags[i].size >= start_offset + size) ) {
-            //data already received
-			goto check_done;
-		}
 
-		//insert fragment
-		if (obj->frags[i].offset > start_offset) {
-			//check overlap (not sure if this is legal)
-			if (start_offset + size > obj->frags[i].offset) {
-				GF_LOG(GF_LOG_WARNING, GF_LOG_ROUTE, ("[ROUTE] Service %d Overlapping LCT fragment, not supported\n", s->service_id));
-				return GF_NOT_SUPPORTED;
-			}
-			if (obj->nb_frags==obj->nb_alloc_frags) {
-				obj->nb_alloc_frags *= 2;
-				obj->frags = gf_realloc(obj->frags, sizeof(GF_LCTFragInfo)*obj->nb_alloc_frags);
-			}
-			memmove(&obj->frags[i+1], &obj->frags[i], sizeof(GF_LCTFragInfo) * (obj->nb_frags - i)  );
-			obj->frags[i].offset = start_offset;
-			obj->frags[i].size = size;
-			obj->nb_bytes += size;
-			obj->nb_frags++;
-			inserted = GF_TRUE;
-            if (!i)
-                do_push = start_offset ? GF_FALSE : routedmx->progressive_dispatch;
-			break;
-		}
-		//expand fragment
-		if (obj->frags[i].offset + obj->frags[i].size == start_offset) {
-			obj->frags[i].size += size;
-			obj->nb_bytes += size;
-			inserted = GF_TRUE;
-            if (!i)
-                do_push = obj->frags[0].offset ? GF_FALSE : routedmx->progressive_dispatch;
-			break;
-		}
-	}
-
-	if (!inserted) {
-		if (obj->nb_frags==obj->nb_alloc_frags) {
-			obj->nb_alloc_frags *= 2;
-			obj->frags = gf_realloc(obj->frags, sizeof(GF_LCTFragInfo)*obj->nb_alloc_frags);
-		}
-		obj->frags[obj->nb_frags].offset = start_offset;
-		obj->frags[obj->nb_frags].size = size;
-		obj->nb_frags++;
-		obj->nb_bytes += size;
-        if (obj->nb_frags==1)
-            do_push = start_offset ? GF_FALSE : routedmx->progressive_dispatch;
-	}
-	*/
 	obj->nb_recv_frags++;
 	obj->status = GF_LCT_OBJ_RECEPTION;
 


### PR DESCRIPTION
When receiving LCT fragments, ensure that packets are not skipped if they overlap with received packets. 
This fix addresses the issue where skipping overlapped packets led to potential data loss or processing errors.