### PR TITLE
UTF conversion buffer sizes: fix crash in .ts -> ccdec -> .vtt conversion

### DIFF
--- a/modules/dx_hw/dx_window.c
+++ b/modules/dx_hw/dx_window.c
@@ -815,9 +815,9 @@ u32 DD_WindowThread(void *par)
 				wchar_t *wcaption;
 				size_t len;
 				size_t len_res;
-				len = (strlen(str_src) + 1)*sizeof(wchar_t);
+				len = ((strlen(str_src)/2)*2 + 2) * sizeof(wchar_t);
 				wcaption = (wchar_t *)gf_malloc(len);
-				len_res = gf_utf8_mbstowcs(wcaption, len, &str_src);
+				len_res = gf_utf8_mbstowcs(wcaption, len+1, &str_src);
 				if (len_res != -1) {
 					SetWindowTextW(ctx->os_hwnd, wcaption);
 				}

--- a/src/compositor/events.c
+++ b/src/compositor/events.c
@@ -145,8 +145,8 @@ GF_Err gf_sc_paste_text(GF_Compositor *compositor, const char *text)
 
 	gf_sc_lock(compositor, GF_TRUE);
 
-	conv_buf = (u16*)gf_malloc(sizeof(u16)*(len+1));
-	len = gf_utf8_mbstowcs(conv_buf, len, &text);
+	conv_buf = (u16*)gf_malloc(sizeof(u16)*((len/2)*2+2));
+	len = gf_utf8_mbstowcs(conv_buf, len+1, &text);
 	if (len == GF_UTF8_FAIL) return GF_IO_ERR;
 
 	compositor->sel_buffer_alloc += len;

--- a/src/compositor/svg_font.c
+++ b/src/compositor/svg_font.c
@@ -376,7 +376,7 @@ void compositor_init_svg_glyph(GF_Compositor *compositor, GF_Node *node)
 	GF_SAFEALLOC(st, SVG_GlyphStack);
 	if (!st) return;
 	utf8 = (u8 *) *atts.unicode;
