### PR TITLE
Disabling Chunked Transfer Encoding

### DIFF
--- a/include/gpac/download.h
+++ b/include/gpac/download.h
@@ -400,16 +400,6 @@ Fetches the session object (process all headers and data transfer). This is only
 GF_Err gf_dm_sess_process(GF_DownloadSession *sess);
 
 /*!
-\brief accumulate data in session
-
-Accumulates data in the session. This is only usable if the session is not using CTE
-\param sess the download session
-\param data the data to accumulate
-\param size the size of the data
-\return the last error in the session or 0 if none*/
-GF_Err gf_dm_sess_accumulate(GF_DownloadSession *sess, const u8 *data, u32 size);
-
-/*!
 \brief fetch session object headers
 
 Fetch the session object headers and stops after that. This is only usable if the session is not threaded

--- a/include/gpac/download.h
+++ b/include/gpac/download.h
@@ -400,6 +400,16 @@ Fetches the session object (process all headers and data transfer). This is only
 GF_Err gf_dm_sess_process(GF_DownloadSession *sess);
 
 /*!
+\brief accumulate data in session
+
+Accumulates data in the session. This is only usable if the session is not using CTE
+\param sess the download session
+\param data the data to accumulate
+\param size the size of the data
+\return the last error in the session or 0 if none*/
+GF_Err gf_dm_sess_accumulate(GF_DownloadSession *sess, const u8 *data, u32 size);
+
+/*!
 \brief fetch session object headers
 
 Fetch the session object headers and stops after that. This is only usable if the session is not threaded

--- a/src/filters/out_http.c
+++ b/src/filters/out_http.c
@@ -2334,7 +2334,7 @@ static void httpout_in_io_ex(void *usr_cbk, GF_NETIO_Parameter *parameter, Bool 
 
 		if (in->is_delete) return;
 
-		if (gf_opts_get_bool("core", "no-cte") && cur_header == HTTP_PUT_HEADER_ENCODING) {
+		if (gf_opts_get_bool("core", "no-cte") && *cur_header == HTTP_PUT_HEADER_ENCODING) {
 			if (in->mime)
 				*cur_header = HTTP_PUT_HEADER_MIME;
 			else
@@ -3710,7 +3710,7 @@ static Bool httpout_close_upload(GF_HTTPOutCtx *ctx, GF_HTTPOutInput *in, Bool f
 	Bool res = GF_TRUE;
 	GF_Err e;
 
-	if (!gf_opts_get_bool("core", "no-cte")) {
+	if (gf_opts_get_bool("core", "no-cte")) {
 		GF_DownloadSession *dls = for_llhls ? in->llhls_upload : in->upload;
 		e = gf_dm_sess_accumulate(dls, NULL, 1); // don't send the data yet
 

--- a/src/utils/downloader.c
+++ b/src/utils/downloader.c
@@ -5485,7 +5485,7 @@ static GF_Err http_send_headers(GF_DownloadSession *sess, char * sHTTP) {
 	} else if (!strcmp(req_name, "HEAD")) sess->http_read_type = HEAD;
 	else sess->http_read_type = OTHER;
 
-	if (!strcmp(req_name, "PUT") || !strcmp(req_name, "POST"))
+	if ((!strcmp(req_name, "PUT") || !strcmp(req_name, "POST")) && !gf_opts_get_bool("core", "no-cte"))
 		sess->put_state = 1;
 
 	//note that url is not used for CURL, already setup together with proxy

--- a/src/utils/downloader.c
+++ b/src/utils/downloader.c
@@ -137,7 +137,8 @@ enum REQUEST_TYPE
 {
 	GET = 0,
 	HEAD = 1,
-	OTHER = 2
+	DELETE = 2,
+	OTHER = 3
 };
 
 /*!the structure used to store an HTTP header*/
@@ -5391,11 +5392,15 @@ static Bool http_request_has_body(GF_DownloadSession *sess) {
 		gf_dm_sess_user_io(sess, &par);
 
 		if (!par.name) return GF_FALSE;
-		if (!strcmp(par.name, "GET") || !strcmp(par.name, "HEAD")) return GF_FALSE;
+		if (!strcmp(par.name, "GET") || !strcmp(par.name, "HEAD") || !strcmp(par.name, "DELETE"))
+			return GF_FALSE;
+
 		return GF_TRUE;
 	}
 
-	if (sess->http_read_type == GET || sess->http_read_type == HEAD) return GF_FALSE;
+	if (sess->http_read_type == GET || sess->http_read_type == HEAD || sess->http_read_type == DELETE)
+		return GF_FALSE;
+
 	return GF_TRUE;
 }
 

