### PR TITLE
Segment Sequence Representations for DASH

### DIFF
--- a/include/gpac/filters.h
+++ b/include/gpac/filters.h
@@ -1249,6 +1249,7 @@ enum
 	GF_PROP_PID_PERIOD_START = GF_4CC('P','E','S','T'),
 	GF_PROP_PID_PERIOD_DUR = GF_4CC('P','E','D','U'),
 	GF_PROP_PID_REP_ID = GF_4CC('D','R','I','D'),
+	GF_PROP_PID_SSR = GF_4CC('S','S','R',' '),
 	GF_PROP_PID_AS_ID = GF_4CC('D','A','I','D'),
 	GF_PROP_PID_MUX_SRC = GF_4CC('M','S','R','C'),
 	GF_PROP_PID_DASH_MODE = GF_4CC('D','M','O','D'),

--- a/include/gpac/filters.h
+++ b/include/gpac/filters.h
@@ -1250,6 +1250,7 @@ enum
 	GF_PROP_PID_PERIOD_DUR = GF_4CC('P','E','D','U'),
 	GF_PROP_PID_REP_ID = GF_4CC('D','R','I','D'),
 	GF_PROP_PID_SSR = GF_4CC('S','S','R',' '),
+	GF_PROP_PID_SSR_MODE = GF_4CC('S','S','R','M'),
 	GF_PROP_PID_AS_ID = GF_4CC('D','A','I','D'),
 	GF_PROP_PID_MUX_SRC = GF_4CC('M','S','R','C'),
 	GF_PROP_PID_DASH_MODE = GF_4CC('D','M','O','D'),

--- a/include/gpac/mpd.h
+++ b/include/gpac/mpd.h
@@ -138,6 +138,8 @@ typedef struct
 	u64 start_time;
 	/*! duration in representation's MPD timescale - mandatory*/
 	u32 duration; /*MANDATORY*/
+	/* number of partial segments */
+	u32 nb_parts;
 	/*! may be 0xFFFFFFFF (-1) (\warning this needs further testing)*/
 	u32 repeat_count;
 } GF_MPD_SegmentTimelineEntry;

--- a/include/gpac/mpd.h
+++ b/include/gpac/mpd.h
@@ -138,8 +138,6 @@ typedef struct
 	u64 start_time;
 	/*! duration in representation's MPD timescale - mandatory*/
 	u32 duration; /*MANDATORY*/
-	/* number of partial segments */
-	u32 nb_parts;
 	/*! may be 0xFFFFFFFF (-1) (\warning this needs further testing)*/
 	u32 repeat_count;
 } GF_MPD_SegmentTimelineEntry;
@@ -319,6 +317,8 @@ typedef struct
 	char *initialization;
 	/*! bitstream switching segment template*/
 	char *bitstream_switching;
+	/*! part count for sub-segment representations*/
+	u32 nb_parts;
 
 	/*! internal, for HLS generation*/
 	const char *hls_init_name;

--- a/include/gpac/mpd.h
+++ b/include/gpac/mpd.h
@@ -716,6 +716,8 @@ typedef struct
 	GF_MPD_Fractional min_framerate;
 	/*! max framerate*/
 	GF_MPD_Fractional max_framerate;
+	/*! set if sub-segment represenation is used*/
+	Bool ssr;
 	/*! set if segment boundaries are time-aligned across qualities*/
 	Bool segment_alignment;
 	/*! set if a single init segment is needed (no reinit at quality switch)*/

--- a/src/filter_core/filter_props.c
+++ b/src/filter_core/filter_props.c
@@ -1686,6 +1686,7 @@ GF_BuiltInProperty GF_BuiltInProps [] =
 	DEC_PROP_F( GF_PROP_PID_PERIOD_DUR, "PDur", "DASH Period duration - cf dasher help", GF_PROP_FRACTION64, GF_PROP_FLAG_GSF_REM),
 	DEC_PROP_F( GF_PROP_PID_REP_ID, "Representation", "ID of DASH representation", GF_PROP_STRING, GF_PROP_FLAG_GSF_REM),
 	DEC_PROP_F( GF_PROP_PID_AS_ID, "ASID", "ID of parent DASH AS", GF_PROP_UINT, GF_PROP_FLAG_GSF_REM),
+	DEC_PROP_F( GF_PROP_PID_SSR, "SSR", "ID of Adaptation Set that this tune-in Adaptation Set is generated for. Works in LL-HLS compatability mode if negative", GF_PROP_SINT, GF_PROP_FLAG_GSF_REM),
 	DEC_PROP_F( GF_PROP_PID_MUX_SRC, "MuxSrc", "Name of mux source(s), set by dasher to direct its outputs", GF_PROP_STRING, GF_PROP_FLAG_GSF_REM),
 	DEC_PROP_F( GF_PROP_PID_DASH_MODE, "DashMode", "DASH mode to be used by multiplexer if any, set by dasher. 0 is no DASH, 1 is regular DASH, 2 is VoD", GF_PROP_UINT, GF_PROP_FLAG_GSF_REM),
 	DEC_PROP_F( GF_PROP_PID_FORCE_SEG_SYNC, "SegSync", "Indicate segment must be completely flushed before sending segment/fragment size events", GF_PROP_BOOL, GF_PROP_FLAG_GSF_REM),

--- a/src/filter_core/filter_props.c
+++ b/src/filter_core/filter_props.c
@@ -1687,6 +1687,7 @@ GF_BuiltInProperty GF_BuiltInProps [] =
 	DEC_PROP_F( GF_PROP_PID_REP_ID, "Representation", "ID of DASH representation", GF_PROP_STRING, GF_PROP_FLAG_GSF_REM),
 	DEC_PROP_F( GF_PROP_PID_AS_ID, "ASID", "ID of parent DASH AS", GF_PROP_UINT, GF_PROP_FLAG_GSF_REM),
 	DEC_PROP_F( GF_PROP_PID_SSR, "SSR", "ID of Adaptation Set that this tune-in Adaptation Set is generated for. Works in LL-HLS compatability mode if negative", GF_PROP_SINT, GF_PROP_FLAG_GSF_REM),
