### PR TITLE
Ensure Enum Arguments are of u32 Type

### DIFF
--- a/src/filters/bsrw.c
+++ b/src/filters/bsrw.c
@@ -665,7 +665,7 @@ static GF_FilterArgs BSRWArgs[] =
 	{ OFFS(pspace), "profile space for HEVC", GF_PROP_SINT, "-1", NULL, GF_FS_ARG_UPDATE},
 	{ OFFS(gpcflags), "general compatibility flags for HEVC", GF_PROP_SINT, "-1", NULL, GF_FS_ARG_UPDATE},
 	{ OFFS(rmsei), "remove SEI messages from bitstream for AVC|H264, HEVC and VVC", GF_PROP_BOOL, "false", NULL, GF_FS_ARG_UPDATE},
-	{ OFFS(vidfmt), "video format for AVC|H264, HEVC and VVC", GF_PROP_UINT, "-1", "component|pal|ntsc|secam|mac|undef", GF_FS_ARG_UPDATE},
+	{ OFFS(vidfmt), "video format for AVC|H264, HEVC and VVC", GF_PROP_SINT, "-1", "component|pal|ntsc|secam|mac|undef", GF_FS_ARG_UPDATE},
 	{0}
 };
 

--- a/src/filters/dec_nvdec.c
+++ b/src/filters/dec_nvdec.c
@@ -68,8 +68,7 @@ typedef enum
 typedef struct _nv_dec_ctx
 {
 	u32 unload;
-	NVDecFrameMode fmode;
-	NVDecVideoMode vmode;
+	u32 vmode, fmode;
 	u32 num_surfaces;
 
 	GF_FilterPid *ipid, *opid;

--- a/src/filters/dmx_dash.c
+++ b/src/filters/dmx_dash.c
@@ -69,11 +69,12 @@ typedef struct
 	u32 max_buffer, tiles_rate, segstore, delay40X, exp_threshold, switch_count, bwcheck;
 	s32 auto_switch;
 	s32 init_timeshift;
-	Bool server_utc, screen_res, aggressive, speedadapt, fmodefwd, skip_lqt, llhls_merge, filemode, chain_mode, asloop;
+	Bool server_utc, screen_res, aggressive, speedadapt, fmodefwd, skip_lqt, llhls_merge, filemode, asloop;
+	u32 chain_mode;
 	u32 forward;
 	GF_PropUIntList debug_as;
-	GF_DASHInitialSelectionMode start_with;
-	GF_DASHTileAdaptationMode tile_mode;
+	u32 start_with;
+	u32 tile_mode;
 	char *algo;
 	Bool max_res, abort;
 	u32 use_bmin;

--- a/src/filters/in_http.c
+++ b/src/filters/in_http.c
@@ -54,7 +54,7 @@ typedef struct
 	//options
 	char *src;
 	u32 block_size;
-	GF_HTTPInStoreMode cache;
+	u32 cache;
 	GF_Fraction64 range;
 	char *ext;
 	char *mime;

--- a/src/filters/mux_isom.c
+++ b/src/filters/mux_isom.c
@@ -8464,7 +8464,7 @@ static const GF_FilterArgs MP4MuxArgs[] =
 			"- v1: use v1 signaling, ISOBMFF style (will mux raw PCM as ISOBMFF style)\n"
 			"- v1qt: use v1 signaling, QTFF style\n"
 			"- v2qt: use v2 signaling, QTFF style (lpcm entry type)"
-		, GF_PROP_UINT, "v0", "v0|v0s|v1|v1qt|v2qt", 0},
+		, GF_PROP_UINT, "v0", "|v0|v0s|v1|v1qt|v2qt", 0},
 	{ OFFS(ssix), "create `ssix` box when `sidx` box is present, level 1 mapping I-frames byte ranges, level 0xFF mapping the rest", GF_PROP_BOOL, "false", NULL, GF_FS_ARG_HINT_ADVANCED},
 	{ OFFS(ccst), "insert coding constraint box for video tracks", GF_PROP_BOOL, "false", NULL, GF_FS_ARG_HINT_ADVANCED},
 	{ OFFS(maxchunk), "set max chunk size in bytes for runs (only used in non-fragmented mode). 0 means no constraints", GF_PROP_UINT, "0", NULL, GF_FS_ARG_HINT_ADVANCED},