--- a/src/utils/downloader.c
+++ b/src/utils/downloader.c
@@ -264,7 +264,7 @@ struct __gf_download_session
 	//0: not PUT/POST, 1: waiting for body to be completed, 2: body done
 	u32 put_state;
 
-	void* holdback_data;
+	u8* holdback_data;
 	u32 holdback_data_size;
 	Bool holdback_data_complete;
 	Bool should_holdback_data;
@@ -7827,7 +7827,7 @@ GF_Err gf_dm_sess_send(GF_DownloadSession *sess, u8 *data, u32 size)
 
 		if (!sess->holdback_data_complete) {
 			sess->holdback_data_size += size;
-			sess->holdback_data = gf_realloc(sess->holdback_data, sess->holdback_data_size);
+			sess->holdback_data = (u8*)gf_realloc(sess->holdback_data, sess->holdback_data_size);
 			memcpy(sess->holdback_data + sess->holdback_data_size - size, data, size);
 			return GF_OK;
 		}

--- a/src/utils/downloader.c
+++ b/src/utils/downloader.c
@@ -137,8 +137,7 @@ enum REQUEST_TYPE
 {
 	GET = 0,
 	HEAD = 1,
-	DELETE = 2,
-	OTHER = 3
+	OTHER = 2
 };
 
 /*!the structure used to store an HTTP header*/
@@ -5392,15 +5391,11 @@ static Bool http_request_has_body(GF_DownloadSession *sess) {
 		gf_dm_sess_user_io(sess, &par);
 
 		if (!par.name) return GF_FALSE;
-		if (!strcmp(par.name, "GET") || !strcmp(par.name, "HEAD") || !strcmp(par.name, "DELETE"))
-			return GF_FALSE;
-
+		if (!strcmp(par.name, "GET") || !strcmp(par.name, "HEAD")) return GF_FALSE;
 		return GF_TRUE;
 	}
 
-	if (sess->http_read_type == GET || sess->http_read_type == HEAD || sess->http_read_type == DELETE)
-		return GF_FALSE;
-
+	if (sess->http_read_type == GET || sess->http_read_type == HEAD) return GF_FALSE;
 	return GF_TRUE;
 }
 

--- a/src/utils/downloader.c
+++ b/src/utils/downloader.c
@@ -3874,6 +3874,7 @@ static void gf_dm_connect(GF_DownloadSession *sess)
 					&& (sess->flags & GF_NETIO_SESSION_NO_BLOCK)
 					&& !sess->dm->disable_http2
 					&& !gf_opts_get_bool("core", "no-h2c")
+					&& 0
 				) {
 					sess->connect_pending = 1;
 					SET_LAST_ERR(GF_IP_NETWORK_EMPTY)
@@ -7738,7 +7739,7 @@ GF_Err gf_dm_sess_accumulate(GF_DownloadSession *sess, const u8 *data, u32 size)
 		return e;
 	}
 
-	if (!data) {
+	if (data == NULL) {
 		sess->holdback_data_complete = GF_TRUE;
 		return GF_OK;
 	}

--- a/src/utils/os_config_init.c
+++ b/src/utils/os_config_init.c
@@ -1538,6 +1538,8 @@ GF_GPACArg GPAC_Args[] = {
  GF_DEF_ARG("h2-copy", NULL, "enable intermediate copy of data in nghttp2 (default is disabled but may report as broken frames in wireshark)", NULL, NULL, GF_ARG_BOOL, GF_ARG_HINT_EXPERT|GF_ARG_SUBSYS_HTTP),
 #endif
 
+ GF_DEF_ARG("no-cte", NULL, "disable chunk-transfer encoding", NULL, NULL, GF_ARG_BOOL, GF_ARG_HINT_EXPERT|GF_ARG_SUBSYS_HTTP),
+
 #ifdef GPAC_HAS_CURL
  GF_DEF_ARG("curl", NULL, "use CURL instead of GPAC HTTP stack", NULL, NULL, GF_ARG_BOOL, GF_ARG_HINT_EXPERT|GF_ARG_SUBSYS_HTTP),
  GF_DEF_ARG("no-h3", NULL, "disable HTTP3 (CURL only)", NULL, NULL, GF_ARG_BOOL, GF_ARG_HINT_EXPERT|GF_ARG_SUBSYS_HTTP),


### PR DESCRIPTION
I had some success in disabling the `Transfer-Encoding: chunked` header for upload requests. @jeanlf I'd really appreciate your input on this.

Adding support for HTTP/2 should be straightforward but I'll look into it later.

## Usage

Add the `-no-cte` global option to disable chunked transfer altogether.

## TODO
- [ ] Test with HTTP/2
- [ ] Defer connection setup until data is ready
- [x] Test with DELETE requests. Should be okay because we check if the request has body but verify again

closes #2939