### PR TITLE
Fix doc printing and formatting issues: Conditionally print </div>

### DIFF
--- a/applications/gpac/gpac_help.c
+++ b/applications/gpac/gpac_help.c
@@ -1619,9 +1619,9 @@ static void print_filter_arg(const GF_FilterArgs *a, u32 gen_doc)
 	} else {
 		gf_sys_format_help(helpout, help_flags | GF_PRINTARG_OPT_DESC, "): %s\n", a->arg_desc);
 	}
-	   if (gen_doc == 1) {
-        gf_sys_format_help(helpout, help_flags, "</div>\n");
-    }
+	if (gen_doc==1) {
+		gf_sys_format_help(helpout, help_flags, "</div>\n");
+	}
 
 	//check syntax
 	if (gen_doc) {

--- a/src/utils/os_config_init.c
+++ b/src/utils/os_config_init.c
@@ -2017,7 +2017,9 @@ void gf_sys_print_arg(FILE *helpout, GF_SysPrintArgFlags flags, const GF_GPACArg
 			gf_sys_format_help(helpout, flags | GF_PRINTARG_OPT_DESC, ": %s", gf_sys_localized(arg_subsystem, arg->name, arg->description) );
 		}
 		gf_sys_format_help(helpout, flags, "\n");
-		fprintf(helpout, "</div>\n");
+		if(gen_doc==1) {
+			fprintf(helpout, "</div>\n");
+		}
 	}
 
 	if ((gen_doc==1) && arg->description && strstr(arg->description, "- "))


### PR DESCRIPTION
This PR addresses two minor issues related to documentation printing:

- The `</div>` tag is now printed only if `gen_doc==1` to avoid unnecessary HTML tags in cases where documentation generation is not required.
- Replaced spaces with tabs for consistent formatting across the codebase.