### PR TITLE
Fix inverted display of input/output filters in protocols  help

### DIFF
--- a/applications/gpac/gpac_help.c
+++ b/applications/gpac/gpac_help.c
@@ -3162,7 +3162,7 @@ void dump_all_proto_schemes(GF_SysArgMode argmode)
 		}
 		for (k=0; k<2; k++) {
 			GF_List *list = k ? pe->out : pe->in;
-			const char *lab = k ? "in" : "out";
+			const char *lab = k ? "out" : "in";
 			c2 = gf_list_count(list);
 			if (c2) {
 				if (gen_doc!=1)


### PR DESCRIPTION
This PR addresses an issue where the `gpac -ha protocols` and `gpac -hh protocols` commands displayed the list of input and output filters for each protocol incorrectly, with input filters shown under "out" and output filters under "in". The filter lists are now correctly categorized and displayed.