### PR TITLE
Fix `pthread_mutex_destroy failed` issue during repair process

### DIFF
--- a/src/media_tools/route_dmx.c
+++ b/src/media_tools/route_dmx.c
@@ -660,6 +660,7 @@ static GF_BlobRangeStatus routedmx_check_blob_range(GF_Blob *blob, u64 start_off
 			return GF_BLOB_RANGE_VALID;
 		}
 	}
+	gf_mx_v(blob->mx);
 	if (blob->flags & GF_BLOB_IN_TRANSFER)
 		return GF_BLOB_RANGE_IN_TRANSFER;
 	return GF_BLOB_RANGE_CORRUPTED;


### PR DESCRIPTION
This PR addresses the error message `pthread_mutex_destroy failed with error code 16` during the repair process.

**Changes:**

- In the function `routedmx_check_blob_range`, unlock mutex `blob->mx` before returning.