### PR TITLE
fix: runtime error member access within null pointer

### DIFF
--- a/src/isomedia/isom_read.c
+++ b/src/isomedia/isom_read.c
@@ -4891,7 +4891,7 @@ GF_EXPORT
 void gf_isom_reset_fragment_info(GF_ISOFile *movie, Bool keep_sample_count)
 {
 	u32 i;
-	if (!movie) return;
+	if (!movie || !movie->moov) return;
 	for (i=0; i<gf_list_count(movie->moov->trackList); i++) {
 		GF_TrackBox *trak = (GF_TrackBox*)gf_list_get(movie->moov->trackList, i);
 		trak->Media->information->sampleTable->SampleSize->sampleCount = 0;


### PR DESCRIPTION

Fix runtime error: member access within null pointer
Add check on `movie->moov` variable

autofuzz bug DmhCZI7TfPXPxQ

