### PR TITLE
Fix infinite loop when segment_template is absent in MPD

### DIFF
--- a/src/media_tools/mpd.c
+++ b/src/media_tools/mpd.c
@@ -5164,7 +5164,7 @@ GF_Err gf_mpd_get_segment_start_time_with_timescale(s32 in_segment_index,
 	if (!rep->segment_template && !set->segment_template && !period->segment_template) {
 		GF_LOG(GF_LOG_WARNING, GF_LOG_DASH, ("[MPD] Representation without any SegmentBase, SegmentList or SegmentTemplate (non compliant). Assuming default SegmentBase\n"));
 		*out_segment_start_time = start_time;
-		return GF_OK;
+		return GF_NON_COMPLIANT_BITSTREAM;
 	}
 
 	if (period->segment_template) {


### PR DESCRIPTION
This pull request addresses the issue of an infinite loop encountered when executing the specified command line.

### Reproduction Steps:

- Download the capture file [route_nozip.zip](https://github.com/gpac/gpac/files/14836928/route_nozip.zip).
- Execute the following command line:
```
gpac -i route://234.1.1.1:1234/live.mpd -netcap=src=route_nozip.gpc,nrt,[s=1,o=847,v=40] inspect -logs=route@info
```

### Expected Behavior:

The command should execute without encountering an infinite loop.

**_Note_:** I am not sure if this is the correct approach to fix the issue, which is why I created this as a draft PR.