### PR TITLE
use correct pointer type for CUdeviceptr on aarch64 in nvdec filter

### DIFF
--- a/src/filters/dec_nvdec_sdk.c
+++ b/src/filters/dec_nvdec_sdk.c
@@ -197,7 +197,7 @@ tcuvidDecodePicture                   *cuvidDecodePicture;
 tcuvidMapVideoFrame                   *cuvidMapVideoFrame;
 tcuvidUnmapVideoFrame                 *cuvidUnmapVideoFrame;
 
-#if defined(WIN64) || defined(_WIN64) || defined(__x86_64) || defined(AMD64) || defined(_M_AMD64)
+#if defined(WIN64) || defined(_WIN64) || defined(__x86_64) || defined(AMD64) || defined(_M_AMD64) || defined(__aarch64__)
 tcuvidMapVideoFrame64                 *cuvidMapVideoFrame64;
 tcuvidUnmapVideoFrame64               *cuvidUnmapVideoFrame64;
 #endif

--- a/src/filters/dec_nvdec_sdk.h
+++ b/src/filters/dec_nvdec_sdk.h
@@ -1821,7 +1821,7 @@ typedef void *CUDADRIVER;
 
 
 
-#if defined(__x86_64) || defined(AMD64) || defined(_M_AMD64)
+#if defined(__x86_64) || defined(AMD64) || defined(_M_AMD64) || defined(__aarch64__)
 #if (CUDA_VERSION >= 3020) && (!defined(CUDA_FORCE_API_VERSION) || (CUDA_FORCE_API_VERSION >= 3020))
 #define __CUVID_DEVPTR64
 #endif
@@ -2526,7 +2526,7 @@ typedef CUresult CUDAAPI tcuvidMapVideoFrame(CUvideodecoder hDecoder, int nPicId
 typedef CUresult CUDAAPI tcuvidUnmapVideoFrame(CUvideodecoder hDecoder, unsigned int DevPtr);
 #endif
 
-#if defined(WIN64) || defined(_WIN64) || defined(__x86_64) || defined(AMD64) || defined(_M_AMD64)
+#if defined(WIN64) || defined(_WIN64) || defined(__x86_64) || defined(AMD64) || defined(_M_AMD64) || defined(__aarch64__)
 /**
  * \fn CUresult CUDAAPI cuvidMapVideoFrame64(CUvideodecoder hDecoder, int nPicIdx, unsigned long long *pDevPtr, unsigned int *pPitch, CUVIDPROCPARAMS *pVPP);
  * map a video frame


### PR DESCRIPTION
This fixes the following warnings:
```
...
filters/dec_nvdec.c: In function ‘nvdec_flush_frame’:
filters/dec_nvdec.c:1031:98: warning: passing argument 3 of ‘cuvidMapVideoFrame’ from incompatible pointer type [-Wincompatible-pointer-types]
 1031 |                 res = cuvidMapVideoFrame(ctx->dec_inst->cu_decoder, f->frame_info.picture_index, &map_mem, &pitch, &params);
      |                                                                                                  ^~~~~~~~
      |                                                                                                  |
      |                                                                                                  CUdeviceptr * {aka long long unsigned int *}
filters/dec_nvdec.c:1031:98: note: expected ‘unsigned int *’ but argument is of type ‘CUdeviceptr *’ {aka ‘long long unsigned int *’}
filters/dec_nvdec.c: In function ‘nvframe_get_gl_texture’:
filters/dec_nvdec.c:1209:90: warning: passing argument 3 of ‘cuvidMapVideoFrame’ from incompatible pointer type [-Wincompatible-pointer-types]
 1209 |         res = cuvidMapVideoFrame(ctx->dec_inst->cu_decoder, f->frame_info.picture_index, &vid_data, &vid_pitch, &params);
      |                                                                                          ^~~~~~~~~
      |                                                                                          |
      |                                                                                          CUdeviceptr * {aka long long unsigned int *}
filters/dec_nvdec.c:1209:90: note: expected ‘unsigned int *’ but argument is of type ‘CUdeviceptr *’ {aka ‘long long unsigned int *’}
filters/dec_nvdec.c: In function ‘nvframe_get_frame’:
filters/dec_nvdec.c:1319:98: warning: passing argument 3 of ‘cuvidMapVideoFrame’ from incompatible pointer type [-Wincompatible-pointer-types]
 1319 |                 res = cuvidMapVideoFrame(ctx->dec_inst->cu_decoder, f->frame_info.picture_index, &map_mem, &pitch, &params);
      |                                                                                                  ^~~~~~~~
      |                                                                                                  |
      |                                                                                                  CUdeviceptr * {aka long long unsigned int *}
filters/dec_nvdec.c:1319:98: note: expected ‘unsigned int *’ but argument is of type ‘CUdeviceptr *’ {aka ‘long long unsigned int *’}
```

These became errors in GCC 14. Note: `CUdeviceptr` was already defined to `long long unsingned int *` on aarch64:
https://github.com/gpac/gpac/blob/master/src/filters/dec_nvdec_sdk.h#L59 but the condition enabling the use of 64-bit pointers was missing in other places.