### PR TITLE
correct `swf_flatten_angle` type

### DIFF
--- a/applications/mp4box/filedump.c
+++ b/applications/mp4box/filedump.c
@@ -61,7 +61,7 @@
 #ifndef GPAC_DISABLE_SWF_IMPORT
 extern u32 swf_flags;
 #endif
-extern Float swf_flatten_angle;
+extern Double swf_flatten_angle;
 extern GF_FileType get_file_type_by_ext(char *inName);
 extern u32 fs_dump_flags;
 extern Bool dump_check_xml;

--- a/applications/mp4box/fileimport.c
+++ b/applications/mp4box/fileimport.c
@@ -107,7 +107,7 @@ GF_Err set_file_udta(GF_ISOFile *dest, u32 tracknum, u32 udta_type, char *src, B
 extern u32 swf_flags;
 #endif
 
-extern Float swf_flatten_angle;
+extern Double swf_flatten_angle;
 extern Bool keep_sys_tracks;
 extern u32 fs_dump_flags;
 


### PR DESCRIPTION
This fixes:
```
filedump.c:64:14: warning: type of ‘swf_flatten_angle’ does not match original declaration [-Wlto-type-mismatch]
   64 | extern Float swf_flatten_angle;
      |              ^
mp4box.c:217:89: note: type ‘Double’ should match type ‘Float’
  217 | Double interleaving_time, split_duration, split_start, dash_duration, dash_subduration, swf_flatten_angle, mpd_live_duration, min_bu
ffer, mpd_update_time;
      |                                                                                         ^
mp4box.c:217:89: note: ‘swf_flatten_angle’ was previously declared here
mp4box.c:217:89: note: code may be misoptimized unless ‘-fno-strict-aliasing’ is used
```
and
```
fileimport.c:110:14: warning: type of ‘swf_flatten_angle’ does not match original declaration [-Wlto-type-mismatch]
  110 | extern Float swf_flatten_angle;
      |              ^
mp4box.c:217:89: note: type ‘Double’ should match type ‘Float’
  217 | Double interleaving_time, split_duration, split_start, dash_duration, dash_subduration, swf_flatten_angle, mpd_live_duration, min_buffer, mpd_update_time;
      |                                                                                         ^
mp4box.c:217:89: note: ‘swf_flatten_angle’ was previously declared here
mp4box.c:217:89: note: code may be misoptimized unless ‘-fno-strict-aliasing’ is used
```

when building with LTO enabled (`-flto=auto -ffat-lto-objects`) on Fedora rawhide with gcc 14.1.1.

However, `swf_flatten_angle` is declared in [src/scene_manager/swf_svg.c:512](https://github.com/gpac/gpac/blob/master/src/scene_manager/swf_svg.c#L512) and [include/gpac/media_tools.h:368](https://github.com/gpac/gpac/blob/master/include/gpac/media_tools.h#L368) as `Float`, so this is probably not a complete fix.