+	DEC_PROP_F( GF_PROP_PID_SSR_MODE, "SSRM", "Internal signalling for #SSR", GF_PROP_BOOL, GF_PROP_FLAG_GSF_REM),
 	DEC_PROP_F( GF_PROP_PID_MUX_SRC, "MuxSrc", "Name of mux source(s), set by dasher to direct its outputs", GF_PROP_STRING, GF_PROP_FLAG_GSF_REM),
 	DEC_PROP_F( GF_PROP_PID_DASH_MODE, "DashMode", "DASH mode to be used by multiplexer if any, set by dasher. 0 is no DASH, 1 is regular DASH, 2 is VoD", GF_PROP_UINT, GF_PROP_FLAG_GSF_REM),
 	DEC_PROP_F( GF_PROP_PID_FORCE_SEG_SYNC, "SegSync", "Indicate segment must be completely flushed before sending segment/fragment size events", GF_PROP_BOOL, GF_PROP_FLAG_GSF_REM),

--- a/src/filters/dasher.c
+++ b/src/filters/dasher.c
@@ -10795,7 +10795,7 @@ static const GF_FilterArgs DasherArgs[] =
 		"- brsf: generate two sets of manifest, one for byte-range and one for files (`_IF` added before extension of manifest)", GF_PROP_UINT, "off", "off|br|sf|brsf", GF_FS_ARG_HINT_EXPERT},
 	{ OFFS(dashll), "DASH Low Latency type\n"
 		" - cte: use Chunked Transfer Encoding for segments\n"
-		" - sf: use separate files for segment parts (post-fixed .1, .2 etc.)\n",
+		" - sf: use Segment Sequence Representation. Separate files for segment parts (post-fixed .1, .2 etc.)\n",
 		GF_PROP_UINT, "cte", "cte|sf", GF_FS_ARG_HINT_EXPERT},
 	{ OFFS(cdur), "chunk duration for fragmentation modes", GF_PROP_FRACTION, "-1/1", NULL, GF_FS_ARG_HINT_HIDE},
 	{ OFFS(hlsdrm), "cryp file info for HLS full segment encryption", GF_PROP_STRING, NULL, NULL, GF_FS_ARG_HINT_EXPERT},

--- a/src/filters/dasher.c
+++ b/src/filters/dasher.c
@@ -2873,6 +2873,11 @@ static void dasher_setup_set_defaults(GF_DasherCtx *ctx, GF_MPD_AdaptationSet *s
 	if (ctx->sseg) set->subsegment_alignment = ctx->align;
 	else set->segment_alignment = ctx->align;
 
+	if (ctx->llhls>1) {
+		set->subsegment_alignment = ctx->align;
+		set->segment_alignment = ctx->align;
+	}
+
 	//startWithSAP is set when the first packet comes in
 
 	//the rest depends on the various profiles/iop, to check
@@ -4430,6 +4435,8 @@ static void dasher_setup_sources(GF_Filter *filter, GF_DasherCtx *ctx, GF_MPD_Ad
 					seg_template->media = dasher_cat_mpd_url(ctx, ds, szSegmentName);
 					if (ds->idx_template)
 						seg_template->index = dasher_cat_mpd_url(ctx, ds, szIndexSegmentName);
+					if (ctx->do_mpd && ctx->llhls>1)
+						gf_dynstrcat(&seg_template->media, "$SubNumber$", ".");
 
 					seg_template->timescale = ds->mpd_timescale;
 					seg_template->start_number = start_number;
@@ -4468,6 +4475,8 @@ static void dasher_setup_sources(GF_Filter *filter, GF_DasherCtx *ctx, GF_MPD_Ad
 					seg_template->media = dasher_cat_mpd_url(ctx, ds, szSegmentName);
 					if (ds->idx_template)
 						seg_template->index = dasher_cat_mpd_url(ctx, ds, szIndexSegmentName);
+					if (ctx->do_mpd && ctx->llhls>1)
+						gf_dynstrcat(&seg_template->media, "$SubNumber$", ".");
 					seg_template->duration = seg_duration;
 					seg_template->timescale = ds->mpd_timescale;
 					seg_template->start_number = start_number;
@@ -7458,6 +7467,7 @@ static void dasher_insert_timeline_entry(GF_DasherCtx *ctx, GF_DashStream *ds)
 	if (!s) return;
 	s->start_time = ds->seg_start_time + pto;
 	s->duration = (u32) duration;
+	s->nb_parts = gf_ceil((ctx->segdur.num * ctx->cdur.den) / ((Double) ctx->segdur.den * ctx->cdur.num)); 
 	gf_list_add(tl->entries, s);
 }
 
@@ -9096,6 +9106,12 @@ static GF_Err dasher_process(GF_Filter *filter)
 							} else {
 								ds->set->starts_with_sap = sap_type;
 							}
+
+							if (ctx->llhls>1)
+							{
+								ds->set->starts_with_sap = ctx->sseg ? ds->set->subsegment_starts_with_sap : ds->set->starts_with_sap;
+								ds->set->subsegment_starts_with_sap = ctx->sseg ? ds->set->subsegment_starts_with_sap : ds->set->starts_with_sap;
+							}
 						}
 					}
 					else if (set_start_with_sap != sap_type) {
@@ -9397,6 +9413,12 @@ static GF_Err dasher_process(GF_Filter *filter)
 							ds->set->subsegment_starts_with_sap = sap_type;
 						else
 							ds->set->starts_with_sap = sap_type;
+
+						if (ctx->llhls>1)
+						{
+							ds->set->starts_with_sap = ctx->sseg ? ds->set->subsegment_starts_with_sap : ds->set->starts_with_sap;
+							ds->set->subsegment_starts_with_sap = ctx->sseg ? ds->set->subsegment_starts_with_sap : ds->set->starts_with_sap;
+						}
 					}
 
 
