### PR TITLE
ffmpeg7 api

### DIFF
--- a/src/filters/ff_dec.c
+++ b/src/filters/ff_dec.c
@@ -713,8 +713,13 @@ dispatch_next:
 	FF_RELEASE_PCK(pkt);
 
 
+#if LIBAVUTIL_VERSION_MAJOR < 59
 	FF_CHECK_PROP(channels, channels, GF_PROP_PID_NUM_CHANNELS)
 	FF_CHECK_PROPL(channel_layout, channel_layout, GF_PROP_PID_CHANNEL_LAYOUT)
+#else
+	FF_CHECK_PROP(channels, ch_layout.nb_channels, GF_PROP_PID_NUM_CHANNELS)
+	FF_CHECK_PROPL(channel_layout, ch_layout.u.mask, GF_PROP_PID_CHANNEL_LAYOUT)
+#endif
 	FF_CHECK_PROP(sample_rate, sample_rate, GF_PROP_PID_SAMPLE_RATE)
 
 	if (prev_afmt != ctx->decoder->sample_fmt) {
@@ -1202,7 +1207,11 @@ static GF_Err ffdec_configure_pid(GF_Filter *filter, GF_FilterPid *pid, Bool is_
 		}
 		if (ctx->sample_rate && ctx->channels) {
 			ctx->decoder->sample_rate = ctx->sample_rate;
+#if LIBAVUTIL_VERSION_MAJOR < 59
 			ctx->decoder->channels = ctx->channels;
+#else
+			ctx->decoder->ch_layout.nb_channels = ctx->channels;
+#endif
 		}
 	}
 
@@ -1353,6 +1362,7 @@ reuse_codec_context:
 		}
 
 		//override PID props with what decoder gives us
+#if LIBAVUTIL_VERSION_MAJOR < 59
 		if (ctx->decoder->channels) {
 			ctx->channels = 0;
 			FF_CHECK_PROP(channels, channels, GF_PROP_PID_NUM_CHANNELS)
@@ -1364,6 +1374,7 @@ reuse_codec_context:
 				ctx->channel_layout = ch_lay;
 			}
 		}
+#endif
 		if (ctx->decoder->sample_rate) {
 			ctx->sample_rate = 0;
 			FF_CHECK_PROP(sample_rate, sample_rate, GF_PROP_PID_SAMPLE_RATE)

--- a/src/filters/ff_dmx.c
+++ b/src/filters/ff_dmx.c
@@ -438,6 +438,7 @@ static GF_Err ffdmx_flush_input(GF_Filter *filter, GF_FFDemuxCtx *ctx)
 	return GF_OK;
 }
 
