### PR TITLE
use plain memcpy instead of zmemcpy macro

### DIFF
--- a/src/utils/gzio.c
+++ b/src/utils/gzio.c
@@ -407,7 +407,7 @@ int gf_gzread(void *file, voidp buf, unsigned len)
 			uInt n = s->stream.avail_in;
 			if (n > s->stream.avail_out) n = s->stream.avail_out;
 			if (n > 0) {
-				zmemcpy(s->stream.next_out, s->stream.next_in, n);
+				memcpy(s->stream.next_out, s->stream.next_in, n);
 				next_out += n;
 				s->stream.next_out = next_out;
 				s->stream.next_in   += n;


### PR DESCRIPTION
This fixes build with zlib-ng, which doesn't define the macro.

Regardless, this macro was defined to memcpy in most cases anyway: https://github.com/madler/zlib/blob/master/zutil.h#L209