@@ -9555,6 +9577,12 @@ static GF_Err dasher_process(GF_Filter *filter)
 							ds->set->subsegment_starts_with_sap = MAX(ds->set->subsegment_starts_with_sap, sap_type);
 						else
 							ds->set->starts_with_sap = MAX(ds->set->starts_with_sap, sap_type);
+					}
+
+					if (ctx->llhls>1)
+					{
+						ds->set->starts_with_sap = ctx->sseg ? ds->set->subsegment_starts_with_sap : ds->set->starts_with_sap;
+						ds->set->subsegment_starts_with_sap = ctx->sseg ? ds->set->subsegment_starts_with_sap : ds->set->starts_with_sap;
 					}
 
 					seg_over = GF_TRUE;

--- a/src/filters/dasher.c
+++ b/src/filters/dasher.c
@@ -2873,11 +2873,6 @@ static void dasher_setup_set_defaults(GF_DasherCtx *ctx, GF_MPD_AdaptationSet *s
 	if (ctx->sseg) set->subsegment_alignment = ctx->align;
 	else set->segment_alignment = ctx->align;
 
-	if (ctx->llhls>1) {
-		set->subsegment_alignment = ctx->align;
-		set->segment_alignment = ctx->align;
-	}
-
 	//startWithSAP is set when the first packet comes in
 
 	//the rest depends on the various profiles/iop, to check
@@ -9106,12 +9101,6 @@ static GF_Err dasher_process(GF_Filter *filter)
 							} else {
 								ds->set->starts_with_sap = sap_type;
 							}
-
-							if (ctx->llhls>1)
-							{
-								ds->set->starts_with_sap = ctx->sseg ? ds->set->subsegment_starts_with_sap : ds->set->starts_with_sap;
-								ds->set->subsegment_starts_with_sap = ctx->sseg ? ds->set->subsegment_starts_with_sap : ds->set->starts_with_sap;
-							}
 						}
 					}
 					else if (set_start_with_sap != sap_type) {
@@ -9413,12 +9402,6 @@ static GF_Err dasher_process(GF_Filter *filter)
 							ds->set->subsegment_starts_with_sap = sap_type;
 						else
 							ds->set->starts_with_sap = sap_type;
-
-						if (ctx->llhls>1)
-						{
-							ds->set->starts_with_sap = ctx->sseg ? ds->set->subsegment_starts_with_sap : ds->set->starts_with_sap;
-							ds->set->subsegment_starts_with_sap = ctx->sseg ? ds->set->subsegment_starts_with_sap : ds->set->starts_with_sap;
-						}
 					}
 
 
@@ -9577,12 +9560,6 @@ static GF_Err dasher_process(GF_Filter *filter)
 							ds->set->subsegment_starts_with_sap = MAX(ds->set->subsegment_starts_with_sap, sap_type);
 						else
 							ds->set->starts_with_sap = MAX(ds->set->starts_with_sap, sap_type);
-					}
-
-					if (ctx->llhls>1)
-					{
-						ds->set->starts_with_sap = ctx->sseg ? ds->set->subsegment_starts_with_sap : ds->set->starts_with_sap;
-						ds->set->subsegment_starts_with_sap = ctx->sseg ? ds->set->subsegment_starts_with_sap : ds->set->starts_with_sap;
 					}
 
 					seg_over = GF_TRUE;

