### PR TITLE
Do Not Abandon Repairing Byte Range After Blacklisting a Repair Server

### DIFF
--- a/src/filters/in_route_repair.c
+++ b/src/filters/in_route_repair.c
@@ -547,6 +547,14 @@ restart:
 			rsess->server->accept_ranges = GF_FALSE;
 			GF_LOG(GF_LOG_WARNING, GF_LOG_ROUTE, ("[REPAIR] Server \"%s\" does not support byte range requests: Server is blacklisted for partial repair \n", rsess->server->url));
 			gf_dm_sess_abort(rsess->dld);
+			gf_dm_sess_del(rsess->dld);
+			//try with another server if there is one
+			rsess->dld = NULL;
+			rsi->pending--;
+			rsess->current_si = NULL;
+			gf_list_add(rsi->ranges, rsess->range);
+			rsess->range = NULL;
+			goto restart;
 		}
 	}
 


### PR DESCRIPTION
This PR improves the repair session logic to ensure that the repair process does not abandon byte range repairs after blacklisting a server that does not support byte range requests. Instead, it will attempt to use an alternative server if available.