### PR TITLE
fix for invalid file that use non-zero upid length even if the upid type is not set

### DIFF
--- a/src/filters/inspect.c
+++ b/src/filters/inspect.c
@@ -2293,7 +2293,7 @@ static void scte35_parse_segmentation_descriptor(FILE *dump, GF_BitStream *bs)
 
 		inspect_printf(dump, ">\n");
 
-		if (segmentation_upid_length) {
+		if (segmentation_upid_type !=0 && segmentation_upid_length) {
 			// jump back to SegmentUpid to dump values
 			gf_bs_seek(bs, segmentation_upid_pos);
 


### PR DESCRIPTION

Example of wrong SCTE marker:
https://tools.middleman.tv/scte35-parser?hex=FC302F00000000000000FFF00506FE19206BBE0019021743554549000000057FC0000052636200016134000000009B016FB3&format=json