--- a/src/filters/dasher.c
+++ b/src/filters/dasher.c
@@ -7226,15 +7226,22 @@ static GF_Err dasher_setup_period(GF_Filter *filter, GF_DasherCtx *ctx, GF_DashS
 
 	//set SSR related descriptors
 	const GF_PropertyValue *p;
-	s32 tune_in_asid = -1;
+	GF_List *ssr_mappings = gf_list_new();
+	struct ssr_map {
+		u32 main_as;
+		u32 tune_in_as;
+	};
+
 	for (i=0; i<count; i++) {
 		GF_DashStream *ds = gf_list_get(ctx->current_period->streams, i);
 		if (!ds->owns_set) continue;
 		p = gf_filter_pid_get_property(ds->ipid, GF_PROP_PID_SSR);
 		if (p && p->value.sint >= 0) {
-			tune_in_asid = ds->as_id;
-			GF_LOG(GF_LOG_INFO, GF_LOG_DASH, ("[Dasher] Stream %s, tune-in ASID set to %d\n", ds->src_url, tune_in_asid));
-			break;
+			struct ssr_map *map = gf_malloc(sizeof(struct ssr_map));
+			map->main_as = p->value.sint;
+			map->tune_in_as = ds->as_id;
+			gf_list_add(ssr_mappings, map);
+			GF_LOG(GF_LOG_INFO, GF_LOG_DASH, ("[Dasher] Stream %s, tune-in ASID set to %d\n", ds->src_url, map->tune_in_as));
 		}
 	}
 
@@ -7245,11 +7252,19 @@ static GF_Err dasher_setup_period(GF_Filter *filter, GF_DasherCtx *ctx, GF_DashS
 		GF_MPD_Descriptor *desc_ssr = NULL;
 		GF_MPD_Descriptor *desc_ass = NULL;
 
+		// Check if this AS has tune-in AS
+		struct ssr_map *map = NULL;
+		for (int j = 0; j < gf_list_count(ssr_mappings); j++) {
+			map = gf_list_get(ssr_mappings, j);
+			if (map->main_as == ds->as_id) break;
+			else map = NULL;
+		}
+
 		char value[256];
-		if (tune_in_asid > 0 && ds->as_id != tune_in_asid) {
-			sprintf(value, "%d", tune_in_asid);
+		if (map != NULL) {
+			sprintf(value, "%d", map->tune_in_as);
 			desc_ass = gf_mpd_descriptor_new(NULL, "urn:mpeg:dash:adaptation-set-switching:2016", value);
-			GF_LOG(GF_LOG_INFO, GF_LOG_DASH, ("[Dasher] Stream %s, ASID %d is the main AS\n", ds->src_url, ds->as_id));
+			GF_LOG(GF_LOG_INFO, GF_LOG_DASH, ("[Dasher] Stream %s, ASID %d is the main AS of %d\n", ds->src_url, ds->as_id, map->tune_in_as));
 		}
 
 		p = gf_filter_pid_get_property(ds->ipid, GF_PROP_PID_SSR);

--- a/src/filters/dasher.c
+++ b/src/filters/dasher.c
@@ -10541,7 +10541,10 @@ static GF_Err dasher_initialize(GF_Filter *filter)
 			GF_LOG(GF_LOG_WARNING, GF_LOG_DASH, ("[Dasher] DASH with partial segments require Segment Timeline, enabling it\n"));
 			ctx->stl = GF_TRUE;
 		}
-		ctx->llhls = 2; // enable llhls=sf
+		if (ctx->llhls==1) {
+			GF_LOG(GF_LOG_WARNING, GF_LOG_DASH, ("[Dasher] DASH with partial segments require LL-HLS with seperate files mode, enabling it\n"));
+		}
+		if (ctx->llhls<2) ctx->llhls = 2;
 	}
 
 	if (!ctx->sap || ctx->sigfrag || ctx->cues)

--- a/src/filters/dasher.c
+++ b/src/filters/dasher.c
@@ -216,6 +216,7 @@ typedef struct
 	char *ckurl;
 	GF_PropStringList hlsx;
 	u32 llhls;
+	u32 dashll;
 	Bool hlsiv;
 	//inherited from mp4mx
 	GF_Fraction cdur;
@@ -4430,7 +4431,7 @@ static void dasher_setup_sources(GF_Filter *filter, GF_DasherCtx *ctx, GF_MPD_Ad
 					seg_template->media = dasher_cat_mpd_url(ctx, ds, szSegmentName);
 					if (ds->idx_template)
 						seg_template->index = dasher_cat_mpd_url(ctx, ds, szIndexSegmentName);
-					if (ctx->do_mpd && ctx->llhls>1)
+					if (ctx->dashll)
 						gf_dynstrcat(&seg_template->media, "$SubNumber$", ".");
 
 					seg_template->timescale = ds->mpd_timescale;
@@ -4470,7 +4471,7 @@ static void dasher_setup_sources(GF_Filter *filter, GF_DasherCtx *ctx, GF_MPD_Ad
 					seg_template->media = dasher_cat_mpd_url(ctx, ds, szSegmentName);
 					if (ds->idx_template)
 						seg_template->index = dasher_cat_mpd_url(ctx, ds, szIndexSegmentName);
-					if (ctx->do_mpd && ctx->llhls>1)
+					if (ctx->dashll)
 						gf_dynstrcat(&seg_template->media, "$SubNumber$", ".");
 					seg_template->duration = seg_duration;
 					seg_template->timescale = ds->mpd_timescale;
@@ -10535,6 +10536,14 @@ static GF_Err dasher_initialize(GF_Filter *filter)
 		}
 	}
 
+	if (ctx->dashll) {
+		if (!ctx->stl) {
+			GF_LOG(GF_LOG_WARNING, GF_LOG_DASH, ("[Dasher] DASH with partial segments require Segment Timeline, enabling it\n"));
+			ctx->stl = GF_TRUE;
+		}
+		ctx->llhls = 2; // enable llhls=sf
+	}
+
 	if (!ctx->sap || ctx->sigfrag || ctx->cues)
 		ctx->sbound = DASHER_BOUNDS_OUT;
 
@@ -10775,6 +10784,10 @@ static const GF_FilterArgs DasherArgs[] =
 		"- br: use LL-HLS with byte-range for segment parts, pointing to full segment (DASH-LL compatible)\n"
 		"- sf: use separate files for segment parts (post-fixed .1, .2 etc.)\n"
 		"- brsf: generate two sets of manifest, one for byte-range and one for files (`_IF` added before extension of manifest)", GF_PROP_UINT, "off", "off|br|sf|brsf", GF_FS_ARG_HINT_EXPERT},
+	{ OFFS(dashll), "DASH Low Latency type\n"
+		" - cte: use Chunked Transfer Encoding for segments\n"
+		" - sf: use separate files for segment parts (post-fixed .1, .2 etc.)\n",
+		GF_PROP_UINT, "cte", "cte|sf", GF_FS_ARG_HINT_EXPERT},
 	{ OFFS(cdur), "chunk duration for fragmentation modes", GF_PROP_FRACTION, "-1/1", NULL, GF_FS_ARG_HINT_HIDE},
 	{ OFFS(hlsdrm), "cryp file info for HLS full segment encryption", GF_PROP_STRING, NULL, NULL, GF_FS_ARG_HINT_EXPERT},
 	{ OFFS(hlsx), "list of string to append to master HLS header before variants with `['#foo','#bar=val']` added as `#foo \\n #bar=val`", GF_PROP_STRING_LIST, NULL, NULL, GF_FS_ARG_HINT_EXPERT},

--- a/src/filters/dasher.c
+++ b/src/filters/dasher.c
@@ -216,7 +216,6 @@ typedef struct
 	char *ckurl;
 	GF_PropStringList hlsx;
 	u32 llhls;
-	u32 dashll;
 	Bool hlsiv;
 	//inherited from mp4mx
 	GF_Fraction cdur;