-	len = gf_utf8_mbstowcs(utf_name, 200, (const char **) &utf8);
+	len = gf_utf8_mbstowcs(utf_name, sizeof(utf_name), (const char **) &utf8);
 	if (len == GF_UTF8_FAIL) return;
 	/*this is a single glyph*/
 	if (len==1) {

--- a/src/filters/load_text.c
+++ b/src/filters/load_text.c
@@ -769,11 +769,11 @@ static GF_Err parse_srt_line(GF_TXTIn *ctx, char *szLine, u32 *char_l, Bool *set
 	unsigned short *uniLine, *uniText, *sptr;
 	char szText[2048];
 
-	len = (u32)strlen(szLine)+1;
+	len = (u32)(strlen(szLine)/2)*2+2;
 	uniLine = gf_malloc(sizeof(u16)*len);
 	uniText = gf_malloc(sizeof(u16)*len);
 
-	len = gf_utf8_mbstowcs(uniLine, 5000, (const char **) &ptr);
+	len = gf_utf8_mbstowcs(uniLine, len+1, (const char **) &ptr);
 	if (len == GF_UTF8_FAIL) {
 		GF_LOG(GF_LOG_WARNING, GF_LOG_PARSER, ("[TXTIn] Invalid UTF data (line %d)\n", ctx->curLine));
 		ctx->state = 0;

--- a/src/filters/write_tx3g.c
+++ b/src/filters/write_tx3g.c
@@ -281,7 +281,7 @@ static GF_Err dump_ttxt_sample_ttml(TX3GMxCtx *ctx, FILE *dump, GF_TextSample *t
 		len = txt->len;
 	} else {
 		u8 *str = (u8 *) (txt->text);
-		len = gf_utf8_mbstowcs(utf16Line, 10000, (const char **) &str);
+		len = gf_utf8_mbstowcs(utf16Line, txt->len+1, (const char **) &str);
 		if (len == GF_UTF8_FAIL) return GF_NON_COMPLIANT_BITSTREAM;
 		utf16Line[len] = 0;
 	}

--- a/src/isomedia/box_dump.c
+++ b/src/isomedia/box_dump.c
@@ -3714,7 +3714,7 @@ void dump_ttxt_sample(FILE *dump, GF_TextSample *s_txt, u64 ts, u32 timescale, u
 
 	gf_fprintf(dump, " xml:space=\"preserve\">");
 	if (s_txt->len) {
-		unsigned short *utf16Line = gf_malloc( sizeof(u16) * s_txt->len);
+		unsigned short *utf16Line = gf_malloc( sizeof(u16) * (s_txt->len/2)*2 + 2 );
 		if (!utf16Line) return;
 		/*UTF16*/
 		if ((s_txt->len>2) && ((unsigned char) s_txt->text[0] == (unsigned char) 0xFE) && ((unsigned char) s_txt->text[1] == (unsigned char) 0xFF)) {
@@ -3724,7 +3724,7 @@ void dump_ttxt_sample(FILE *dump, GF_TextSample *s_txt, u64 ts, u32 timescale, u
 		} else {
 			char *str;
 			str = s_txt->text;
-			len = gf_utf8_mbstowcs((u16*)utf16Line, 10000, (const char **) &str);
+			len = gf_utf8_mbstowcs((u16*)utf16Line, s_txt->len+1, (const char **) &str);
 		}
 		if (len != GF_UTF8_FAIL) {
 			utf16Line[len] = 0;
@@ -3982,7 +3982,7 @@ GF_Err dump_ttxt_sample_srt(FILE *dump, GF_TextSample *txt, GF_Tx3gSampleEntryBo
 	}
 
 	u32 styles, char_num, new_styles, color, new_color;
-	u16 *utf16_buf = gf_malloc(sizeof(u16)*(txt->len+1));
+	u16 *utf16_buf = gf_malloc(sizeof(u16)*((txt->len/2)*2+2));
 	if (!utf16_buf) return GF_OUT_OF_MEM;
 
 	/*UTF16*/
@@ -3993,7 +3993,7 @@ GF_Err dump_ttxt_sample_srt(FILE *dump, GF_TextSample *txt, GF_Tx3gSampleEntryBo
 		len = txt->len;
 	} else {
 		u8 *str = (u8 *) (txt->text);
-		len = gf_utf8_mbstowcs(utf16_buf, txt->len, (const char **) &str);
+		len = gf_utf8_mbstowcs(utf16_buf, txt->len+1, (const char **) &str);
 		if (len == GF_UTF8_FAIL) return GF_NON_COMPLIANT_BITSTREAM;
 		utf16_buf[len] = 0;
 	}

--- a/src/isomedia/box_dump.c
+++ b/src/isomedia/box_dump.c
@@ -3982,7 +3982,7 @@ GF_Err dump_ttxt_sample_srt(FILE *dump, GF_TextSample *txt, GF_Tx3gSampleEntryBo
 	}
 
 	u32 styles, char_num, new_styles, color, new_color;
-	u16 *utf16_buf = gf_malloc(sizeof(u16)*txt->len);
+	u16 *utf16_buf = gf_malloc(sizeof(u16)*(txt->len+1));
 	if (!utf16_buf) return GF_OUT_OF_MEM;
 
 	/*UTF16*/

--- a/src/isomedia/isom_write.c
+++ b/src/isomedia/isom_write.c
@@ -6420,10 +6420,10 @@ GF_Err gf_isom_wma_set_tag(GF_ISOFile *mov, char *name, char *value)
 	}
 
 	u32 len = (u32) strlen(value);
-	tag->prop_value = gf_malloc(sizeof(u16) * (len+1) );
-	memset(tag->prop_value, 0, sizeof(u16) * (len+1) );
+	tag->prop_value = gf_malloc(sizeof(u16) * ((len/2)*2+2) );
+	memset(tag->prop_value, 0, sizeof(u16) * ((len/2)*2+2) );
 	if (len) {
-		u32 _len = gf_utf8_mbstowcs((u16 *) tag->prop_value, len, (const char **) &value);
+		u32 _len = gf_utf8_mbstowcs((u16 *) tag->prop_value, len+1, (const char **) &value);
 		if (_len == GF_UTF8_FAIL) _len = 0;
 		tag->prop_value[2 * _len] = 0;
 		tag->prop_value[2 * _len + 1] = 0;

--- a/src/scene_manager/scene_dump.c
+++ b/src/scene_manager/scene_dump.c
@@ -595,10 +595,8 @@ static void gf_dump_vrml_sffield(GF_SceneDumper *sdump, u32 type, void *ptr, Boo
 			gf_fprintf(sdump->trace, "\"%s\"", str);
 		}
 		else {
-			u16 *uniLine;
-
-			uniLine = (u16*)gf_malloc(sizeof(short) * (len + 1));
-			len = gf_utf8_mbstowcs(uniLine, len, (const char **)&str);
+			u16 *uniLine = (u16*)gf_malloc(sizeof(u16) * ((len/2)*2 + 2));
+			len = gf_utf8_mbstowcs(uniLine, len+1, (const char **)&str);
 
 			if (len != GF_UTF8_FAIL) {
 				for (i = 0; i<len; i++) {


### PR DESCRIPTION
```
unsigned short utf16Line = gf_malloc( sizeof(u16)  s_txt->len);
[...]
			len = gf_utf8_mbstowcs((u16*)utf16Line, 10000, (const char **) &str);
```

We have this hardcoded pattern. It seems safe because the underlying buffer sizes shouldn't allow to go beyond the allocated size. However this is weird. Does anyone remember how we ended up with this in the code?