### PR TITLE
Support for the Multiview extension of H.265/HEVC

### DIFF
--- a/include/gpac/internal/media_dev.h
+++ b/include/gpac/internal/media_dev.h
@@ -572,6 +572,7 @@ typedef struct _hevc_state
 	u8 clli_data[4];
 	u8 mdcv_data[24];
 	u8 clli_valid, mdcv_valid;
+	u8 has_3d_ref_disp_info;
 } HEVCState;
 
 typedef struct hevc_combine{

--- a/src/media_tools/av_parsers.c
+++ b/src/media_tools/av_parsers.c
@@ -7521,7 +7521,9 @@ static void gf_hevc_vvc_parse_sei(char *buffer, u32 nal_size, HEVCState *hevc, V
 		}
 
 		nb_zeros = gf_bs_get_emulation_byte_removed(bs);
-
+		if (hevc) {
+			hevc->has_3d_ref_disp_info = 0;
+		}
 		switch (ptype) {
 		case 4: /*user registered ITU-T T35*/
 			if (hevc) {
@@ -7552,6 +7554,12 @@ static void gf_hevc_vvc_parse_sei(char *buffer, u32 nal_size, HEVCState *hevc, V
 				hevc->mdcv_valid = 1;
 			} else {
 				vvc->mdcv_valid = 1;
+			}
+			break;
+		// three_dimensional_reference_displays_info
+		case 176:
+			if (hevc) {
+				hevc->has_3d_ref_disp_info = 1;
 			}
 			break;
 		default:
@@ -8319,8 +8327,10 @@ static s32 gf_hevc_read_sps_bs_internal(GF_BitStream *bs, HEVCState *hevc, u8 la
 	sps_ext_or_max_sub_layers_minus1 = 0;
 	if (layer_id == 0)
 		max_sub_layers_minus1 = gf_bs_read_int_log(bs, 3, "max_sub_layers_minus1");
-	else
+	else {
 		sps_ext_or_max_sub_layers_minus1 = gf_bs_read_int_log(bs, 3, "sps_ext_or_max_sub_layers_minus1");
+		max_sub_layers_minus1 = sps_ext_or_max_sub_layers_minus1 == 7 ? hevc->vps[vps_id].max_sub_layers - 1 : sps_ext_or_max_sub_layers_minus1;
+	}
 	multiLayerExtSpsFlag = (layer_id != 0) && (sps_ext_or_max_sub_layers_minus1 == 7);
 	if (!multiLayerExtSpsFlag) {
 		gf_bs_read_int_log(bs, 1, "temporal_id_nesting_flag");


### PR DESCRIPTION
- A fix for the parsing of the SPS is provided. This is because for NALUs associated with layers whose identifier is greater than 0 the spec requires the decoder to parse sps_ext_or_max_sub_layers_minus1 (see F.7.3.2.2.1). The value of this syntax element is then used to infer the value for sps_max_sub_layers_minus1 as specified in Clause F.7.4.3.2.1. The current design would led to have sps_max_sub_layers_minus1 equal to zero. This is fine for streams captured by devices such as Apple iPhones since the value for sps_ext_or_max_sub_layers_minus1 is set to 7 and the spec in this case mandates that sps_max_sub_layers_minus1 assumes the same value transmitted in the SPS. However, different encoders might be setting sps_ext_or_max_sub_layers_minus1 to a different value, thus also sps_max_sub_layers_minus1 will be different from the value parsed in the VPS. The fix proposed in av_parser.c::gf_hevc_read_sps_bs_internal addresses some discrepancy between the implementation and the spec.
- Support is added to parse and embed in a .mov file the three dimension reference displays info SEI message from Clause G.14.2.3.3. Such a supplemental information is required to play Multiview content on devices such as the Apple Vision Pro. Having MP4box embedding such information would allow users to wrap Annex B HEVC streams into .mov containers.