@@ -4431,7 +4430,7 @@ static void dasher_setup_sources(GF_Filter *filter, GF_DasherCtx *ctx, GF_MPD_Ad
 					seg_template->media = dasher_cat_mpd_url(ctx, ds, szSegmentName);
 					if (ds->idx_template)
 						seg_template->index = dasher_cat_mpd_url(ctx, ds, szIndexSegmentName);
-					if (ctx->dashll)
+					if (set->ssr)
 						gf_dynstrcat(&seg_template->media, "$SubNumber$", ".");
 
 					seg_template->timescale = ds->mpd_timescale;
@@ -4471,7 +4470,7 @@ static void dasher_setup_sources(GF_Filter *filter, GF_DasherCtx *ctx, GF_MPD_Ad
 					seg_template->media = dasher_cat_mpd_url(ctx, ds, szSegmentName);
 					if (ds->idx_template)
 						seg_template->index = dasher_cat_mpd_url(ctx, ds, szIndexSegmentName);
-					if (ctx->dashll)
+					if (set->ssr)
 						gf_dynstrcat(&seg_template->media, "$SubNumber$", ".");
 					seg_template->duration = seg_duration;
 					seg_template->timescale = ds->mpd_timescale;
@@ -7225,6 +7224,53 @@ static GF_Err dasher_setup_period(GF_Filter *filter, GF_DasherCtx *ctx, GF_DashS
 		GF_LOG(GF_LOG_INFO, GF_LOG_DASH, ("[Dasher] MPD Availability start time initialized to "LLU" ms\n", ctx->mpd->availabilityStartTime));
 	}
 
+	//set SSR related descriptors
+	const GF_PropertyValue *p;
+	s32 tune_in_asid = -1;
+	for (i=0; i<count; i++) {
+		GF_DashStream *ds = gf_list_get(ctx->current_period->streams, i);
+		if (!ds->owns_set) continue;
+		p = gf_filter_pid_get_property(ds->ipid, GF_PROP_PID_SSR);
+		if (p && p->value.sint >= 0) {
+			tune_in_asid = ds->as_id;
+			GF_LOG(GF_LOG_INFO, GF_LOG_DASH, ("[Dasher] Stream %s, tune-in ASID set to %d\n", ds->src_url, tune_in_asid));
+			break;
+		}
+	}
+
+	for (i=0; i<count; i++) {
+		GF_DashStream *ds = gf_list_get(ctx->current_period->streams, i);
+		if (!ds->owns_set) continue;
+
+		GF_MPD_Descriptor *desc_ssr = NULL;
+		GF_MPD_Descriptor *desc_ass = NULL;
+
+		char value[256];
+		if (tune_in_asid > 0 && ds->as_id != tune_in_asid) {
+			sprintf(value, "%d", tune_in_asid);
+			desc_ass = gf_mpd_descriptor_new(NULL, "urn:mpeg:dash:adaptation-set-switching:2016", value);
+			GF_LOG(GF_LOG_INFO, GF_LOG_DASH, ("[Dasher] Stream %s, ASID %d is the main AS\n", ds->src_url, ds->as_id));
+		}
+
+		p = gf_filter_pid_get_property(ds->ipid, GF_PROP_PID_SSR);
+		if (p) {
+			ds->set->ssr = GF_TRUE;
+			if (p->value.sint < 0) {
+				// LL-HLS compatibility mode
+				desc_ssr = gf_mpd_descriptor_new(NULL, "urn:mpeg:dash:ssr:2023", NULL);
+				GF_LOG(GF_LOG_INFO, GF_LOG_DASH, ("[Dasher] Stream %s, ASID %d is using SSR with LL-HLS compatibility mode\n", ds->src_url, ds->as_id));
+			} else {
+				sprintf(value, "%d", p->value.sint);
+				desc_ssr = gf_mpd_descriptor_new(NULL, "urn:mpeg:dash:ssr:2023", value);
+				desc_ass = gf_mpd_descriptor_new(NULL, "urn:mpeg:dash:adaptation-set-switching:2016", value);
+				GF_LOG(GF_LOG_INFO, GF_LOG_DASH, ("[Dasher] Stream %s, ASID %d is the tune-in AS\n", ds->src_url, ds->as_id));
+			}
+		}
+
+		if (desc_ssr != NULL) gf_list_add(ds->set->essential_properties, desc_ssr);
+		if (desc_ass != NULL) gf_list_add(ds->set->supplemental_properties, desc_ass);
+	}
+
 	//setup adaptation sets bitstream switching
 	for (i=0; i<count; i++) {
 		GF_DashStream *ds = gf_list_get(ctx->current_period->streams, i);
@@ -7454,7 +7500,7 @@ static void dasher_insert_timeline_entry(GF_DasherCtx *ctx, GF_DashStream *ds)
 	}
 
 	//add to last entry ONLY if not keeping segments
-	u32 last_part_count = ctx->dashll && s ? s->nb_parts : 0;
+	u32 last_part_count = ds->set->ssr && s ? s->nb_parts : 0;
 	Bool same_parts = sctx ? (sctx->nb_frags + 1 == last_part_count) : GF_TRUE;
 	if (!ctx->keep_segs && s && (s->duration == duration) && same_parts
 		&& (s->start_time + (s->repeat_count+1) * s->duration == ds->seg_start_time + pto)
@@ -7468,7 +7514,7 @@ static void dasher_insert_timeline_entry(GF_DasherCtx *ctx, GF_DashStream *ds)
 	if (!s) return;
 	s->start_time = ds->seg_start_time + pto;
 	s->duration = (u32) duration;
-	if (ctx->dashll) s->nb_parts = sctx->nb_frags + 1;
+	if (ds->set->ssr) s->nb_parts = sctx->nb_frags + 1;
 	gf_list_add(tl->entries, s);
 	GF_LOG(GF_LOG_INFO, GF_LOG_DASH, ("[Dasher] Inserting segment timeline entry for %s, start %llu, dur %llu, nb_parts %d\n", ds->src_url, s->start_time, s->duration, s->nb_parts));
 }
@@ -8022,7 +8068,7 @@ static void dasher_mark_segment_start(GF_DasherCtx *ctx, GF_DashStream *ds, GF_F
 		if (!seg_state) return;
 		seg_state->time = ds->seg_start_time;
 		seg_state->seg_num = ds->seg_number;
-		seg_state->llhls_mode = ctx->llhls;
+		seg_state->llhls_mode = ctx->llhls || ds->set->ssr;
 		ds->current_seg_state = seg_state;
 		seg_state->encrypted = GF_FALSE;
 
@@ -10542,17 +10588,6 @@ static GF_Err dasher_initialize(GF_Filter *filter)
 		}
 	}
 
-	if (ctx->dashll) {
-		if (!ctx->stl) {
-			GF_LOG(GF_LOG_WARNING, GF_LOG_DASH, ("[Dasher] DASH with partial segments require Segment Timeline, enabling it\n"));
-			ctx->stl = GF_TRUE;
-		}
-		if (ctx->llhls==1) {
-			GF_LOG(GF_LOG_WARNING, GF_LOG_DASH, ("[Dasher] DASH with partial segments require LL-HLS with seperate files mode, enabling it\n"));
-		}
-		if (ctx->llhls<2) ctx->llhls = 2;
-	}
-
 	if (!ctx->sap || ctx->sigfrag || ctx->cues)
 		ctx->sbound = DASHER_BOUNDS_OUT;
 
@@ -10793,10 +10828,6 @@ static const GF_FilterArgs DasherArgs[] =
 		"- br: use LL-HLS with byte-range for segment parts, pointing to full segment (DASH-LL compatible)\n"
 		"- sf: use separate files for segment parts (post-fixed .1, .2 etc.)\n"
 		"- brsf: generate two sets of manifest, one for byte-range and one for files (`_IF` added before extension of manifest)", GF_PROP_UINT, "off", "off|br|sf|brsf", GF_FS_ARG_HINT_EXPERT},
