### PR TITLE
backport the security patch of CVE-2023-50120

### DIFF
--- a/src/media_tools/av_parsers.c
+++ b/src/media_tools/av_parsers.c
@@ -1635,7 +1635,7 @@ static u32 av1_uvlc(GF_BitStream *bs, const char *fname)
 {
 	u32 res;
 	u8 leadingZeros = 0;
-	while (1) {
+	while (gf_bs_available(bs)) {
 		Bool done = gf_bs_read_int(bs, 1);
 		if (done)
 			break;


### PR DESCRIPTION
Here is a vulnerability which is mentioned in https://github.com/gpac/gpac/issues/2698 and fixed in the master branch(https://github.com/gpac/gpac/commit/b655955b840ccd7c7198bb15375aa510e76208eb) but is not fixed in the branch of buildbot-mabr_misc,  maybe it should be backported?