### PR TITLE
Add warning message for blacklisted repair servers

### DIFF
--- a/src/filters/in_route_repair.c
+++ b/src/filters/in_route_repair.c
@@ -510,6 +510,7 @@ restart:
 
 		if(!url) {
 			GF_LOG(GF_LOG_ERROR, GF_LOG_ROUTE, ("[REPAIR] Failed to find an adequate repair server - Repair abort \n"));
+			rsi->nb_errors++;
 			repair_session_done(ctx, rsess, e);
 			return;
 		}
@@ -544,6 +545,7 @@ restart:
 		if (e==GF_IP_NETWORK_EMPTY) return;
 		if (e==GF_IO_BYTE_RANGE_NOT_SUPPORTED) {
 			rsess->server->accept_ranges = GF_FALSE;
+			GF_LOG(GF_LOG_WARNING, GF_LOG_ROUTE, ("[REPAIR] Server \"%s\" does not support byte range requests: Server is blacklisted for partial repair \n", rsess->server->url));
 			gf_dm_sess_abort(rsess->dld);
 		}
 	}


### PR DESCRIPTION
This PR adds a warning message to inform users when a repair server has been blacklisted because it does not support byte range requests (partial repair).