### PR TITLE
Handle Multiple Enum Values with Same Name in Filter Arguments

### DIFF
--- a/src/filter_core/filter.c
+++ b/src/filter_core/filter.c
@@ -1991,29 +1991,36 @@ skip_date:
 		if (for_script)
 		 	f_args = filter->instance_args;
 
+		Bool is_my_arg = GF_FALSE;
+		u32 count_enum_val = 0;
+		const char *restricted=NULL;
+		Bool reverse_bool = GF_FALSE;
+		const GF_FilterArgs *save_a = NULL;
+
 		while (filter->filter_udta && f_args) {
-			Bool is_my_arg = GF_FALSE;
-			Bool reverse_bool = GF_FALSE;
-			const char *restricted=NULL;
+
 			const GF_FilterArgs *a = &f_args[i];
 			i++;
 			if (!a || !a->arg_name) break;
 
-			if (!strcmp(a->arg_name, szArg))
+			if (!strcmp(a->arg_name, szArg)) {
 				is_my_arg = GF_TRUE;
-			else if ( (szArg[0]==filter->session->sep_neg) && !strcmp(a->arg_name, szArg+1)) {
+				save_a = a;
+			} else if ((szArg[0]==filter->session->sep_neg) && !strcmp(a->arg_name, szArg+1)) {
 				is_my_arg = GF_TRUE;
 				reverse_bool = GF_TRUE;
+				save_a = a;
 			}
 			//little optim here: if no value provided, check if argument name is exactly one of the possible enums
-			else if (!value && a->min_max_enum && strchr(a->min_max_enum, '|') && strstr(a->min_max_enum, szArg)) {
+			else if (a->min_max_enum && strchr(a->min_max_enum, '|') && strstr(a->min_max_enum, szArg)) {
 				const char *enums = a->min_max_enum;
 				while (enums) {
 					if (!strncmp(enums, szArg, len)) {
 						char c = enums[len];
 						if (!c || (c=='|')) {
-							is_my_arg = GF_TRUE;
+							count_enum_val++;
 							value = szArg;
+							save_a = a;
 							break;
 						}
 					}
@@ -2023,36 +2030,39 @@ skip_date:
 				}
 			}
 
-			if (is_my_arg) {
-				restricted = gf_opts_get_key_restricted(szSecName, a->arg_name);
-				if (restricted) {
-					GF_LOG(GF_LOG_WARNING, GF_LOG_FILTER, ("Argument %s of filter %s is restricted to %s by system-wide configuration, ignoring\n", szArg, filter->freg->name, restricted));
-					found=GF_TRUE;
-					break;
-				}
+			if(is_my_arg || count_enum_val>1) break;		
+		}
 
+		if(is_my_arg && count_enum_val>0) {
+			GF_LOG(GF_LOG_WARNING, GF_LOG_FILTER, ("Ambiguous argument %s in filter %s: both an argument and an enum value share the name \"%s\", ignoring\n", szArg, filter->freg->name, szArg));
+		} else if(count_enum_val>1) {
+			GF_LOG(GF_LOG_WARNING, GF_LOG_FILTER, ("Argument %s of filter %s is ambiguous (multiple enum arguments have \"%s\" as possible value), ignoring\n", szArg, filter->freg->name, szArg));
+		} else if (is_my_arg || count_enum_val==1) {
+			restricted = gf_opts_get_key_restricted(szSecName, save_a->arg_name);
+			found=GF_TRUE;
+			if (restricted) {
+				GF_LOG(GF_LOG_WARNING, GF_LOG_FILTER, ("Argument %s of filter %s is restricted to %s by system-wide configuration, ignoring\n", szArg, filter->freg->name, restricted));
+			} else {
 				GF_PropertyValue argv;
-				found=GF_TRUE;
-
-				argv = gf_filter_parse_prop_solve_env_var(filter->session, filter, (a->flags & GF_FS_ARG_META) ? GF_PROP_STRING : a->arg_type, a->arg_name, value, a->min_max_enum);
+				argv = gf_filter_parse_prop_solve_env_var(filter->session, filter, (save_a->flags & GF_FS_ARG_META) ? GF_PROP_STRING : save_a->arg_type, save_a->arg_name, value, save_a->min_max_enum);
 
 				if (reverse_bool && (argv.type==GF_PROP_BOOL))
 					argv.value.boolean = !argv.value.boolean;
 
 				if (argv.type != GF_PROP_FORBIDDEN) {
-					if (!for_script && (a->offset_in_private>=0)) {
-						gf_filter_set_arg(filter, a, &argv);
+					if (!for_script && (save_a->offset_in_private>=0)) {
+						gf_filter_set_arg(filter, save_a, &argv);
 					} else if (filter->freg->update_arg) {
 						FSESS_CHECK_THREAD(filter)
-						filter->freg->update_arg(filter, a->arg_name, &argv);
+						filter->freg->update_arg(filter, save_a->arg_name, &argv);
 						opaque_arg = GF_FALSE;
 						if ((argv.type==GF_PROP_STRING) || (argv.type==GF_PROP_STRING_LIST))
 							gf_props_reset_single(&argv);
 					}
 				}
-				break;
 			}
 		}
+	
 		GF_Filter *meta_filter = NULL;
 		if (!strlen(szArg)) {
 			found = GF_TRUE;

--- a/src/filter_core/filter.c
+++ b/src/filter_core/filter.c
@@ -2005,7 +2005,7 @@ skip_date:
 				is_my_arg = GF_TRUE;
 				reverse_bool = GF_TRUE;
 			}
-			//little optim here, if no value check if argument nale is exactly one of the possible enums
+			//little optim here: if no value provided, check if argument name is exactly one of the possible enums
 			else if (!value && a->min_max_enum && strchr(a->min_max_enum, '|') && strstr(a->min_max_enum, szArg)) {
 				const char *enums = a->min_max_enum;
 				while (enums) {

--- a/src/filter_core/filter.c
+++ b/src/filter_core/filter.c
@@ -2023,14 +2023,14 @@ skip_date:
 				}
 			}
 
-			if (is_my_arg) restricted = gf_opts_get_key_restricted(szSecName, a->arg_name);
-			if (restricted) {
-				GF_LOG(GF_LOG_WARNING, GF_LOG_FILTER, ("Argument %s of filter %s is restricted to %s by system-wide configuration, ignoring\n", szArg, filter->freg->name, restricted));
-				found=GF_TRUE;
-				break;
-			}
-
 			if (is_my_arg) {
+				restricted = gf_opts_get_key_restricted(szSecName, a->arg_name);
+				if (restricted) {
+					GF_LOG(GF_LOG_WARNING, GF_LOG_FILTER, ("Argument %s of filter %s is restricted to %s by system-wide configuration, ignoring\n", szArg, filter->freg->name, restricted));
+					found=GF_TRUE;
+					break;
+				}
+
 				GF_PropertyValue argv;
 				found=GF_TRUE;
 


### PR DESCRIPTION
### Description
This PR addresses the issue where multiple enum values with the same name were causing ambiguity in filter arguments. The changes ensure that such cases are handled correctly by logging appropriate warnings and ignoring ambiguous arguments.

### Changes Made
- Added new variables to track counts and save specific arguments.
- Adjusted the logic in `filter_parse_dyn_args` function to handle ambiguous arguments and log warnings.
- Updated relevant parts of the code to ensure correct handling of enum values.

### Fixes
This PR fixes the issue of ambiguous enum values in filter arguments.