### PR TITLE
Update .gitignore to exclude Python cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ x86/
 bld/
 [Bb]in/
 [Oo]bj/
+__pycache__/
+*.py[cod]
 
 
 .DS_Store .AppleDouble .LSOverride


### PR DESCRIPTION
This PR updates the `.gitignore` file to exclude Python cache files. The following entries were added:

- `__pycache__/`: to ignore Python bytecode directories.
- `*.py[cod]`: to ignore compiled Python files.