### PR TITLE
Segment Sequence Representations for DASH

### DIFF
--- a/include/gpac/mpd.h
+++ b/include/gpac/mpd.h
@@ -138,6 +138,8 @@ typedef struct
 	u64 start_time;
 	/*! duration in representation's MPD timescale - mandatory*/
 	u32 duration; /*MANDATORY*/
+	/* number of partial segments */
+	u32 nb_parts;
 	/*! may be 0xFFFFFFFF (-1) (\warning this needs further testing)*/
 	u32 repeat_count;
 } GF_MPD_SegmentTimelineEntry;

--- a/src/filters/dasher.c
+++ b/src/filters/dasher.c
@@ -10795,7 +10795,7 @@ static const GF_FilterArgs DasherArgs[] =
 		"- brsf: generate two sets of manifest, one for byte-range and one for files (`_IF` added before extension of manifest)", GF_PROP_UINT, "off", "off|br|sf|brsf", GF_FS_ARG_HINT_EXPERT},
 	{ OFFS(dashll), "DASH Low Latency type\n"
 		" - cte: use Chunked Transfer Encoding for segments\n"
-		" - sf: use separate files for segment parts (post-fixed .1, .2 etc.)\n",
+		" - sf: use Segment Sequence Representation. Separate files for segment parts (post-fixed .1, .2 etc.)\n",
 		GF_PROP_UINT, "cte", "cte|sf", GF_FS_ARG_HINT_EXPERT},
 	{ OFFS(cdur), "chunk duration for fragmentation modes", GF_PROP_FRACTION, "-1/1", NULL, GF_FS_ARG_HINT_HIDE},
 	{ OFFS(hlsdrm), "cryp file info for HLS full segment encryption", GF_PROP_STRING, NULL, NULL, GF_FS_ARG_HINT_EXPERT},

--- a/src/filters/dasher.c
+++ b/src/filters/dasher.c
@@ -2873,6 +2873,11 @@ static void dasher_setup_set_defaults(GF_DasherCtx *ctx, GF_MPD_AdaptationSet *s
 	if (ctx->sseg) set->subsegment_alignment = ctx->align;
 	else set->segment_alignment = ctx->align;
 
+	if (ctx->llhls>1) {
+		set->subsegment_alignment = ctx->align;
+		set->segment_alignment = ctx->align;
+	}
+
 	//startWithSAP is set when the first packet comes in
 
 	//the rest depends on the various profiles/iop, to check
@@ -4430,6 +4435,8 @@ static void dasher_setup_sources(GF_Filter *filter, GF_DasherCtx *ctx, GF_MPD_Ad
 					seg_template->media = dasher_cat_mpd_url(ctx, ds, szSegmentName);
 					if (ds->idx_template)
 						seg_template->index = dasher_cat_mpd_url(ctx, ds, szIndexSegmentName);
+					if (ctx->do_mpd && ctx->llhls>1)
+						gf_dynstrcat(&seg_template->media, "$SubNumber$", ".");
 
 					seg_template->timescale = ds->mpd_timescale;
 					seg_template->start_number = start_number;
@@ -4468,6 +4475,8 @@ static void dasher_setup_sources(GF_Filter *filter, GF_DasherCtx *ctx, GF_MPD_Ad
 					seg_template->media = dasher_cat_mpd_url(ctx, ds, szSegmentName);
 					if (ds->idx_template)
 						seg_template->index = dasher_cat_mpd_url(ctx, ds, szIndexSegmentName);
+					if (ctx->do_mpd && ctx->llhls>1)
+						gf_dynstrcat(&seg_template->media, "$SubNumber$", ".");
 					seg_template->duration = seg_duration;
 					seg_template->timescale = ds->mpd_timescale;
 					seg_template->start_number = start_number;
@@ -7458,6 +7467,7 @@ static void dasher_insert_timeline_entry(GF_DasherCtx *ctx, GF_DashStream *ds)
 	if (!s) return;
 	s->start_time = ds->seg_start_time + pto;
 	s->duration = (u32) duration;
+	s->nb_parts = gf_ceil((ctx->segdur.num * ctx->cdur.den) / ((Double) ctx->segdur.den * ctx->cdur.num)); 
 	gf_list_add(tl->entries, s);
 }
 
@@ -9096,6 +9106,12 @@ static GF_Err dasher_process(GF_Filter *filter)
 							} else {
 								ds->set->starts_with_sap = sap_type;
 							}
+
+							if (ctx->llhls>1)
+							{
+								ds->set->starts_with_sap = ctx->sseg ? ds->set->subsegment_starts_with_sap : ds->set->starts_with_sap;
+								ds->set->subsegment_starts_with_sap = ctx->sseg ? ds->set->subsegment_starts_with_sap : ds->set->starts_with_sap;
+							}
 						}
 					}
 					else if (set_start_with_sap != sap_type) {
@@ -9397,6 +9413,12 @@ static GF_Err dasher_process(GF_Filter *filter)
 							ds->set->subsegment_starts_with_sap = sap_type;
 						else
 							ds->set->starts_with_sap = sap_type;
+
+						if (ctx->llhls>1)
+						{
+							ds->set->starts_with_sap = ctx->sseg ? ds->set->subsegment_starts_with_sap : ds->set->starts_with_sap;
+							ds->set->subsegment_starts_with_sap = ctx->sseg ? ds->set->subsegment_starts_with_sap : ds->set->starts_with_sap;
+						}
 					}
 
 
