### PR TITLE
Write empty WebVTT file if no cue is present

### DIFF
--- a/src/filters/write_generic.c
+++ b/src/filters/write_generic.c
@@ -1463,6 +1463,8 @@ GF_Err writegen_process(GF_Filter *filter)
 					goto no_output;
 				}
 				empty_seg=GF_TRUE;
+			} else if (ctx->webvtt) {
+				empty_seg=GF_TRUE;
 			} else {
 				ctx->sample_num--;
 				goto no_output;

--- a/src/filters/write_vtt.c
+++ b/src/filters/write_vtt.c
@@ -55,6 +55,7 @@ typedef struct
 
 	GF_FilterPacket *src_pck;
 	Bool dash_mode;
+	Bool first;
 	u32 seg_pck_in, seg_pck_out;
 } GF_WebVTTMxCtx;
 
@@ -80,6 +81,7 @@ GF_Err vttmx_configure_pid(GF_Filter *filter, GF_FilterPid *pid, Bool is_remove)
 	if (!p) return GF_NOT_SUPPORTED;
 	ctx->codecid = p->value.uint;
 	ctx->ipid = pid;
+	ctx->first = GF_TRUE;
 
 
 	if (!ctx->opid) {
@@ -235,6 +237,14 @@ GF_Err vttmx_process(GF_Filter *filter)
 	if (!pck) {
 		if (gf_filter_pid_is_eos(ctx->ipid)) {
 			gf_filter_pid_set_eos(ctx->opid);
+			if (ctx->first) {
+				// send empty packet to init the file
+				GF_FilterPacket *dst = gf_filter_pck_new_alloc(ctx->opid, 0, NULL);
+				gf_filter_pck_set_sap(dst, GF_FILTER_SAP_1);
+				gf_filter_pck_set_byte_offset(dst, GF_FILTER_NO_BO);
+				gf_filter_pck_send(dst);
+				ctx->first = GF_FALSE;
+			}
 			if (ctx->parser) {
 				vttmx_parser_flush(ctx);
 			}
@@ -247,6 +257,7 @@ GF_Err vttmx_process(GF_Filter *filter)
 		return GF_OK;
 	}
 	data = (char *) gf_filter_pck_get_data(pck, &pck_size);
+	ctx->first = GF_FALSE;
 
 	start_ts = gf_filter_pck_get_cts(pck);
 	end_ts = start_ts + gf_filter_pck_get_duration(pck);

--- a/src/filters/write_vtt.c
+++ b/src/filters/write_vtt.c
@@ -54,7 +54,7 @@ typedef struct
 	GF_WebVTTParser *parser;
 
 	GF_FilterPacket *src_pck;
-	Bool dash_mode;
+	Bool dash_mode, first;
 	u32 seg_pck_in, seg_pck_out;
 } GF_WebVTTMxCtx;
 
@@ -80,6 +80,7 @@ GF_Err vttmx_configure_pid(GF_Filter *filter, GF_FilterPid *pid, Bool is_remove)
 	if (!p) return GF_NOT_SUPPORTED;
 	ctx->codecid = p->value.uint;
 	ctx->ipid = pid;
+	ctx->first = GF_TRUE;
 
 
 	if (!ctx->opid) {
@@ -234,12 +235,13 @@ GF_Err vttmx_process(GF_Filter *filter)
 	pck = gf_filter_pid_get_packet(ctx->ipid);
 	if (!pck) {
 		if (gf_filter_pid_is_eos(ctx->ipid)) {
-			if (!ctx->noempty) {
+			if (!ctx->noempty && ctx->first) {
 				// send empty packet to init the file
 				GF_FilterPacket *dst = gf_filter_pck_new_alloc(ctx->opid, 0, NULL);
 				gf_filter_pck_set_sap(dst, GF_FILTER_SAP_1);
 				gf_filter_pck_set_byte_offset(dst, GF_FILTER_NO_BO);
 				gf_filter_pck_send(dst);
+				ctx->first = GF_FALSE;
 			}
 			gf_filter_pid_set_eos(ctx->opid);
 			if (ctx->parser) {
@@ -254,6 +256,7 @@ GF_Err vttmx_process(GF_Filter *filter)
 		return GF_OK;
 	}
 	data = (char *) gf_filter_pck_get_data(pck, &pck_size);
+	ctx->first = GF_FALSE;
 
 	start_ts = gf_filter_pck_get_cts(pck);
 	end_ts = start_ts + gf_filter_pck_get_duration(pck);

--- a/src/filters/write_vtt.c
+++ b/src/filters/write_vtt.c
@@ -35,7 +35,7 @@
 typedef struct
 {
 	//opts
-	Bool exporter, merge_cues;
+	Bool exporter, merge_cues, noempty;
 
 	//only one input pid declared
 	GF_FilterPid *ipid;
@@ -55,7 +55,6 @@ typedef struct
 
 	GF_FilterPacket *src_pck;
 	Bool dash_mode;
-	Bool first;
 	u32 seg_pck_in, seg_pck_out;
 } GF_WebVTTMxCtx;
 
@@ -81,7 +80,6 @@ GF_Err vttmx_configure_pid(GF_Filter *filter, GF_FilterPid *pid, Bool is_remove)
 	if (!p) return GF_NOT_SUPPORTED;
 	ctx->codecid = p->value.uint;
 	ctx->ipid = pid;
-	ctx->first = GF_TRUE;
 
 
 	if (!ctx->opid) {
@@ -236,15 +234,14 @@ GF_Err vttmx_process(GF_Filter *filter)
 	pck = gf_filter_pid_get_packet(ctx->ipid);
 	if (!pck) {
 		if (gf_filter_pid_is_eos(ctx->ipid)) {
-			gf_filter_pid_set_eos(ctx->opid);
-			if (ctx->first) {
+			if (!ctx->noempty) {
 				// send empty packet to init the file
 				GF_FilterPacket *dst = gf_filter_pck_new_alloc(ctx->opid, 0, NULL);
 				gf_filter_pck_set_sap(dst, GF_FILTER_SAP_1);
 				gf_filter_pck_set_byte_offset(dst, GF_FILTER_NO_BO);
 				gf_filter_pck_send(dst);
-				ctx->first = GF_FALSE;
 			}
+			gf_filter_pid_set_eos(ctx->opid);
 			if (ctx->parser) {
 				vttmx_parser_flush(ctx);
 			}
@@ -257,7 +254,6 @@ GF_Err vttmx_process(GF_Filter *filter)
 		return GF_OK;
 	}
 	data = (char *) gf_filter_pck_get_data(pck, &pck_size);
-	ctx->first = GF_FALSE;
 
 	start_ts = gf_filter_pck_get_cts(pck);
 	end_ts = start_ts + gf_filter_pck_get_duration(pck);
@@ -344,6 +340,7 @@ static const GF_FilterArgs WebVTTMxArgs[] =
 {
 	{ OFFS(exporter), "compatibility with old exporter, displays export results", GF_PROP_BOOL, "false", NULL, GF_FS_ARG_HINT_ADVANCED},
 	{ OFFS(merge_cues), "merge VTT cues (undo ISOBMFF cue split)", GF_PROP_BOOL, "true", NULL, GF_FS_ARG_HINT_ADVANCED},
+	{ OFFS(noempty), "Do not create an empty file if no VTT cues are present", GF_PROP_BOOL, "true", NULL, GF_FS_ARG_HINT_ADVANCED},
 	{0}
 };
 


### PR DESCRIPTION
Add the ability to export the WebVTT track when no cues are present in the track.

```
MP4Box -raw <vtt_track_id> --noempty=0 test.mp4
gpac -i test.mp4 @#text -o test.vtt:!noempty
```