### PR TITLE
Buildbot full repair if 80 percent loss

### DIFF
--- a/src/filters/in_route_repair.c
+++ b/src/filters/in_route_repair.c
@@ -537,13 +537,14 @@ restart:
 				}
 				rr->br_start = 0;
 				rr->br_end = rsi->finfo.total_size;
-				gf_list_add(rsi->ranges, rr);
 				rsess->range = rr;
 			} 
 		}
 		if (!url) {
-			GF_LOG(GF_LOG_ERROR, GF_LOG_ROUTE, ("[REPAIR] Failed to find an adequate repair server - Repair abort \n"));
+			GF_LOG(GF_LOG_ERROR, GF_LOG_ROUTE, ("[REPAIR] Failed to find an adequate repair server for segment %s - Repair abort \n", rsi->finfo.filename));
 			rsi->nb_errors++;
+			// ignore all other ranges for this segment
+			gf_list_transfer(ctx->seg_range_reservoir, rsi->ranges);
 			repair_session_done(ctx, rsess, e);
 			return;
 		}


### PR DESCRIPTION
This pull request introduces a new feature to handle cases where all repair servers are inadequate, and the segment has more than 80% data loss. In such scenarios, the system will attempt to use repair servers that do not support byte range to repair the entire segment.

**Changes**

- Added a check for the loss percentage in the segment.
- If the loss is more than 80%, the system will attempt to use non-byte-range repair servers.
- Ignore all other byte ranges for a segment is full segment repair is not possible.