--- a/src/filters/mux_isom.c
+++ b/src/filters/mux_isom.c
@@ -293,7 +293,7 @@ typedef struct
 	Bool ssix;
 	Bool ccst;
 	s32 mediats;
-	GF_AudioSampleEntryImportMode ase;
+	u32 ase;
 	char *styp;
 	Bool sseg;
 	Bool noroll, norap;
@@ -8464,7 +8464,7 @@ static const GF_FilterArgs MP4MuxArgs[] =
 			"- v1: use v1 signaling, ISOBMFF style (will mux raw PCM as ISOBMFF style)\n"
 			"- v1qt: use v1 signaling, QTFF style\n"
 			"- v2qt: use v2 signaling, QTFF style (lpcm entry type)"
-		, GF_PROP_UINT, "v0", "|v0|v0s|v1|v1qt|v2qt", 0},
+		, GF_PROP_UINT, "v0", "v0|v0s|v1|v1qt|v2qt", 0},
 	{ OFFS(ssix), "create `ssix` box when `sidx` box is present, level 1 mapping I-frames byte ranges, level 0xFF mapping the rest", GF_PROP_BOOL, "false", NULL, GF_FS_ARG_HINT_ADVANCED},
 	{ OFFS(ccst), "insert coding constraint box for video tracks", GF_PROP_BOOL, "false", NULL, GF_FS_ARG_HINT_ADVANCED},
 	{ OFFS(maxchunk), "set max chunk size in bytes for runs (only used in non-fragmented mode). 0 means no constraints", GF_PROP_UINT, "0", NULL, GF_FS_ARG_HINT_ADVANCED},

--- a/src/filters/mux_ts.c
+++ b/src/filters/mux_ts.c
@@ -103,7 +103,7 @@ typedef struct
 	u32 pmt_id, pmt_rate, pmt_version, sdt_rate, breq, mpeg4;
 	u64 pcr_offset, first_pts;
 	u32 rate, pat_rate, repeat_rate, repeat_img, max_pcr, nb_pack, sid, bifs_pes;
-	GF_M2TS_PackMode pes_pack;
+	u32 pes_pack;
 	Bool flush_rap, realtime, pcr_only, disc, latm;
 	s64 pcr_init;
 	char *name, *provider, *temi;

--- a/src/filters/out_video.c
+++ b/src/filters/out_video.c
@@ -93,7 +93,7 @@ typedef struct
 {
 	//options
 	char *drv;
-	GF_VideoOutMode disp;
+	u32 disp;
 	Bool vsync, linear, fullscreen, drop, hide, step, vjs, async;
 	GF_Fraction64 dur;
 	Double speed, hold;

--- a/src/filters/write_nhml.c
+++ b/src/filters/write_nhml.c
@@ -36,11 +36,19 @@
 #include <zlib.h>
 #endif
 
+typedef enum
+{
+	NO_CHKSUM,
+	CRC32_CHKSUM,
+	SHA1_CHKSUM,
+} GF_NHMLChksum;
+
 typedef struct
 {
 	//opts
 	const char *name;
-	Bool exporter, dims, pckp, nhmlonly, payload, chksum;
+	Bool exporter, dims, pckp, nhmlonly, payload;
+	u32 chksum;
 	FILE *filep;
 
 
@@ -775,8 +783,8 @@ static GF_Err nhmldump_send_frame(GF_NHMLDumpCtx *ctx, char *data, u32 data_size
 		}
 	}
 
-	if (ctx->chksum) {
-		if (ctx->chksum==1) {
+	if (ctx->chksum!=NO_CHKSUM) {
+		if (ctx->chksum==CRC32_CHKSUM) {
 			u32 crc = gf_crc_32(data, data_size);
 			sprintf(nhml, "crc=\"%08X\" ", crc);
 			gf_bs_write_data(ctx->bs_w, nhml, (u32) strlen(nhml));


### PR DESCRIPTION
This PR includes the following changes to improve type safety and consistency:

- fix type of `bsrw.vidfmt`: `GF_PROP_SINT` instead of `GF_PROP_UINT`.
- Declare all `enum` arguments as `u32` variables to maintain consistency and prevent type mismatches.

PS: This PR is a follow-up to the closed PR #2984 