### PR TITLE
Error handling fixes

### DIFF
--- a/src/media_tools/route_dmx.c
+++ b/src/media_tools/route_dmx.c
@@ -2020,7 +2020,7 @@ static GF_Err gf_route_dmx_keep_or_remove_object_by_name(GF_ROUTEDmx *routedmx, 
 	i=0;
 	while ((obj = gf_list_enum(s->objects, &i))) {
 		u32 toi;
-		if (obj->rlct && (sscanf(fileName, obj->rlct->toi_template, &toi) == 1)) {
+		if (obj->rlct && obj->rlct->toi_template && (sscanf(fileName, obj->rlct->toi_template, &toi) == 1)) {
 			u32 tsi;
 			if (toi == obj->toi) {
 				GF_ROUTELCTChannel *rlct = obj->rlct;

--- a/src/media_tools/route_dmx.c
+++ b/src/media_tools/route_dmx.c
@@ -783,7 +783,11 @@ static GF_Err gf_route_service_gather_object(GF_ROUTEDmx *routedmx, GF_ROUTEServ
 		}
 	}
 
-	if(total_len && ((u64)start_offset + size > total_len)) {
+	if((u64)start_offset + size > UINT32_MAX) {
+		GF_LOG(GF_LOG_ERROR, GF_LOG_ROUTE, ("[ROUTE] Service %d TSI %u TOI %u Not supported: Offset (%u) + Size (%u) exceeds the maximum supported value (%u), skipping\n", s->service_id, tsi, toi, start_offset, size, UINT32_MAX));
+		return GF_NOT_SUPPORTED;
+	}
+	if(total_len && (start_offset + size > total_len)) {
 		GF_LOG(GF_LOG_ERROR, GF_LOG_ROUTE, ("[ROUTE] Service %d TSI %u TOI %u Corrupted data: Offset (%u) + Size (%u) exceeds Total Size of the object (%u), skipping\n", s->service_id, tsi, toi, start_offset, size, total_len));
 		return GF_NOT_SUPPORTED;
 	}
@@ -1040,7 +1044,7 @@ static GF_Err gf_route_service_gather_object(GF_ROUTEDmx *routedmx, GF_ROUTEServ
         obj->blob.data = obj->payload;
         gf_mx_v(routedmx->blob_mx);
     }
-	gf_assert(obj->alloc_size >= (u64)start_offset + size);
+	gf_assert(obj->alloc_size >= start_offset + size);
 
 	memcpy(obj->payload + start_offset, data, size);
 	GF_LOG(GF_LOG_DEBUG, GF_LOG_ROUTE, ("[ROUTE] Service %d TSI %u TOI %u append LCT fragment, offset %d total size %d recv bytes %d - offset diff since last %d\n", s->service_id, obj->tsi, obj->toi, start_offset, obj->total_length, obj->nb_bytes, (s32) start_offset - (s32) obj->prev_start_offset));

--- a/src/media_tools/route_dmx.c
+++ b/src/media_tools/route_dmx.c
@@ -783,8 +783,8 @@ static GF_Err gf_route_service_gather_object(GF_ROUTEDmx *routedmx, GF_ROUTEServ
 		}
 	}
 
-	if((u64)start_offset + size > UINT32_MAX) {
-		GF_LOG(GF_LOG_ERROR, GF_LOG_ROUTE, ("[ROUTE] Service %d TSI %u TOI %u Not supported: Offset (%u) + Size (%u) exceeds the maximum supported value (%u), skipping\n", s->service_id, tsi, toi, start_offset, size, UINT32_MAX));
+	if((u64)start_offset + size > GF_UINT_MAX) {
+		GF_LOG(GF_LOG_ERROR, GF_LOG_ROUTE, ("[ROUTE] Service %d TSI %u TOI %u Not supported: Offset (%u) + Size (%u) exceeds the maximum supported value (%u), skipping\n", s->service_id, tsi, toi, start_offset, size, GF_UINT_MAX));
 		return GF_NOT_SUPPORTED;
 	}
 	if(total_len && (start_offset + size > total_len)) {


### PR DESCRIPTION
Fix some autofuzz bugs:

- `nJauzoDhd5DctA`: skip packet when `start_offset + size > GF_UINT_MAX`  (Not supported)
- `yXRaBOYUxQRZFA`: null pointer passed as  second argument to `sscanf`