-	{ OFFS(dashll), "DASH Low Latency type\n"
-		" - cte: use Chunked Transfer Encoding for segments\n"
-		" - sf: use Segment Sequence Representation. Separate files for segment parts (post-fixed .1, .2 etc.)\n",
-		GF_PROP_UINT, "cte", "cte|sf", GF_FS_ARG_HINT_EXPERT},
 	{ OFFS(cdur), "chunk duration for fragmentation modes", GF_PROP_FRACTION, "-1/1", NULL, GF_FS_ARG_HINT_HIDE},
 	{ OFFS(hlsdrm), "cryp file info for HLS full segment encryption", GF_PROP_STRING, NULL, NULL, GF_FS_ARG_HINT_EXPERT},
 	{ OFFS(hlsx), "list of string to append to master HLS header before variants with `['#foo','#bar=val']` added as `#foo \\n #bar=val`", GF_PROP_STRING_LIST, NULL, NULL, GF_FS_ARG_HINT_EXPERT},

--- a/src/filters/mux_isom.c
+++ b/src/filters/mux_isom.c
@@ -7759,9 +7759,8 @@ static GF_Err mp4_mux_on_data(void *cbk, u8 *data, u32 block_size, void *cbk_dat
 	}
 
 	if ((ctx->llhls_mode>1 || ctx->ssr) && ctx->fragment_started && !ctx->frag_size && ctx->dst_pck) {
-		if (ctx->llhls_mode>1) ctx->frag_num++;
+		ctx->frag_num++;
 		gf_filter_pck_set_property(ctx->dst_pck, GF_PROP_PCK_HLS_FRAG_NUM, &PROP_UINT(ctx->frag_num));
-		if (ctx->ssr) ctx->frag_num++;
 	}
 	ctx->frag_size += block_size;
 

--- a/src/filters/mux_isom.c
+++ b/src/filters/mux_isom.c
@@ -1282,7 +1282,7 @@ static GF_Err mp4_mux_setup_pid(GF_Filter *filter, GF_FilterPid *pid, Bool is_tr
 		ctx->dash_mode = MP4MX_DASH_ON;
 	}
 
-	p = gf_filter_pid_get_property(pid, GF_PROP_PID_SSR);
+	p = gf_filter_pid_get_property(pid, GF_PROP_PID_SSR_MODE);
 	ctx->ssr = p ? GF_TRUE : GF_FALSE;
 	p = gf_filter_pid_get_property(pid, GF_PROP_PID_LLHLS);
 	ctx->llhls_mode = p ? p->value.uint : 0;

--- a/src/filters/mux_isom.c
+++ b/src/filters/mux_isom.c
@@ -326,6 +326,7 @@ typedef struct
 	GF_FilterPid *opid;
 	Bool first_pck_sent;
 	Bool track_removed;
+	Bool ssr;
 
 	GF_List *tracks;
 
@@ -1281,10 +1282,13 @@ static GF_Err mp4_mux_setup_pid(GF_Filter *filter, GF_FilterPid *pid, Bool is_tr
 		ctx->dash_mode = MP4MX_DASH_ON;
 	}
 
+	p = gf_filter_pid_get_property(pid, GF_PROP_PID_SSR);
+	ctx->ssr = p ? GF_TRUE : GF_FALSE;
 	p = gf_filter_pid_get_property(pid, GF_PROP_PID_LLHLS);
 	ctx->llhls_mode = p ? p->value.uint : 0;
+
 	//insert tfdt in each traf for LL-HLS so that correct timing can be found when doing in-segment tune-in
