### PR TITLE
fix a bunch of use-of-uninitialized-memory errors

### DIFF
--- a/src/filters/inspect.c
+++ b/src/filters/inspect.c
@@ -3316,7 +3316,7 @@ static void inspect_dump_vpx(GF_InspectCtx *ctx, FILE *dump, u8 *ptr, u64 frame_
 {
 	GF_Err e;
 	Bool key_frame = GF_FALSE;
-	u32 width = 0, height = 0, renderWidth, renderHeight;
+	u32 width = 0, height = 0, renderWidth=0, renderHeight=0;
 	u32 num_frames_in_superframe = 0, superframe_index_size = 0, i = 0;
 	u32 frame_sizes[VP9_MAX_FRAMES_IN_SUPERFRAME];
 	gf_bs_reassign_buffer(pctx->bs, ptr, frame_size);

--- a/src/filters/isoffin_load.c
+++ b/src/filters/isoffin_load.c
@@ -1561,6 +1561,8 @@ props_done:
 
 	if (streamtype==GF_STREAM_VISUAL) {
 		u32 cwn, cwd, chn, chd, cxn, cxd, cyn, cyd;
+		cwn=cwd=chn=chd=cxn=cxd=cyn=cyd=0;
+
 		gf_isom_get_clean_aperture(ch->owner->mov, ch->track, ch->last_sample_desc_index ? ch->last_sample_desc_index : 1, &cwn, &cwd, &chn, &chd, &cxn, &cxd, &cyn, &cyd);
 
 		if (cwd && chd && cxd && cyd) {

--- a/src/filters/load_text.c
+++ b/src/filters/load_text.c
@@ -783,12 +783,11 @@ static GF_Err parse_srt_line(GF_TXTIn *ctx, char *szLine, u32 *char_l, Bool *set
 		u32 font_style = 0;
 		u32 style_nb_chars = 0;
 		u32 style_def_type = 0;
-
-		if ( (uniLine[i]=='<') && (uniLine[i+2]=='>')) {
+		if ( (i+2<len) && (uniLine[i]=='<') && (uniLine[i+2]=='>')) {
 			style_nb_chars = 3;
 			style_def_type = 1;
 		}
-		else if ( (uniLine[i]=='<') && (uniLine[i+1]=='/') && (uniLine[i+3]=='>')) {
+		else if ( (i+3<len) && (uniLine[i]=='<') && (uniLine[i+1]=='/') && (uniLine[i+3]=='>')) {
 			style_def_type = 2;
 			style_nb_chars = 4;
 		}

--- a/src/filters/reframe_av1.c
+++ b/src/filters/reframe_av1.c
@@ -729,7 +729,7 @@ GF_Err av1dmx_parse_ivf(GF_Filter *filter, GF_AV1DmxCtx *ctx)
 	u64 frame_size = 0, pts = GF_FILTER_NO_TS;
 	GF_FilterPacket *pck;
 	u64 pos=0, pos_ivf_hdr=0;
-	u8 *output;
+	u8 *output=NULL;
 
 	if (ctx->bsmode==IVF) {
 		pos_ivf_hdr = gf_bs_get_position(ctx->bs);
@@ -787,9 +787,8 @@ GF_Err av1dmx_parse_ivf(GF_Filter *filter, GF_AV1DmxCtx *ctx)
 	}
 
 	gf_bs_seek(ctx->bs, pos);
-	gf_bs_read_data(ctx->bs, output, pck_size);
 
-	if (output[0] & 0x80)
+	if (gf_bs_read_data(ctx->bs, output, pck_size) && (output[0] & 0x80))
 		gf_filter_pck_set_sap(pck, GF_FILTER_SAP_1);
 	else
 		gf_filter_pck_set_sap(pck, GF_FILTER_SAP_NONE);
@@ -1404,4 +1403,3 @@ const GF_FilterRegister *rfav1_register(GF_FilterSession *session)
 	return NULL;
 }
 #endif // #if !defined(GPAC_DISABLE_AV_PARSERS) && !defined(GPAC_DISABLE_RFAV1)
-

--- a/src/filters/reframe_flac.c
+++ b/src/filters/reframe_flac.c
@@ -520,6 +520,7 @@ GF_Err flac_dmx_process(GF_Filter *filter)
 	u32 pck_size, remain, prev_pck_size;
 	u64 cts;
 	FLACHeader hdr;
+	memset(&hdr, 0, sizeof(FLACHeader));
 
 restart:
 	cts = GF_FILTER_NO_TS;
@@ -882,4 +883,3 @@ const GF_FilterRegister *rfflac_register(GF_FilterSession *session)
 	return NULL;
 }
 #endif // GPAC_DISABLE_RFFLAC
-

--- a/src/filters/reframe_latm.c
+++ b/src/filters/reframe_latm.c
@@ -631,6 +631,7 @@ static const char *latm_dmx_probe_data(const u8 *data, u32 size, GF_FilterProbeS
 	u32 nb_frames=0;
 	u32 nb_skip=0;
 	GF_M4ADecSpecInfo acfg;
+	acfg.base_sr_index = (u32)-1;
 	GF_BitStream *bs = gf_bs_new(data, size, GF_BITSTREAM_READ);
 	while (1) {
 		u32 nb_skipped = 0;

--- a/src/filters/reframe_nalu.c
+++ b/src/filters/reframe_nalu.c
@@ -2485,7 +2485,7 @@ static s32 naludmx_parse_nal_hevc(GF_NALUDmxCtx *ctx, char *data, u32 size, Bool
 {
 	s32 ps_idx = 0;
 	s32 res;
-	u8 nal_unit_type, temporal_id, layer_id;
+	u8 nal_unit_type=0, temporal_id=0, layer_id=0;
 	*skip_nal = GF_FALSE;
 
 	if (size<2) return -1;
@@ -2666,7 +2666,7 @@ static s32 naludmx_parse_nal_vvc(GF_NALUDmxCtx *ctx, char *data, u32 size, Bool 
 {
 	s32 ps_idx = 0;
 	s32 res;
-	u8 nal_unit_type, temporal_id, layer_id;
+	u8 nal_unit_type=0, temporal_id=0, layer_id=0;
 	*skip_nal = GF_FALSE;
 
 	if (size<2) return -1;

--- a/src/filters/reframe_rawvid.c
+++ b/src/filters/reframe_rawvid.c
@@ -297,7 +297,7 @@ GF_Err rawvidreframe_process(GF_Filter *filter)
 				else if (data[0] == 'H') ctx->size.y = atoi(data+1);
 				else if (data[0] == 'F') sscanf(data+1, "%d:%d", &ctx->fps.num, &ctx->fps.den);
 				else if (data[0] == 'A') {
-					GF_Fraction sar;
+					GF_Fraction sar = {0,1};
 					sscanf(data+1, "%d:%d", &sar.num, &sar.den);
 					gf_filter_pid_set_property(ctx->opid, GF_PROP_PID_SAR, &PROP_FRAC(sar));
 				}
@@ -401,7 +401,7 @@ GF_Err rawvidreframe_process(GF_Filter *filter)
 			data += remain;
 			byte_offset += remain;
 			offset_in_pck += remain;
-			
+
 			ctx->out_pck = NULL;
 			ctx->nb_bytes_in_frame = 0;
 
@@ -505,5 +505,3 @@ const GF_FilterRegister *rfrawvid_register(GF_FilterSession *session)
 	return NULL;
 }
 #endif //#ifndef GPAC_DISABLE_RFRAWVID
-
-

--- a/src/isomedia/isom_write.c
+++ b/src/isomedia/isom_write.c
@@ -4017,6 +4017,7 @@ static GF_Err gf_isom_get_trex_props(GF_ISOFile *file, GF_TrackBox *trak, GF_Tra
 {
 	u32 i;
 	if (!file->moov->mvex) return GF_NOT_FOUND;
+	*trex = NULL;
 	for (i=0; i<gf_list_count(file->moov->mvex->TrackExList); i++) {
 		*trex = gf_list_get(file->moov->mvex->TrackExList, i);
 		if ((*trex)->trackID == trak->Header->trackID) break;
@@ -4091,7 +4092,7 @@ GF_Err gf_isom_get_track_template(GF_ISOFile *file, u32 track, u8 **output, u32 
 	//get CSLG from trex if not in stbl
 	GF_CompositionToDecodeBox *trex_cslg=NULL;
 	if (!stbl_temp->CompositionToDecode) {
-		GF_TrackExtendsBox *trex;
+		GF_TrackExtendsBox *trex=NULL;
 		GF_TrackExtensionPropertiesBox *trexprop=NULL;
 		gf_isom_get_trex_props(file, trak, &trex, &trexprop);
 		if (trexprop) {

--- a/src/media_tools/dash_client.c
+++ b/src/media_tools/dash_client.c
@@ -8628,12 +8628,15 @@ GF_Err gf_dash_open(GF_DashClient *dash, const char *manifest_url)
 
 	//peek payload, check if m3u8 - MPD and SmoothStreaming are checked after
 	char szLine[100];
-	memset(&szLine, 0, 100);
+	szLine[0] = 0;
 	FILE *f = gf_fopen(local_url, "r");
 	if (f) {
-		gf_fread(szLine, 100, f);
+		u32 read_count = gf_fread(szLine, 100, f);
+		if (read_count < 99)
+			szLine[read_count] = 0;
 		gf_fclose(f);
 	}
+
 	szLine[99] = 0;
 	if (strstr(szLine, "#EXTM3U"))
 		dash->is_m3u8 = 1;

--- a/src/media_tools/dash_client.c
+++ b/src/media_tools/dash_client.c
@@ -8628,6 +8628,7 @@ GF_Err gf_dash_open(GF_DashClient *dash, const char *manifest_url)
 
 	//peek payload, check if m3u8 - MPD and SmoothStreaming are checked after
 	char szLine[100];
+	memset(&szLine, 0, 100);
 	FILE *f = gf_fopen(local_url, "r");
 	if (f) {
 		gf_fread(szLine, 100, f);

--- a/src/media_tools/mpeg2_ps.c
+++ b/src/media_tools/mpeg2_ps.c
@@ -523,8 +523,8 @@ static void copy_bytes_to_pes_buffer (mpeg2ps_stream_t *sptr,
 			sptr->pes_buffer_size_max = to_move + pes_len + 2048;
 		}
 	}
-	file_read_bytes(sptr->m_fd, sptr->pes_buffer + sptr->pes_buffer_size, pes_len);
-	sptr->pes_buffer_size += pes_len;
+	u32 size_read = (u32) gf_fread(sptr->pes_buffer + sptr->pes_buffer_size, pes_len, sptr->m_fd);
+	sptr->pes_buffer_size += size_read;
 }
 
 /*

--- a/src/utils/xml_parser.c
+++ b/src/utils/xml_parser.c
@@ -63,7 +63,7 @@ GF_STATIC char *xml_translate_xml_string(char *str)
 			if (str[i+1]=='#') {
 				char szChar[20], *end;
 				u16 wchar[2];
-				u32 val, _len;
+				u32 val=0, _len;
 				const unsigned short *srcp;
 				strncpy(szChar, str+i, 10);
 				szChar[10] = 0;


### PR DESCRIPTION
Hi all,

For clarity and record keeping, I'm putting all of these in a single PR, with each bug in its own commit. 

## Credits

Thanks and credits to @skorpion98 and @Heinzeen from Sapienza University of Rome for the detection and responsible disclosure of these issues. 

## Security and functional concerns

I don't think any of these poses great security concerns since the path to exploitation seems really difficult. 

However we've had functional seemingly-random bugs caused by uninitialized variables before, so these reports are valuable to remove some sources of undefined behavior. 

## Good practices for developers

Sorry in advance if the recommendations in this section seem trivial or obvious, but the existence of these issues show that we need to be more vigilant on a few points: 

### Init local structures

When using local variables in a block, remember to give them an initial value (0/-1 for ints, null for pointers, etc.). 

For structs, it's important to remember that without OOP-style constructors, fields inside structs are not initialized. 

For struct pointers on the heap we usually use a constructor function (like `gf_bs_new()`) or the `GF_SAFEALLOC()` macro. 

For local structs on the stack we need to manually init the fields to a sensible value. We can also memset() the whole struct to 0 to just ensure initialization. e.g.:

```c
GF_Fraction frac; 
frac.num=0; frac.den=1;

FLACHeader hdr;
memset(&hdr, 0, sizeof(FLACHeader));
```


### check buffer functions

One use case that happens a lot in gpac is: 

1. we declare a pretty big buffer
2. we get the functional size from somewhere (bitstream read for example)
3. we read/write size bytes of data into our buffer
4. we pass this buffer and size to another function/struct

It's important to have checks around point 2 since it usually comes from user supplied data. 

But for our subject matter here, it's on point 3 that we need to be more careful. 

Functions like `fread()`, `gf_bs_read_data()`, and many buffer handling functions will return the number of bytes actually read (or written). 

We need to think about checking this return value against the hoped size we passed, so that we can know which part of the buffer is actually initialized. 


Again these are pretty basic but it never hurts to be reminded of good practices :)