@@ -9555,6 +9577,12 @@ static GF_Err dasher_process(GF_Filter *filter)
 							ds->set->subsegment_starts_with_sap = MAX(ds->set->subsegment_starts_with_sap, sap_type);
 						else
 							ds->set->starts_with_sap = MAX(ds->set->starts_with_sap, sap_type);
+					}
+
+					if (ctx->llhls>1)
+					{
+						ds->set->starts_with_sap = ctx->sseg ? ds->set->subsegment_starts_with_sap : ds->set->starts_with_sap;
+						ds->set->subsegment_starts_with_sap = ctx->sseg ? ds->set->subsegment_starts_with_sap : ds->set->starts_with_sap;
 					}
 
 					seg_over = GF_TRUE;

--- a/src/filters/dasher.c
+++ b/src/filters/dasher.c
@@ -2873,11 +2873,6 @@ static void dasher_setup_set_defaults(GF_DasherCtx *ctx, GF_MPD_AdaptationSet *s
 	if (ctx->sseg) set->subsegment_alignment = ctx->align;
 	else set->segment_alignment = ctx->align;
 
-	if (ctx->llhls>1) {
-		set->subsegment_alignment = ctx->align;
-		set->segment_alignment = ctx->align;
-	}
-
 	//startWithSAP is set when the first packet comes in
 
 	//the rest depends on the various profiles/iop, to check
@@ -9106,12 +9101,6 @@ static GF_Err dasher_process(GF_Filter *filter)
 							} else {
 								ds->set->starts_with_sap = sap_type;
 							}
-
-							if (ctx->llhls>1)
-							{
-								ds->set->starts_with_sap = ctx->sseg ? ds->set->subsegment_starts_with_sap : ds->set->starts_with_sap;
-								ds->set->subsegment_starts_with_sap = ctx->sseg ? ds->set->subsegment_starts_with_sap : ds->set->starts_with_sap;
-							}
 						}
 					}
 					else if (set_start_with_sap != sap_type) {
@@ -9413,12 +9402,6 @@ static GF_Err dasher_process(GF_Filter *filter)
 							ds->set->subsegment_starts_with_sap = sap_type;
 						else
 							ds->set->starts_with_sap = sap_type;
-
-						if (ctx->llhls>1)
-						{
-							ds->set->starts_with_sap = ctx->sseg ? ds->set->subsegment_starts_with_sap : ds->set->starts_with_sap;
-							ds->set->subsegment_starts_with_sap = ctx->sseg ? ds->set->subsegment_starts_with_sap : ds->set->starts_with_sap;
-						}
 					}
 
 
@@ -9577,12 +9560,6 @@ static GF_Err dasher_process(GF_Filter *filter)
 							ds->set->subsegment_starts_with_sap = MAX(ds->set->subsegment_starts_with_sap, sap_type);
 						else
 							ds->set->starts_with_sap = MAX(ds->set->starts_with_sap, sap_type);
-					}
-
-					if (ctx->llhls>1)
-					{
-						ds->set->starts_with_sap = ctx->sseg ? ds->set->subsegment_starts_with_sap : ds->set->starts_with_sap;
-						ds->set->subsegment_starts_with_sap = ctx->sseg ? ds->set->subsegment_starts_with_sap : ds->set->starts_with_sap;
 					}
 
 					seg_over = GF_TRUE;

