### PR TITLE
Support packaging of generic ID3 tags into ISOBMFF coming from TS streams.

### DIFF
--- a/src/filters/dmx_m2ts.c
+++ b/src/filters/dmx_m2ts.c
@@ -33,6 +33,19 @@
 #include <gpac/thread.h>
 #include <gpac/internal/media_dev.h>
 
+// First 36 bytes of a Nielsen ID3 tag: "ID3\x04\x00 \x00\x00\x02\x05PRIV\x00\x00\x01{\x00\x00www.nielsen.com/"
+static const u32 NIELSEN_ID3_TAG_PREFIX_LEN = 36;
+static const u8 NIELSEN_ID3_TAG_PREFIX[] = {0x49, 0x44, 0x33, 0x04, 0x00, 0x20,
+											0x00, 0x00, 0x02, 0x05, 0x50, 0x52,
+											0x49, 0x56, 0x00, 0x00, 0x01, 0x7B,
+											0x00, 0x00, 0x77, 0x77, 0x77, 0x2E,
+											0x6E, 0x69, 0x65, 0x6C, 0x73, 0x65,
+											0x6E, 0x2E, 0x63, 0x6F, 0x6D, 0x2F};
+
+static const char *ID3_PROP_SCHEME_URI = "https://aomedia.org/emsg/ID3";
+static const char *ID3_PROP_VALUE_URI_NIELSEN = "www.nielsen.com:id3:v1";
+static const char *ID3_PROP_VALUE_URI_DEFAULT = "https://aomedia.org/emsg/ID3";
+
 typedef struct {
 	char *fragment;
 	u32 id;
@@ -1190,11 +1203,34 @@ static void m2tsdmx_on_event(GF_M2TS_Demuxer *ts, u32 evt_type, void *param)
 			GF_SAFEALLOC(t, GF_M2TS_Prop);
 			if (!t) break;
 			t->type = M2TS_ID3;
+
+			u32 value_uri_len = 0;
+			const char *value_uri = NULL;
+
+			// test if the data is a Nielsen ID3 tag
+			if (memcmp(pck->data, NIELSEN_ID3_TAG_PREFIX, NIELSEN_ID3_TAG_PREFIX_LEN) == 0)
+			{
+				value_uri_len = strlen(ID3_PROP_VALUE_URI_NIELSEN) + 1; // plus null character
+				value_uri = ID3_PROP_VALUE_URI_NIELSEN;
+			}
+			else
+			{
+				value_uri_len = strlen(ID3_PROP_VALUE_URI_DEFAULT) + 1; // plus null character
+				value_uri = ID3_PROP_VALUE_URI_DEFAULT;
+			}
+
+			const u32 id3_scheme_uri_len = (u32)strlen(ID3_PROP_SCHEME_URI) + 1; // plus null character
+
 			bs = gf_bs_new(NULL, 0, GF_BITSTREAM_WRITE);
-			gf_bs_write_u32(bs, 90000);                     // timescale
-			gf_bs_write_u64(bs, pck->PTS);                  // pts
-			gf_bs_write_u32(bs, pck->data_len);				// data length (bytes)
-			gf_bs_write_data(bs, pck->data, pck->data_len); // data
+			gf_bs_write_u32(bs, 90000);												   // timescale
+			gf_bs_write_u64(bs, pck->PTS);											   // pts
+			gf_bs_write_u32(bs, id3_scheme_uri_len);								   // scheme URI length
+			gf_bs_write_data(bs, (const u8 *)ID3_PROP_SCHEME_URI, id3_scheme_uri_len); // scheme URI
+			gf_bs_write_u32(bs, value_uri_len);										   // value URI length
+			gf_bs_write_data(bs, (const u8 *)value_uri, value_uri_len);				   // value URI
+			gf_bs_write_u32(bs, pck->data_len);										   // data length (bytes)
+			gf_bs_write_data(bs, pck->data, pck->data_len);							   // data
+
 			gf_bs_get_content(bs, &t->data, &t->len);
 			gf_bs_del(bs);
 


### PR DESCRIPTION
Currently, the ID3 demuxing and packaging implementation only supports Nielsen-specific tags with a fixed data size and scheme URI.

This URI improves upon those changes by supporting generic tags of any size. The TS demuxer detects whether the incoming ID3 tag corresponds to a Nielsen ID3 tag, and sets its corresponding scheme URI for later use. Otherwise, it uses `https://aomedia.org/emsg/ID3` for both scheme and value URI.