### PR TITLE
Refactor: Change repair variable type from u32 to enum

### DIFF
--- a/src/filters/in_route.h
+++ b/src/filters/in_route.h
@@ -47,13 +47,13 @@ typedef struct
 	char *seg_name;
 } SegInfo;
 
-enum
+typedef enum
 {
 	ROUTEIN_REPAIR_NO = 0,
 	ROUTEIN_REPAIR_SIMPLE,
 	ROUTEIN_REPAIR_STRICT,
 	ROUTEIN_REPAIR_FULL,
-};
+} RouteRepairType;
 
 typedef struct _route_repair_seg_info RepairSegmentInfo;
 
@@ -86,7 +86,8 @@ typedef struct
 	//options
 	char *src, *ifce, *odir;
 	Bool gcache, kc, skipr, reorder, fullseg, cloop, llmode, dynsel;
-	u32 buffer, timeout, stats, max_segs, tsidbg, rtimeout, nbcached, repair;
+	u32 buffer, timeout, stats, max_segs, tsidbg, rtimeout, nbcached;
+	RouteRepairType repair;
 	u32 max_sess;
 	s32 tunein, stsi;
 	GF_PropStringList repair_urls;


### PR DESCRIPTION
This PR refactors the repair variable by changing its type from `u32` to `enum`. This modification ensures better code readability and makes the logic behind the repair state more explicit, aligning the type with its intended usage.