--- a/src/filters/dasher.c
+++ b/src/filters/dasher.c
@@ -10541,7 +10541,10 @@ static GF_Err dasher_initialize(GF_Filter *filter)
 			GF_LOG(GF_LOG_WARNING, GF_LOG_DASH, ("[Dasher] DASH with partial segments require Segment Timeline, enabling it\n"));
 			ctx->stl = GF_TRUE;
 		}
-		ctx->llhls = 2; // enable llhls=sf
+		if (ctx->llhls==1) {
+			GF_LOG(GF_LOG_WARNING, GF_LOG_DASH, ("[Dasher] DASH with partial segments require LL-HLS with seperate files mode, enabling it\n"));
+		}
+		if (ctx->llhls<2) ctx->llhls = 2;
 	}
 
 	if (!ctx->sap || ctx->sigfrag || ctx->cues)

--- a/src/filters/dasher.c
+++ b/src/filters/dasher.c
@@ -216,6 +216,7 @@ typedef struct
 	char *ckurl;
 	GF_PropStringList hlsx;
 	u32 llhls;
+	u32 dashll;
 	Bool hlsiv;
 	//inherited from mp4mx
 	GF_Fraction cdur;
@@ -4430,7 +4431,7 @@ static void dasher_setup_sources(GF_Filter *filter, GF_DasherCtx *ctx, GF_MPD_Ad
 					seg_template->media = dasher_cat_mpd_url(ctx, ds, szSegmentName);
 					if (ds->idx_template)
 						seg_template->index = dasher_cat_mpd_url(ctx, ds, szIndexSegmentName);
-					if (ctx->do_mpd && ctx->llhls>1)
+					if (ctx->dashll)
 						gf_dynstrcat(&seg_template->media, "$SubNumber$", ".");
 
 					seg_template->timescale = ds->mpd_timescale;
@@ -4470,7 +4471,7 @@ static void dasher_setup_sources(GF_Filter *filter, GF_DasherCtx *ctx, GF_MPD_Ad
 					seg_template->media = dasher_cat_mpd_url(ctx, ds, szSegmentName);
 					if (ds->idx_template)
 						seg_template->index = dasher_cat_mpd_url(ctx, ds, szIndexSegmentName);
-					if (ctx->do_mpd && ctx->llhls>1)
+					if (ctx->dashll)
 						gf_dynstrcat(&seg_template->media, "$SubNumber$", ".");
 					seg_template->duration = seg_duration;
 					seg_template->timescale = ds->mpd_timescale;
@@ -10535,6 +10536,14 @@ static GF_Err dasher_initialize(GF_Filter *filter)
 		}
 	}
 
+	if (ctx->dashll) {
+		if (!ctx->stl) {
+			GF_LOG(GF_LOG_WARNING, GF_LOG_DASH, ("[Dasher] DASH with partial segments require Segment Timeline, enabling it\n"));
+			ctx->stl = GF_TRUE;
+		}
+		ctx->llhls = 2; // enable llhls=sf
+	}
+
 	if (!ctx->sap || ctx->sigfrag || ctx->cues)
 		ctx->sbound = DASHER_BOUNDS_OUT;
 
@@ -10775,6 +10784,10 @@ static const GF_FilterArgs DasherArgs[] =
 		"- br: use LL-HLS with byte-range for segment parts, pointing to full segment (DASH-LL compatible)\n"
 		"- sf: use separate files for segment parts (post-fixed .1, .2 etc.)\n"
 		"- brsf: generate two sets of manifest, one for byte-range and one for files (`_IF` added before extension of manifest)", GF_PROP_UINT, "off", "off|br|sf|brsf", GF_FS_ARG_HINT_EXPERT},
