### PR TITLE
export `gf_props_parse_value`

### DIFF
--- a/include/gpac/filters.h
+++ b/include/gpac/filters.h
@@ -1466,6 +1466,16 @@ Bool gf_props_type_is_enum(GF_PropType type);
 */
 u32 gf_props_parse_enum(u32 type, const char *value);
 
+/*! Parses a property value from string
+\param type property type to parse
+\param name property name to parse (for logs)
+\param value string containing the value to parse
+\param enum_values string containig enum_values, or NULL. enum_values are used for unsigned int properties, take the form "a|b|c" and resolve to 0|1|2.
+\param list_sep_char value of the list separator character to use
+\return the parsed property value
+*/
+GF_PropertyValue gf_props_parse_value(u32 type, const char *name, const char *value, const char *enum_values, char list_sep_char);
+
 /*! Get the name of a constant type property value
 \param type  property type
 \param value value of constant
@@ -1484,17 +1494,6 @@ const char *gf_props_enum_all_names(u32 type);
 \return base property type
 */
 u32 gf_props_get_base_type(u32 type);
-
-
-/*! Parses a property value from string
-\param type property type to parse
-\param name property name to parse (for logs)
-\param value string containing the value to parse
-\param enum_values string containig enum_values, or NULL. enum_values are used for unsigned int properties, take the form "a|b|c" and resolve to 0|1|2.
-\param list_sep_char value of the list separator character to use
-\return the parsed property value
-*/
-GF_PropertyValue gf_props_parse_value(u32 type, const char *name, const char *value, const char *enum_values, char list_sep_char);
 
 /*! Maximum string size to use when dumping a property*/
 #define GF_PROP_DUMP_ARG_SIZE	100

--- a/src/export.cpp
+++ b/src/export.cpp
@@ -2400,6 +2400,7 @@
 
 #pragma comment (linker, EXPORT_SYMBOL(gf_props_type_is_enum) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_props_parse_enum) )
+#pragma comment (linker, EXPORT_SYMBOL(gf_props_parse_value) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_props_enum_name) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_props_enum_all_names) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_props_reset_single) )

--- a/src/filter_core/filter_props.c
+++ b/src/filter_core/filter_props.c
@@ -186,6 +186,7 @@ static Bool parse_time(const char *str, u64 *val)
 	return GF_TRUE;
 }
 
+GF_EXPORT
 GF_PropertyValue gf_props_parse_value(u32 type, const char *name, const char *value, const char *enum_values, char list_sep_char)
 {
 	GF_PropertyValue p;


### PR DESCRIPTION
`filters.h` already includes the definition. Having this function available would be great for applications using libgpac and pass PID properties via string.