-	if (ctx->llhls_mode) {
+	if (ctx->llhls_mode || ctx->ssr) {
 		ctx->tfdt_traf = GF_TRUE;
 		ctx->store = MP4MX_MODE_SFRAG;
 	}
@@ -5757,7 +5761,7 @@ static void mp4_mux_flush_seg(GF_MP4MuxCtx *ctx, Bool is_init, u64 idx_start_ran
 		if (signal_flush)
 			gf_filter_pid_send_flush(ctx->opid);
 	}
-	if (!is_init && ctx->llhls_mode && ctx->frag_size) {
+	if (!is_init && (ctx->llhls_mode || ctx->ssr) && ctx->frag_size) {
 		mp4_mux_flush_frag_hls(ctx);
 	}
 	if (ctx->dash_mode) {
@@ -6737,7 +6741,7 @@ static GF_Err mp4_mux_process_fragmented(GF_MP4MuxCtx *ctx)
 					break;
 				}
 				tkw->dur_in_frag += dur;
-				if (ctx->llhls_mode && (ctx->frag_duration * tkw->src_timescale <= tkw->dur_in_frag * ctx->frag_timescale)) {
+				if ((ctx->llhls_mode || ctx->ssr) && (ctx->frag_duration * tkw->src_timescale <= tkw->dur_in_frag * ctx->frag_timescale)) {
 					ctx->frag_duration = tkw->dur_in_frag;
 					ctx->frag_timescale = tkw->src_timescale;
 				}
@@ -6960,11 +6964,11 @@ static GF_Err mp4_mux_process_fragmented(GF_MP4MuxCtx *ctx)
 
 			//we need to wait for packet to be written
 			if (ctx->seg_flush_state) {
-				if (ctx->llhls_mode) ctx->flush_ll_hls = GF_TRUE;
+				if (ctx->llhls_mode || ctx->ssr) ctx->flush_ll_hls = GF_TRUE;
 				return GF_OK;
 			}
 
-			if (ctx->llhls_mode) {
+			if (ctx->llhls_mode || ctx->ssr) {
 				mp4_mux_flush_frag_hls(ctx);
 			}
 
@@ -7754,9 +7758,10 @@ static GF_Err mp4_mux_on_data(void *cbk, u8 *data, u32 block_size, void *cbk_dat
 			gf_filter_pck_set_duration(ctx->dst_pck, 1);
 	}
 
-	if ((ctx->llhls_mode>1) && ctx->fragment_started && !ctx->frag_size && ctx->dst_pck) {
-		ctx->frag_num++;
+	if ((ctx->llhls_mode>1 || ctx->ssr) && ctx->fragment_started && !ctx->frag_size && ctx->dst_pck) {
+		if (ctx->llhls_mode>1) ctx->frag_num++;
 		gf_filter_pck_set_property(ctx->dst_pck, GF_PROP_PCK_HLS_FRAG_NUM, &PROP_UINT(ctx->frag_num));
+		if (ctx->ssr) ctx->frag_num++;
 	}
 	ctx->frag_size += block_size;
 

--- a/src/filters/mux_ts.c
+++ b/src/filters/mux_ts.c
@@ -1216,7 +1216,7 @@ static GF_Err tsmux_configure_pid(GF_Filter *filter, GF_FilterPid *pid, Bool is_
 				ctx->force_seg_sync = GF_TRUE;
 		}
 	}
-	p = gf_filter_pid_get_property(pid, GF_PROP_PID_SSR);
+	p = gf_filter_pid_get_property(pid, GF_PROP_PID_SSR_MODE);
 	ctx->ssr = p ? GF_TRUE : GF_FALSE;
 	p = gf_filter_pid_get_info(pid, GF_PROP_PID_LLHLS, &pe);
 	ctx->llhls = p ? p->value.uint : 0;

--- a/src/filters/mux_ts.c
+++ b/src/filters/mux_ts.c
@@ -1868,9 +1868,8 @@ static GF_Err tsmux_process(GF_Filter *filter)
 		}
 		else if (ctx->next_is_llhls_start) {
 			if (ctx->llhls>1 || ctx->ssr) {
-				if (ctx->llhls>1) ctx->frag_num++;
+				ctx->frag_num++;
 				gf_filter_pck_set_property(pck, GF_PROP_PCK_HLS_FRAG_NUM, &PROP_UINT(ctx->frag_num));
-				if (ctx->ssr) ctx->frag_num++;
 			}
 			ctx->next_is_llhls_start = GF_FALSE;
 		}

--- a/src/media_tools/mpd.c
+++ b/src/media_tools/mpd.c
@@ -391,8 +391,6 @@ static GF_MPD_SegmentTimeline *gf_mpd_parse_segment_timeline(GF_MPD *mpd, GF_XML
 					seg_tl_ent->start_time = gf_mpd_parse_long_int(att->value);
 				else if (!strcmp(att->name, "d"))
 					seg_tl_ent->duration = gf_mpd_parse_int(att->value);
-				else if (!strcmp(att->name, "k"))
-					seg_tl_ent->nb_parts = gf_mpd_parse_int(att->value);
 				else if (!strcmp(att->name, "r")) {
 					seg_tl_ent->repeat_count = gf_mpd_parse_int(att->value);
 					if (seg_tl_ent->repeat_count == (u32)-1)
@@ -2806,14 +2804,13 @@ static void gf_mpd_print_segment_timeline(FILE *out, GF_MPD_SegmentTimeline *tl,
 	gf_fprintf(out, "<S");
 	gf_fprintf(out, " t=\""LLD"\"", prev->start_time);
 	if (prev->duration) gf_fprintf(out, " d=\"%d\"", prev->duration);
-	if (prev->nb_parts) gf_fprintf(out, " k=\"%d\"", prev->nb_parts);
 	rcount = prev->repeat_count;
 	start_time = prev->start_time + (prev->repeat_count+1) * prev->duration;
 
 	for (i = tsb_first_entry+1; i<count && prev; i++) {
 		se = gf_list_get(tl->entries, i);
 		//close entry
-		if ((se->start_time != start_time) || (prev->duration!=se->duration) || (prev->nb_parts!=se->nb_parts)) {
+		if ((se->start_time != start_time) || (prev->duration!=se->duration)) {
 			if (rcount) gf_fprintf(out, " r=\"%d\"", rcount);
 			gf_fprintf(out, "/>");
 			gf_mpd_lf(out, indent);
@@ -2825,7 +2822,6 @@ static void gf_mpd_print_segment_timeline(FILE *out, GF_MPD_SegmentTimeline *tl,
 				start_time = se->start_time;
 			}
 			if (se->duration) gf_fprintf(out, " d=\"%d\"", se->duration);
-			if (se->nb_parts) gf_fprintf(out, " k=\"%d\"", se->nb_parts);
 			rcount=0;
 		} else {
 			rcount++;
@@ -2954,6 +2950,7 @@ static void gf_mpd_print_segment_template(FILE *out, GF_MPD_SegmentTemplate *s, 
 	if (s->index) gf_fprintf(out, " index=\"%s\"", s->index);
 	if (s->initialization) gf_xml_dump_string(out, " initialization=\"", s->initialization, "\"");
 	if (s->bitstream_switching) gf_fprintf(out, " bitstreamSwitching=\"%s\"", s->bitstream_switching);
+	if (s->nb_parts) gf_fprintf(out, " k=\"%d\"", s->nb_parts);
 
 	if (gf_mpd_print_multiple_segment_base(out, (GF_MPD_MultipleSegmentBase *)s, indent, GF_TRUE))
 		return;

--- a/src/media_tools/mpd.c
+++ b/src/media_tools/mpd.c
@@ -2804,6 +2804,7 @@ static void gf_mpd_print_segment_timeline(FILE *out, GF_MPD_SegmentTimeline *tl,
 	gf_fprintf(out, "<S");
 	gf_fprintf(out, " t=\""LLD"\"", prev->start_time);
 	if (prev->duration) gf_fprintf(out, " d=\"%d\"", prev->duration);
+	if (prev->nb_parts) gf_fprintf(out, " k=\"%d\"", prev->nb_parts);
 	rcount = prev->repeat_count;
 	start_time = prev->start_time + (prev->repeat_count+1) * prev->duration;
 
@@ -2822,6 +2823,7 @@ static void gf_mpd_print_segment_timeline(FILE *out, GF_MPD_SegmentTimeline *tl,
 				start_time = se->start_time;
 			}
 			if (se->duration) gf_fprintf(out, " d=\"%d\"", se->duration);
+			if (se->nb_parts) gf_fprintf(out, " k=\"%d\"", se->nb_parts);
 			rcount=0;
 		} else {
 			rcount++;

--- a/src/media_tools/mpd.c
+++ b/src/media_tools/mpd.c
@@ -391,6 +391,8 @@ static GF_MPD_SegmentTimeline *gf_mpd_parse_segment_timeline(GF_MPD *mpd, GF_XML
 					seg_tl_ent->start_time = gf_mpd_parse_long_int(att->value);
 				else if (!strcmp(att->name, "d"))
 					seg_tl_ent->duration = gf_mpd_parse_int(att->value);
+				else if (!strcmp(att->name, "k"))
+					seg_tl_ent->nb_parts = gf_mpd_parse_int(att->value);
 				else if (!strcmp(att->name, "r")) {
 					seg_tl_ent->repeat_count = gf_mpd_parse_int(att->value);
 					if (seg_tl_ent->repeat_count == (u32)-1)

--- a/src/media_tools/mpd.c
+++ b/src/media_tools/mpd.c
@@ -2813,7 +2813,7 @@ static void gf_mpd_print_segment_timeline(FILE *out, GF_MPD_SegmentTimeline *tl,
 	for (i = tsb_first_entry+1; i<count && prev; i++) {
 		se = gf_list_get(tl->entries, i);
 		//close entry
-		if ((se->start_time != start_time) || (prev->duration!=se->duration)) {
+		if ((se->start_time != start_time) || (prev->duration!=se->duration) || (prev->nb_parts!=se->nb_parts)) {
 			if (rcount) gf_fprintf(out, " r=\"%d\"", rcount);
 			gf_fprintf(out, "/>");
 			gf_mpd_lf(out, indent);


### PR DESCRIPTION
Opened in place of #2932

So far, the manifest seems to be generated without a problem. The signalling is shown in the examples.

Shaka player [hyperlink](https://shaka-player-demo.appspot.com/demo/#audiolang=en-US;textlang=en-US;lowLatencyMode=true;autoLowLatencyMode=true;forceHTTP=true;parsePrftBox=true;streaming.liveSync.enabled=true;infiniteLiveStreamDuration=true;uilang=en-US;asset=http://localhost:8080/dash/live.mpd;panel=CUSTOM%20CONTENT;build=uncompiled)

# TODO
- [x] If segments don't have consistent parts, ~we have to warn that the input frame rate is not correct~ new `<S />` elements must be generated
- [ ] Implement playback with gpac
- [x] ~Start parts numbers at `0`~
- [x] Essential Property `urn:mpeg:dash:ssr:2023` should always be signaled.
- [x] Per Annex G.28, we should support the two modes. IDR per **partial** segment or IDR per segment
- [x] Remove the dasher option and instead use PID properties
- [x] Behaves differently if ran locally vs pushing to origin
- [ ] Part count might not be consistent

# Examples

There are two modes for SSR:

- `#SSR=-1` for LL-HLS compatibility mode
- `#SSR=x` for creating tune-in adaptation set for the `x`-th adaptation set

> For the latter mode, using `#ASID=x` is advised to signal the adaptation set ID.


## G.28.1 Low Delay Representation
Single bitrate with extra tune-in adaptation set
```
gpac avgen:lock:v:fps=30:FID=AV \
    c=libx264:fintra=2:#ASID=1:SID=AV:FID=SM \
    c=libx264:fintra=0.1:#SSR=1:#ASID=2:SID=AV:FID=STI \
    -o http://localhost:8080/dash/live.mpd:gpac:rdirs=/tmp:profile=dashif.ll:asto=1.7:dmode=dynamic:stl:segdur=2:cdur=0.1:ntp=yes:cmf2:SID=SM,STI:sreg
```

## G.28.1.2 Low Delay Representation with Audio
Single bitrate with extra tune-in adaptation set and audio adaptation set in LL-HLS compatibility mode
```
gpac avgen:lock:fps=30:FID=AV \
    c=libx264:fintra=2:#ASID=1:SID=AV:FID=SMV \
    c=libx264:fintra=0.1:#SSR=1:#ASID=2:SID=AV:FID=STV \
    c=aac:#ASID=3:#SSR=-1:SID=AV:FID=SMA \
    -o http://localhost:8080/dash/live.mpd:gpac:rdirs=/tmp:profile=dashif.ll:asto=1.7:dmode=dynamic:stl:segdur=2:cdur=0.1:ntp=yes:cmf2:SID=SMV,STV,SMA:sreg
```

## G.28.2 Low Latency Segment Sequence Representation
Single bitrate with LL-HLS compatibility mode
```
gpac avgen:lock:v:fps=30 \
    c=libx264:fintra=0.1:#SSR=-1 \
    -o http://localhost:8080/dash/live.mpd:gpac:rdirs=/tmp:profile=dashif.ll:asto=1.7:dmode=dynamic:stl:segdur=2:cdur=0.1:ntp=yes:cmf2:sreg
```