### PR TITLE
fix time source for wasm

### DIFF
--- a/src/utils/os_divers.c
+++ b/src/utils/os_divers.c
@@ -133,7 +133,7 @@ u32 gf_gpac_abi_micro()
 }
 
 
-#ifndef WIN32
+#if !defined(WIN32) && !defined(GPAC_CONFIG_EMSCRIPTEN)
 
 GF_EXPORT
 u32 gf_sys_clock()
@@ -149,6 +149,23 @@ u64 gf_sys_clock_high_res()
 	struct timeval now;
 	gettimeofday(&now, NULL);
 	return (now.tv_sec)*1000000 + (now.tv_usec) - sys_start_time_hr;
+}
+
+#endif
+
+#ifdef GPAC_CONFIG_EMSCRIPTEN
+#include <emscripten/emscripten.h>
+
+GF_EXPORT
+u32 gf_sys_clock()
+{
+	return (u32)(emscripten_get_now() - sys_start_time);
+}
+
+GF_EXPORT
+u64 gf_sys_clock_high_res()
+{
+	return (long long)(emscripten_get_now() * 1000.0) - sys_start_time_hr;
 }
 
 #endif


### PR DESCRIPTION
In wasm build, usage of `gettimeofday()` is painfully slow when gpac runs on a worker. Emscripten offers a [substitute](https://emscripten.org/docs/api_reference/emscripten.h.html#c.emscripten_get_now) for it. I had to make this change because when I profiled my application, almost all of the time wasm made a call to javascript to get the time and it stalled the entie stack because of it.

I haven't fully tested it but as emscripten documentation pointed out, this might use `performance.now()`. Which means between different workers (threads) this value will have a different origin ([mdn reference](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now#performance.now_vs._date.now)). Depending on how these clocks are used internally the implementation might need to change. For reference, here is how this function is defined in emscripten:

https://github.com/emscripten-core/emscripten/blob/main/system/lib/standalone/standalone.c#L179-L185

fixes #2775
related https://github.com/urho3d/Urho3D/issues/916