### PR TITLE
Enhancements for Manifest Parsing and Validation

### DIFF
--- a/include/gpac/tools.h
+++ b/include/gpac/tools.h
@@ -379,6 +379,16 @@ Compares two timestamps
  */
 Bool gf_timestamp_equal(u64 value1, u64 timescale1, u64 value2, u64 timescale2);
 
+/*!
+\brief strict convert str into integer
+
+Validate and parse str into integer
+\param str text to convert to integer
+\param integer to fill
+\return GF_TRUE if str represents an integer without any leading space nor extra chars
+ */
+Bool gf_strict_atoi(const char* str, int* ans);
+
 /*! @} */
 
 /*!

--- a/src/media_tools/route_dmx.c
+++ b/src/media_tools/route_dmx.c
@@ -1560,6 +1560,16 @@ static GF_Err gf_route_dmx_process_service_signaling(GF_ROUTEDmx *routedmx, GF_R
 		GF_LOG(GF_LOG_ERROR, GF_LOG_ROUTE, ("[ROUTE] Service %d Unable to process %d remaining characters in the payload due to data corruption\n",s->service_id, payload_size));
 		return GF_CORRUPTED_DATA;
 	} else {
+		GF_ROUTESession *rsess;
+		u32 i=0;
+		u32 nb_channels=0;
+		while ((rsess = gf_list_enum(s->route_sessions, &i))) {
+			nb_channels += gf_list_count(rsess->channels);
+		}
+		if(nb_channels == 0) {
+			GF_LOG(GF_LOG_ERROR, GF_LOG_ROUTE, ("[ROUTE] Service %d No session found, dropping manifest\n", s->service_id));
+			return GF_INVALID_CONFIGURATION;
+		}
 		return GF_OK;
 	}
 }

--- a/src/media_tools/route_dmx.c
+++ b/src/media_tools/route_dmx.c
@@ -1244,7 +1244,16 @@ static GF_Err gf_route_service_setup_stsid(GF_ROUTEDmx *routedmx, GF_ROUTEServic
 							u32 n=0;
 							while ((att = gf_list_enum(fdt->attributes, &n))) {
 								if (!strcmp(att->name, "Content-Location")) rf->filename = gf_strdup(att->value);
-								else if (!strcmp(att->name, "TOI")) sscanf(att->value, "%u", &rf->toi);
+								else if (!strcmp(att->name, "TOI")) {
+									char * end_ptr;
+									rf->toi = strtol(att->value, &end_ptr, 10); 
+									if(end_ptr == att->value || *end_ptr != '\0') {
+										GF_LOG(GF_LOG_ERROR, GF_LOG_ROUTE, ("[ROUTE] Service %d wrong TOI value (%s), it should be numeric \n", s->service_id, att->value));
+										gf_free(rf->filename);
+										gf_free(rf);
+										return GF_CORRUPTED_DATA;
+									}
+								}
 							}
 							if (!rf->filename) {
 								gf_free(rf);
@@ -1272,7 +1281,16 @@ static GF_Err gf_route_service_setup_stsid(GF_ROUTEDmx *routedmx, GF_ROUTEServic
 							u32 n=0;
 							while ((att = gf_list_enum(fdt->attributes, &n))) {
 								if (!strcmp(att->name, "Content-Location")) rf->filename = gf_strdup(att->value);
-								else if (!strcmp(att->name, "TOI")) sscanf(att->value, "%u", &rf->toi);
+								else if (!strcmp(att->name, "TOI")) {
+									char * end_ptr;
+									rf->toi = strtol(att->value, &end_ptr, 10); 
+									if(end_ptr == att->value || *end_ptr != '\0') {
+										GF_LOG(GF_LOG_ERROR, GF_LOG_ROUTE, ("[ROUTE] Service %d wrong TOI value (%s), it should be numeric \n", s->service_id, att->value));
+										gf_free(rf->filename);
+										gf_free(rf);
+										return GF_CORRUPTED_DATA;
+									}
+								}
 							}
 							if (!rf->filename) {
 								gf_free(rf);

--- a/src/media_tools/route_dmx.c
+++ b/src/media_tools/route_dmx.c
@@ -1160,9 +1160,7 @@ static GF_Err gf_route_service_setup_stsid(GF_ROUTEDmx *routedmx, GF_ROUTEServic
 		while ((att = gf_list_enum(rs->attributes, &j))) {
 			if (!stricmp(att->name, "dIpAddr")) dst_ip = att->value;
 			else if (!stricmp(att->name, "dPort")) {
-				char* end_ptr;
-				dst_port = strtol(att->value, &end_ptr, 10); 
-				if(isspace(*att->value) || end_ptr == att->value || *end_ptr != '\0') {
+				if(! gf_strict_atoi(att->value, &dst_port)) {
 					GF_LOG(GF_LOG_ERROR, GF_LOG_ROUTE, ("[ROUTE] Service %d wrong dPort value (%s), it should be numeric \n", s->service_id, att->value));
 					return GF_CORRUPTED_DATA;
 				} else if(dst_port >= 65536 || dst_port < 0) {
@@ -1204,9 +1202,7 @@ static GF_Err gf_route_service_setup_stsid(GF_ROUTEDmx *routedmx, GF_ROUTEServic
 			k=0;
 			while ((att = gf_list_enum(ls->attributes, &k))) {
 				if (!strcmp(att->name, "tsi")) {
-					char* end_ptr;
-					tsi = strtol(att->value, &end_ptr, 10); 
-					if(isspace(*att->value) || end_ptr == att->value || *end_ptr != '\0') {
+					if(! gf_strict_atoi(att->value, &tsi)) {
 						GF_LOG(GF_LOG_ERROR, GF_LOG_ROUTE, ("[ROUTE] Service %d wrong TSI value (%s), it should be numeric \n", s->service_id, att->value));
 						return GF_CORRUPTED_DATA;
 					}
@@ -1262,9 +1258,7 @@ static GF_Err gf_route_service_setup_stsid(GF_ROUTEDmx *routedmx, GF_ROUTEServic
 							while ((att = gf_list_enum(fdt->attributes, &n))) {
 								if (!strcmp(att->name, "Content-Location")) rf->filename = gf_strdup(att->value);
 								else if (!strcmp(att->name, "TOI")) {
-									char * end_ptr;
-									rf->toi = strtol(att->value, &end_ptr, 10); 
-									if(isspace(*att->value) || end_ptr == att->value || *end_ptr != '\0') {
+									if(! gf_strict_atoi(att->value, &rf->toi)) {
 										GF_LOG(GF_LOG_ERROR, GF_LOG_ROUTE, ("[ROUTE] Service %d wrong TOI value (%s), it should be numeric \n", s->service_id, att->value));
 										gf_free(rf->filename);
 										gf_free(rf);
@@ -1299,9 +1293,7 @@ static GF_Err gf_route_service_setup_stsid(GF_ROUTEDmx *routedmx, GF_ROUTEServic
 							while ((att = gf_list_enum(fdt->attributes, &n))) {
 								if (!strcmp(att->name, "Content-Location")) rf->filename = gf_strdup(att->value);
 								else if (!strcmp(att->name, "TOI")) {
-									char * end_ptr;
-									rf->toi = strtol(att->value, &end_ptr, 10); 
-									if(isspace(*att->value) || end_ptr == att->value || *end_ptr != '\0') {
+									if(! gf_strict_atoi(att->value, &rf->toi)) {
 										GF_LOG(GF_LOG_ERROR, GF_LOG_ROUTE, ("[ROUTE] Service %d wrong TOI value (%s), it should be numeric \n", s->service_id, att->value));
 										gf_free(rf->filename);
 										gf_free(rf);

--- a/src/media_tools/route_dmx.c
+++ b/src/media_tools/route_dmx.c
@@ -1196,7 +1196,7 @@ static GF_Err gf_route_service_setup_stsid(GF_ROUTEDmx *routedmx, GF_ROUTEServic
 				if (!strcmp(att->name, "tsi")) {
 					char* end_ptr;
 					tsi = strtol(att->value, &end_ptr, 10); 
-					if(end_ptr == att->value || *end_ptr != '\0') {
+					if(isspace(*att->value) || end_ptr == att->value || *end_ptr != '\0') {
 						GF_LOG(GF_LOG_ERROR, GF_LOG_ROUTE, ("[ROUTE] Service %d wrong TSI value (%s), it should be numeric \n", s->service_id, att->value));
 						return GF_CORRUPTED_DATA;
 					}
@@ -1254,7 +1254,7 @@ static GF_Err gf_route_service_setup_stsid(GF_ROUTEDmx *routedmx, GF_ROUTEServic
 								else if (!strcmp(att->name, "TOI")) {
 									char * end_ptr;
 									rf->toi = strtol(att->value, &end_ptr, 10); 
-									if(end_ptr == att->value || *end_ptr != '\0') {
+									if(isspace(*att->value) || end_ptr == att->value || *end_ptr != '\0') {
 										GF_LOG(GF_LOG_ERROR, GF_LOG_ROUTE, ("[ROUTE] Service %d wrong TOI value (%s), it should be numeric \n", s->service_id, att->value));
 										gf_free(rf->filename);
 										gf_free(rf);
@@ -1291,7 +1291,7 @@ static GF_Err gf_route_service_setup_stsid(GF_ROUTEDmx *routedmx, GF_ROUTEServic
 								else if (!strcmp(att->name, "TOI")) {
 									char * end_ptr;
 									rf->toi = strtol(att->value, &end_ptr, 10); 
-									if(end_ptr == att->value || *end_ptr != '\0') {
+									if(isspace(*att->value) || end_ptr == att->value || *end_ptr != '\0') {
 										GF_LOG(GF_LOG_ERROR, GF_LOG_ROUTE, ("[ROUTE] Service %d wrong TOI value (%s), it should be numeric \n", s->service_id, att->value));
 										gf_free(rf->filename);
 										gf_free(rf);

--- a/src/media_tools/route_dmx.c
+++ b/src/media_tools/route_dmx.c
@@ -1193,7 +1193,14 @@ static GF_Err gf_route_service_setup_stsid(GF_ROUTEDmx *routedmx, GF_ROUTEServic
 			//extract TSI
 			k=0;
 			while ((att = gf_list_enum(ls->attributes, &k))) {
-				if (!strcmp(att->name, "tsi")) sscanf(att->value, "%u", &tsi);
+				if (!strcmp(att->name, "tsi")) {
+					char* end_ptr;
+					tsi = strtol(att->value, &end_ptr, 10); 
+					if(end_ptr == att->value || *end_ptr != '\0') {
+						GF_LOG(GF_LOG_ERROR, GF_LOG_ROUTE, ("[ROUTE] Service %d wrong TSI value (%s), it should be numeric \n", s->service_id, att->value));
+						return GF_CORRUPTED_DATA;
+					}
+				}
 			}
 			if (!tsi) {
 				GF_LOG(GF_LOG_ERROR, GF_LOG_ROUTE, ("[ROUTE] Service %d missing TSI in LS/ROUTE session\n", s->service_id));

--- a/src/media_tools/route_dmx.c
+++ b/src/media_tools/route_dmx.c
@@ -1528,6 +1528,8 @@ static GF_Err gf_route_dmx_process_service_signaling(GF_ROUTEDmx *routedmx, GF_R
 			} else {
 				GF_LOG(GF_LOG_DEBUG, GF_LOG_ROUTE, ("[ROUTE] Service %d same S-TSID version, ignoring\n",s->service_id));
 			}
+		} else {
+			GF_LOG(GF_LOG_WARNING, GF_LOG_ROUTE, ("[ROUTE] Service %d unsupported content type (%s), parsing payload is skipped\n", s->service_id, szContentType));
 		}
 		if (!sep) break;
 		sep[0] = boundary[0];

--- a/src/media_tools/route_dmx.c
+++ b/src/media_tools/route_dmx.c
@@ -1159,7 +1159,17 @@ static GF_Err gf_route_service_setup_stsid(GF_ROUTEDmx *routedmx, GF_ROUTEServic
 		j=0;
 		while ((att = gf_list_enum(rs->attributes, &j))) {
 			if (!stricmp(att->name, "dIpAddr")) dst_ip = att->value;
-			else if (!stricmp(att->name, "dPort")) dst_port = atoi(att->value);
+			else if (!stricmp(att->name, "dPort")) {
+				char* end_ptr;
+				dst_port = strtol(att->value, &end_ptr, 10); 
+				if(isspace(*att->value) || end_ptr == att->value || *end_ptr != '\0') {
+					GF_LOG(GF_LOG_ERROR, GF_LOG_ROUTE, ("[ROUTE] Service %d wrong dPort value (%s), it should be numeric \n", s->service_id, att->value));
+					return GF_CORRUPTED_DATA;
+				} else if(dst_port >= 65536 || dst_port < 0) {
+					GF_LOG(GF_LOG_ERROR, GF_LOG_ROUTE, ("[ROUTE] Service %d wrong dPort value (%s), it should belong to the interval [0, 65535] \n", s->service_id, att->value));
+					return GF_CORRUPTED_DATA;
+				}
+			}
 		}
 
 		GF_SAFEALLOC(rsess, GF_ROUTESession);

--- a/src/utils/error.c
+++ b/src/utils/error.c
@@ -2169,3 +2169,9 @@ Bool gf_parse_frac(const char *value, GF_Fraction *frac)
 	frac->den = (u32) r.den;
 	return res;
 }
+
+Bool gf_strict_atoi(const char* str, int* ans) {
+    char * end_ptr;
+    *ans = strtol(str, &end_ptr, 10); 
+    return !isspace(*str) && end_ptr != str && *end_ptr == '\0';
+}

--- a/src/utils/error.c
+++ b/src/utils/error.c
@@ -2171,7 +2171,7 @@ Bool gf_parse_frac(const char *value, GF_Fraction *frac)
 }
 
 Bool gf_strict_atoi(const char* str, int* ans) {
-    char * end_ptr;
+    char* end_ptr = NULL;
     *ans = strtol(str, &end_ptr, 10); 
     return !isspace(*str) && end_ptr != str && *end_ptr == '\0';
 }


### PR DESCRIPTION
-  Replace sscanf with strtol to ensure TOI field is parsed as an integer.
-  Replace sscanf with strtol to ensure TSI field is parsed as an integer.
-  Validate that the dport field is an integer within the range [0, 65535].
-  Verify if session channels are defined in the manifest.