### PR TITLE
Buildbot mabr inband mani init transport

### DIFF
--- a/src/filters/out_route.c
+++ b/src/filters/out_route.c
@@ -51,7 +51,7 @@ typedef struct
 	//options
 	char *dst, *ext, *mime, *ifce, *ip;
 	u32 carousel, first_port, bsid, mtu, splitlct, ttl, brinc, runfor;
-	Bool korean, llmode, noreg, nozip, furl, flute;
+	Bool korean, llmode, noreg, nozip, furl, flute, flute_inband_mani_init;
 	u32 csum;
 	u32 recv_obj_timeout;
 
@@ -2988,6 +2988,7 @@ static const GF_FilterArgs ROUTEOutArgs[] =
 		"- all: send checksum for everything", GF_PROP_UINT, "meta", "no|meta|all", 0},
 	{ OFFS(recv_obj_timeout), "timeout period in ms before resorting to unicast repair", GF_PROP_UINT, "50", NULL, 0},
 	{ OFFS(errsim), "simulate errors using a 2-state Markov chain. Value are percentages", GF_PROP_VEC2, "0.0x100.0", NULL, 0},
+	{ OFFS(flute_inband_mani_init), "DVB mabr option: If true send the mani and init segment in content transport sessions instead of configuration transport session", GF_PROP_BOOL, "false", NULL, 0},
 	{0}
 };
 

--- a/src/filters/out_route.c
+++ b/src/filters/out_route.c
@@ -2163,6 +2163,10 @@ void routeout_send_fdt(GF_ROUTEOutCtx *ctx, ROUTEService *serv, ROUTEPid *rpid)
 	if (!rpid->current_toi)
 		rpid->current_toi = 1;
 
+	//update current toi with value of next toi available since we sent mani and init
+	if (rpid->current_toi !=1 && rpid->current_toi  < ctx->next_toi_avail)
+		rpid->current_toi = ctx->next_toi_avail;
+
 	const u8 *pck_data;
 	if (!rpid->frag_idx && (ctx->csum==DVB_CSUM_ALL))
 		pck_data = rpid->pck_data;

--- a/src/filters/out_route.c
+++ b/src/filters/out_route.c
@@ -2125,6 +2125,9 @@ void routeout_send_fdt(GF_ROUTEOutCtx *ctx, ROUTEService *serv, ROUTEPid *rpid)
 		u32 j, nb_pids = gf_list_count(serv->pids);
 		for (j=0; j<nb_pids; j++) {
 			ROUTEPid *pid = gf_list_get(serv->pids, j);
+
+			if (pid->tsi != rpid->tsi) continue;
+
 			if (pid->raw_file) {
 				if (!pid->current_toi || !pid->full_frame_size)
 					continue;


### PR DESCRIPTION
DVB mabr: Adding an option to offer the possibility of selecting how the manifests and init
segments are delivered:
         - either in the multicast gateway configuration transport session .
         - or in the multicast transport sessions delivering the content.
         