### PR TITLE
httpout server: ignore query strings when getting file on disk (#2834)

### DIFF
--- a/applications/gpac/gpac.c
+++ b/applications/gpac/gpac.c
@@ -3379,6 +3379,7 @@ static u64 creds_set_pass(GF_Config *creds, const char *user, const char *passwd
 	u64 now = gf_sys_clock_high_res();
 	sprintf(szVAL, LLU, now);
 	gf_cfg_set_key(creds, user, "pass_date", szVAL);
+	gf_free(pass);
 	return now;
 }
 

--- a/src/filters/out_http.c
+++ b/src/filters/out_http.c
@@ -1631,7 +1631,17 @@ static void httpout_sess_io(void *usr_cbk, GF_NETIO_Parameter *parameter)
 			if (!strchr("/\\", mdir[len-1]))
 				gf_dynstrcat(&full_path, "/", NULL);
 
+			char *querystring = strchr(res_url, '?');
+
+			// ignore query string when looking for a file on disk
+			if (querystring)
+				querystring[0] = 0;
+
 			gf_dynstrcat(&full_path, res_url, NULL);
+
+			// restore query string in original url
+			if (querystring)
+				querystring[0] = '?';
 
 			if (gf_file_exists(full_path) || gf_dir_exists(full_path) ) {
 				the_dir = adi;


### PR DESCRIPTION
doing this as a PR for potential review

related to #2834

I made a patch to ignore the query string part of a url when looking for a file on disk

I've not done it for DELETE method and other scenarios 

one possible issue is that we're working on the url-decoded URI (without the %xx stuff), so if there was a url-encoded '?' character in the path it will be interpreted (wrongly) as the start of the query string (not sure if that would ever actually happen but just to keep in mind)