### PR TITLE
Add `availabilityTimeComplete` to SegmentTemplate

### DIFF
--- a/src/media_tools/mpd.c
+++ b/src/media_tools/mpd.c
@@ -2757,7 +2757,10 @@ static void gf_mpd_print_segment_base_attr(FILE *out, GF_MPD_SegmentBase *s)
 		if (s->index_range_exact) gf_fprintf(out, " indexRangeExact=\"true\"");
 		if (s->index_range) gf_fprintf(out, " indexRange=\""LLD"-"LLD"\"", s->index_range->start_range, s->index_range->end_range);
 	}
-	if (s->availability_time_offset) gf_fprintf(out, " availabilityTimeOffset=\"%g\"", s->availability_time_offset);
+	if (s->availability_time_offset) {
+		gf_fprintf(out, " availabilityTimeOffset=\"%g\"", s->availability_time_offset);
+		gf_fprintf(out, " availabilityTimeComplete=\"%s\"", "false");
+	}
 	if ((s32) s->time_shift_buffer_depth > 0)
 		gf_mpd_print_duration(out, "timeShiftBufferDepth", s->time_shift_buffer_depth, GF_TRUE);
 }


### PR DESCRIPTION
As indicated by [CR-Low-Latency-Live-r8.pdf](https://dashif.org/docs/CR-Low-Latency-Live-r8.pdf) 9.X.4.5.5 `availabilityTimeComplete` must be present and be set to `false`