+#include <libavcodec/packet.h>
 static GF_Err ffdmx_process(GF_Filter *filter)
 {
 	GF_Err e;
@@ -599,6 +600,8 @@ restart:
 				GF_BitStream *bs = gf_bs_new(sd->data, sd->size, GF_BITSTREAM_READ);
 
 				u32 flags = gf_bs_read_u32_le(bs);
+
+#if LIBAVUTIL_VERSION_MAJOR < 59
 				if (flags & AV_SIDE_DATA_PARAM_CHANGE_CHANNEL_COUNT) {
 					u32 new_ch = gf_bs_read_u32_le(bs);
 					gf_filter_pid_set_property(pctx->pid, GF_PROP_PID_NUM_CHANNELS, &PROP_UINT(new_ch) );
@@ -608,6 +611,7 @@ restart:
 					new_lay = ffmpeg_channel_layout_to_gpac(new_lay);
 					gf_filter_pid_set_property(pctx->pid, GF_PROP_PID_CHANNEL_LAYOUT, &PROP_LONGUINT(new_lay) );
 				}
+#endif
 				if (flags & AV_SIDE_DATA_PARAM_CHANGE_SAMPLE_RATE) {
 					u32 new_sr = gf_bs_read_u32_le(bs);
 					gf_filter_pid_set_property(pctx->pid, GF_PROP_PID_SAMPLE_RATE, &PROP_UINT(new_sr) );
@@ -978,7 +982,11 @@ GF_Err ffdmx_init_common(GF_Filter *filter, GF_FFDemuxCtx *ctx, u32 grab_type)
 		u32 exdata_size = stream->codecpar->extradata_size;
 		u32 codec_sample_rate = stream->codecpar->sample_rate;
 		u32 codec_frame_size = stream->codecpar->frame_size;
+#if LIBAVUTIL_VERSION_MAJOR < 59
 		u32 codec_channels = stream->codecpar->channels;
+#else
+		u32 codec_channels = stream->codecpar->ch_layout.nb_channels;
+#endif
 		u32 codec_width = stream->codecpar->width;
 		u32 codec_height = stream->codecpar->height;
 		u32 codec_field_order = stream->codecpar->field_order;
@@ -1068,7 +1076,11 @@ GF_Err ffdmx_init_common(GF_Filter *filter, GF_FFDemuxCtx *ctx, u32 grab_type)
 		if (grab_type)
 			gf_filter_pid_set_property(pid, GF_PROP_PID_RAWGRAB, &PROP_UINT(grab_type) );
 		else if (ctx->demuxer->iformat) {
-			if ((ctx->demuxer->iformat->flags & AVFMT_SEEK_TO_PTS) || ctx->demuxer->iformat->read_seek)
+			if ((ctx->demuxer->iformat->flags & AVFMT_SEEK_TO_PTS)
+#if (LIBAVFORMAT_VERSION_MAJOR < 59)
+			 || ctx->demuxer->iformat->read_seek
+#endif
+			)
 				gf_filter_pid_set_property(pid, GF_PROP_PID_PLAYBACK_MODE, &PROP_UINT(GF_PLAYBACK_MODE_FASTFORWARD ) );
 		}
 


### PR DESCRIPTION
The most important change (that doesn't work) is the audio channel layout management. Now we have:

```
/**
 * An AVChannelCustom defines a single channel within a custom order layout
 *
 * Unlike most structures in FFmpeg, sizeof(AVChannelCustom) is a part of the
 * public ABI.
 *
 * No new fields may be added to it without a major version bump.
 */
typedef struct AVChannelCustom {
    enum AVChannel id;
    char name[16];
    void *opaque;
} AVChannelCustom;

/**
 * An AVChannelLayout holds information about the channel layout of audio data.
 *
 * A channel layout here is defined as a set of channels ordered in a specific
 * way (unless the channel order is AV_CHANNEL_ORDER_UNSPEC, in which case an
 * AVChannelLayout carries only the channel count).
 * All orders may be treated as if they were AV_CHANNEL_ORDER_UNSPEC by
 * ignoring everything but the channel count, as long as av_channel_layout_check()
 * considers they are valid.
 *
 * Unlike most structures in FFmpeg, sizeof(AVChannelLayout) is a part of the
 * public ABI and may be used by the caller. E.g. it may be allocated on stack
 * or embedded in caller-defined structs.
 *
 * AVChannelLayout can be initialized as follows:
 * - default initialization with {0}, followed by setting all used fields
 *   correctly;
 * - by assigning one of the predefined AV_CHANNEL_LAYOUT_* initializers;
 * - with a constructor function, such as av_channel_layout_default(),
 *   av_channel_layout_from_mask() or av_channel_layout_from_string().
 *
 * The channel layout must be unitialized with av_channel_layout_uninit()
 *
 * Copying an AVChannelLayout via assigning is forbidden,
 * av_channel_layout_copy() must be used instead (and its return value should
 * be checked)
 *
 * No new fields may be added to it without a major version bump, except for
 * new elements of the union fitting in sizeof(uint64_t).
 */
typedef struct AVChannelLayout {
    /**
     * Channel order used in this layout.
     * This is a mandatory field.
     */
    enum AVChannelOrder order;

    /**
     * Number of channels in this layout. Mandatory field.
     */
    int nb_channels;

    /**
     * Details about which channels are present in this layout.
     * For AV_CHANNEL_ORDER_UNSPEC, this field is undefined and must not be
     * used.
     */
    union {
        /**
         * This member must be used for AV_CHANNEL_ORDER_NATIVE, and may be used
         * for AV_CHANNEL_ORDER_AMBISONIC to signal non-diegetic channels.
         * It is a bitmask, where the position of each set bit means that the
         * AVChannel with the corresponding value is present.
         *
         * I.e. when (mask & (1 << AV_CHAN_FOO)) is non-zero, then AV_CHAN_FOO
         * is present in the layout. Otherwise it is not present.
         *
         * @note when a channel layout using a bitmask is constructed or
         * modified manually (i.e.  not using any of the av_channel_layout_*
         * functions), the code doing it must ensure that the number of set bits
         * is equal to nb_channels.
         */
        uint64_t mask;
        /**
         * This member must be used when the channel order is
         * AV_CHANNEL_ORDER_CUSTOM. It is a nb_channels-sized array, with each
         * element signalling the presence of the AVChannel with the
         * corresponding value in map[i].id.
         *
         * I.e. when map[i].id is equal to AV_CHAN_FOO, then AV_CH_FOO is the
         * i-th channel in the audio data.
         *
         * When map[i].id is in the range between AV_CHAN_AMBISONIC_BASE and
         * AV_CHAN_AMBISONIC_END (inclusive), the channel contains an ambisonic
         * component with ACN index (as defined above)
         * n = map[i].id - AV_CHAN_AMBISONIC_BASE.
         *
         * map[i].name may be filled with a 0-terminated string, in which case
         * it will be used for the purpose of identifying the channel with the
         * convenience functions below. Otherise it must be zeroed.
         */
        AVChannelCustom *map;
    } u;

    /**
     * For some private data of the user.
     */
    void *opaque;
} AVChannelLayout;
```

Mapping brutally as I did in my first commit leads to this kind errors:
```
$ gpac avgen:ch=2 c=aac -o null
[aac] Unsupported channel layout "2 channels"
[FFEnc] PID audio failed to open codec context: Invalid argument
Failed to connect filter resample PID audio to filter ffenc: Bad Parameter
```

Some linkes:
- https://github.com/FFmpeg/FFmpeg/commit/9875fd24ce585497b26d8b7a3d87143b3e80a6ca
- https://github.com/FFmpeg/FFmpeg/commit/65ddc74988245a01421a63c5cffa4d900c47117c
- https://github.com/FFmpeg/FFmpeg/blob/master/doc/APIchanges