### PR TITLE
Fix bugs found by fuzzer

### DIFF
--- a/src/filter_core/filter_pid.c
+++ b/src/filter_core/filter_pid.c
@@ -5613,7 +5613,7 @@ static GF_PropertyMap *check_new_pid_props(GF_FilterPid *pid, Bool merge_props)
 	nb_recf = 0;
 	for (i=0; i<pid->num_destinations; i++) {
 		GF_FilterPidInst *pidi = gf_list_get(pid->destinations, i);
-		if (!pidi->filter->process_task_queued) {
+		if (!pidi->filter || !pidi->filter->process_task_queued) {
 			//remember the pid prop map to use
 			pidi->reconfig_pid_props = map;
 			nb_recf++;

--- a/src/filters/in_route.c
+++ b/src/filters/in_route.c
@@ -190,7 +190,7 @@ static void routein_repair_segment_isobmf(ROUTEInCtx *ctx, GF_ROUTEEventFileInfo
     //if box completely in a received byte range, keep as is
     //if mdat or free box, keep as is
     //otherwise change box type to free
-    while (pos + 8 < size) {
+    while ((u64)pos + 8 < size) {
         u32 i;
 		Bool is_mdat = GF_FALSE;
         Bool box_complete = GF_FALSE;

--- a/src/isomedia/stbl_write.c
+++ b/src/isomedia/stbl_write.c
@@ -1980,7 +1980,9 @@ GF_Err stbl_AppendCTSOffset(GF_SampleTableBox *stbl, s32 offset)
 	ctts->nb_entries++;
 	if (offset<0) ctts->version=1;
 
-	if (ABS(offset) >= ctts->max_cts_delta) {
+	if(offset == GF_INT_MIN) {
+		ctts->max_cts_delta = GF_INT_MAX;
+	} else if (ABS(offset) > ctts->max_cts_delta) {
 		ctts->max_cts_delta = ABS(offset);
 		//ctts->sample_num_max_cts_delta = ctts->w_LastSampleNumber;
 	}

--- a/src/media_tools/route_dmx.c
+++ b/src/media_tools/route_dmx.c
@@ -783,7 +783,7 @@ static GF_Err gf_route_service_gather_object(GF_ROUTEDmx *routedmx, GF_ROUTEServ
 		}
 	}
 
-	if(total_len && (start_offset + size > total_len)) {
+	if(total_len && ((u64)start_offset + size > total_len)) {
 		GF_LOG(GF_LOG_ERROR, GF_LOG_ROUTE, ("[ROUTE] Service %d TSI %u TOI %u Corrupted data: Offset (%u) + Size (%u) exceeds Total Size of the object (%u), skipping\n", s->service_id, tsi, toi, start_offset, size, total_len));
 		return GF_NOT_SUPPORTED;
 	}
@@ -1025,7 +1025,7 @@ static GF_Err gf_route_service_gather_object(GF_ROUTEDmx *routedmx, GF_ROUTEServ
         obj->blob.data = obj->payload;
         gf_mx_v(routedmx->blob_mx);
     }
-	gf_assert(obj->alloc_size >= start_offset + size);
+	gf_assert(obj->alloc_size >= (u64)start_offset + size);
 
 	memcpy(obj->payload + start_offset, data, size);
 	GF_LOG(GF_LOG_DEBUG, GF_LOG_ROUTE, ("[ROUTE] Service %d TSI %u TOI %u append LCT fragment, offset %d total size %d recv bytes %d - offset diff since last %d\n", s->service_id, obj->tsi, obj->toi, start_offset, obj->total_length, obj->nb_bytes, (s32) start_offset - (s32) obj->prev_start_offset));

--- a/src/media_tools/route_dmx.c
+++ b/src/media_tools/route_dmx.c
@@ -861,7 +861,7 @@ static GF_Err gf_route_service_gather_object(GF_ROUTEDmx *routedmx, GF_ROUTEServ
 		gf_list_add(s->objects, obj);
 	} else if (!obj->total_length && total_len) {
 		GF_LOG(GF_LOG_INFO, GF_LOG_ROUTE, ("[ROUTE] Service %d object TSI %u TOI %u was started without total-length assigned, assigning to %u\n", s->service_id, tsi, toi, total_len));
-        // Check if there are no fragments in the object that extend beyond the total length
+		// Check if there are no fragments in the object that extend beyond the total length
 		for (i=0; i < obj->nb_frags; i++) {
 			if((u64) obj->frags[i].offset + obj->frags[i].size > total_len) {
 				GF_LOG(GF_LOG_ERROR, GF_LOG_ROUTE, ("[ROUTE] Service %d object TSI %u TOI %u: TOL (%u) doesn't cover previously received fragment [%u, %u[, purging object \n", s->service_id, tsi, toi, total_len, obj->frags[i].offset, obj->frags[i].offset+obj->frags[i].size));

--- a/src/media_tools/route_dmx.c
+++ b/src/media_tools/route_dmx.c
@@ -830,6 +830,14 @@ static GF_Err gf_route_service_gather_object(GF_ROUTEDmx *routedmx, GF_ROUTEServ
 		obj->tsi = tsi;
 		obj->status = GF_LCT_OBJ_INIT;
 		obj->total_length = total_len;
+		if (obj->alloc_size < total_len) {
+            gf_mx_p(routedmx->blob_mx);
+            obj->payload = gf_realloc(obj->payload, total_len);
+            obj->alloc_size = total_len;
+            obj->blob.size = total_len;
+            obj->blob.data = obj->payload;
+            gf_mx_v(routedmx->blob_mx);
+        }
 		if (tsi && rlct) {
 			count = gf_list_count(rlct->static_files);
 			obj->rlct = rlct;

--- a/src/media_tools/route_dmx.c
+++ b/src/media_tools/route_dmx.c
@@ -1773,6 +1773,9 @@ static GF_Err gf_route_dmx_process_service(GF_ROUTEDmx *routedmx, GF_ROUTEServic
 
 		case GF_LCT_EXT_TOL24:
 			tol_size = gf_bs_read_int(routedmx->bs, 24);
+			if(! tol_size) {
+				GF_LOG(GF_LOG_WARNING, GF_LOG_ROUTE, ("[ROUTE] Service %d : wrong TOL=%u value \n", s->service_id, tol_size));
+			}
 			break;
 
 		case GF_LCT_EXT_TOL48:
@@ -1781,6 +1784,9 @@ static GF_Err gf_route_dmx_process_service(GF_ROUTEDmx *routedmx, GF_ROUTEServic
 				continue;
 			}
 			tol_size = gf_bs_read_long_int(routedmx->bs, 48);
+			if(! tol_size) {
+				GF_LOG(GF_LOG_WARNING, GF_LOG_ROUTE, ("[ROUTE] Service %d : wrong TOL=%u value \n", s->service_id, tol_size));
+			}
 			break;
 
 		default:


### PR DESCRIPTION
- Fixing runtime error: 
> negation of -2147483648 cannot be represented in type 'int'

- Check if `filter` field is not null also to prevent segmentation fault
- In Route dmx, update `alloc_size` of an object if necessary when picking it from reservoir
- Cast to `u64` to avoid overflow in comparisons
- Purge segment if there are any fragments that extend beyond the total length
- Display warning message if received TOL is null