### PR TITLE
Fix documentation for 'epow2' property in compositor filter to use 'true/false' instead of 'yes/no'

### DIFF
--- a/src/filters/compose.c
+++ b/src/filters/compose.c
@@ -1029,8 +1029,8 @@ static GF_FilterArgs CompositorArgs[] =
 	"", GF_PROP_UINT, "none", "none|walk|fly|pan|game|slide|exam|orbit|vr", GF_FS_ARG_UPDATE|GF_FS_ARG_HINT_ADVANCED},
 	{ OFFS(linegl), "indicate that outlining shall be done through OpenGL pen width rather than vectorial outlining", GF_PROP_BOOL, "false", NULL, GF_FS_ARG_UPDATE|GF_FS_ARG_HINT_EXPERT},
 	{ OFFS(epow2), "emulate power-of-2 textures for OpenGL (old hardware). Ignored if OpenGL rectangular texture extension is enabled\n"
-	"- yes: video texture is not resized but emulated with padding. This usually speeds up video mapping on shapes but disables texture transformations\n"
-	"- no: video is resized to a power of 2 texture when mapping to a shape", GF_PROP_BOOL, "true", NULL, GF_FS_ARG_UPDATE|GF_FS_ARG_HINT_EXPERT},
+	"- true: video texture is not resized but emulated with padding. This usually speeds up video mapping on shapes but disables texture transformations\n"
+	"- false: video is resized to a power of 2 texture when mapping to a shape", GF_PROP_BOOL, "true", NULL, GF_FS_ARG_UPDATE|GF_FS_ARG_HINT_EXPERT},
 	{ OFFS(paa), "indicate whether polygon antialiasing should be used in full antialiasing mode. If not set, only lines and points antialiasing are used", GF_PROP_BOOL, "false", NULL, GF_FS_ARG_UPDATE|GF_FS_ARG_HINT_EXPERT},
 	{ OFFS(bcull), "indicate whether backface culling shall be disable or not\n"
 				"- on: enables backface culling\n"


### PR DESCRIPTION
### Description
This PR fixes the documentation for the `epow2` property in the compositor filter. The documentation incorrectly used `yes/no` instead of `true/false` to describe the boolean values. This change corrects the documentation to use `true/false` for consistency and clarity.

### Changes Made
- Updated the description of the `epow2` property to use `true/false` instead of `yes/no`.