+	{ OFFS(dashll), "DASH Low Latency type\n"
+		" - cte: use Chunked Transfer Encoding for segments\n"
+		" - sf: use separate files for segment parts (post-fixed .1, .2 etc.)\n",
+		GF_PROP_UINT, "cte", "cte|sf", GF_FS_ARG_HINT_EXPERT},
 	{ OFFS(cdur), "chunk duration for fragmentation modes", GF_PROP_FRACTION, "-1/1", NULL, GF_FS_ARG_HINT_HIDE},
 	{ OFFS(hlsdrm), "cryp file info for HLS full segment encryption", GF_PROP_STRING, NULL, NULL, GF_FS_ARG_HINT_EXPERT},
 	{ OFFS(hlsx), "list of string to append to master HLS header before variants with `['#foo','#bar=val']` added as `#foo \\n #bar=val`", GF_PROP_STRING_LIST, NULL, NULL, GF_FS_ARG_HINT_EXPERT},

--- a/src/media_tools/mpd.c
+++ b/src/media_tools/mpd.c
@@ -2804,6 +2804,7 @@ static void gf_mpd_print_segment_timeline(FILE *out, GF_MPD_SegmentTimeline *tl,
 	gf_fprintf(out, "<S");
 	gf_fprintf(out, " t=\""LLD"\"", prev->start_time);
 	if (prev->duration) gf_fprintf(out, " d=\"%d\"", prev->duration);
+	if (prev->nb_parts) gf_fprintf(out, " k=\"%d\"", prev->nb_parts);
 	rcount = prev->repeat_count;
 	start_time = prev->start_time + (prev->repeat_count+1) * prev->duration;
 
@@ -2822,6 +2823,7 @@ static void gf_mpd_print_segment_timeline(FILE *out, GF_MPD_SegmentTimeline *tl,
 				start_time = se->start_time;
 			}
 			if (se->duration) gf_fprintf(out, " d=\"%d\"", se->duration);
+			if (se->nb_parts) gf_fprintf(out, " k=\"%d\"", se->nb_parts);
 			rcount=0;
 		} else {
 			rcount++;

--- a/src/media_tools/mpd.c
+++ b/src/media_tools/mpd.c
@@ -391,6 +391,8 @@ static GF_MPD_SegmentTimeline *gf_mpd_parse_segment_timeline(GF_MPD *mpd, GF_XML
 					seg_tl_ent->start_time = gf_mpd_parse_long_int(att->value);
 				else if (!strcmp(att->name, "d"))
 					seg_tl_ent->duration = gf_mpd_parse_int(att->value);
+				else if (!strcmp(att->name, "k"))
+					seg_tl_ent->nb_parts = gf_mpd_parse_int(att->value);
 				else if (!strcmp(att->name, "r")) {
 					seg_tl_ent->repeat_count = gf_mpd_parse_int(att->value);
 					if (seg_tl_ent->repeat_count == (u32)-1)

--- a/src/media_tools/mpd.c
+++ b/src/media_tools/mpd.c
@@ -2813,7 +2813,7 @@ static void gf_mpd_print_segment_timeline(FILE *out, GF_MPD_SegmentTimeline *tl,
 	for (i = tsb_first_entry+1; i<count && prev; i++) {
 		se = gf_list_get(tl->entries, i);
 		//close entry
-		if ((se->start_time != start_time) || (prev->duration!=se->duration)) {
+		if ((se->start_time != start_time) || (prev->duration!=se->duration) || (prev->nb_parts!=se->nb_parts)) {
 			if (rcount) gf_fprintf(out, " r=\"%d\"", rcount);
 			gf_fprintf(out, "/>");
 			gf_mpd_lf(out, indent);


### PR DESCRIPTION
So far, the manifest seems to be generated without a problem. The new option is `dashll=sf`.

Shaka player [hyperlink](https://shaka-player-demo.appspot.com/demo/#audiolang=en-US;textlang=en-US;lowLatencyMode=true;autoLowLatencyMode=true;forceHTTP=true;parsePrftBox=true;streaming.liveSync.enabled=true;infiniteLiveStreamDuration=true;uilang=en-US;asset=http://localhost:8080/test.mpd;panel=CUSTOM%20CONTENT;build=uncompiled)

## TODO
- [x] If segments don't have consistent parts, ~we have to warn that the input frame rate is not correct~ new `<S />` elements must be generated
- [ ] Implement playback with gpac

## Testing with
```
gpac avgen:lock:v c=libx264:fintra=1 reframer:rt=on -o http://localhost:8080/test.mpd:gpac:profile=dashif.ll:asto=1.7:dmode=dynauto:stl:segdur=2:cdur=0.1:ntp=yes:cmf2:rdirs=/tmp:dashll=sf
```