### PR TITLE
dash client: increase stl tolerance when being ahead of time from 1 seg to 1.5 seg dur

### DIFF
--- a/src/filters/in_route.c
+++ b/src/filters/in_route.c
@@ -329,7 +329,7 @@ void routein_on_event_file(ROUTEInCtx *ctx, GF_ROUTEEventType evt, u32 evt_param
         }
 			
 		if (!ctx->clock_init_seg
-			//if full seg push of previsously advertized init, reset x-mcast-ll header
+			//if full seg push of previously advertized init, reset x-mcast-ll header
 			|| ((evt==GF_ROUTE_EVT_DYN_SEG) && !strcmp(ctx->clock_init_seg, finfo->filename))
 		) {
 			//store current seg if LL mode or full seg - MPD cache entry may still be null

--- a/src/media_tools/dash_client.c
+++ b/src/media_tools/dash_client.c
@@ -1401,8 +1401,8 @@ setup_multicast_clock:
 				segdur_in_timeline += ent->duration;
 			}
 		}
-		//check if we're ahead of time but "reasonably" ahead (max 1 min) - otherwise consider the timing is broken
-		if ((current_time_rescale + last_s_dur >= segtime) && (current_time_rescale <= segtime + 60*timescale)) {
+		//check if we're ahead of time but "reasonably" ahead (max 1.5 seg) - otherwise consider the timing is broken
+		if ((current_time_rescale + last_s_dur >= segtime*3/2) && (current_time_rescale <= segtime + 60*timescale)) {
 			GF_LOG(GF_LOG_WARNING, GF_LOG_DASH, ("[DASH] current time "LLU" is greater than last SegmentTimeline end "LLU" by %g sec - defaulting to last entry in SegmentTimeline\n", current_time_rescale, segtime, (Double) (current_time_rescale - segtime)/timescale ));
 			group->download_segment_index = (seg_idx > 2) ? (seg_idx-2) : 0;
 			group->nb_segments_in_rep = seg_idx;

--- a/src/utils/downloader.c
+++ b/src/utils/downloader.c
@@ -7712,7 +7712,7 @@ void gf_dm_sess_detach_async(GF_DownloadSession *sess)
 		gf_sk_set_block_mode(sess->sock, GF_TRUE);
 	}
 	sess->flags |= GF_NETIO_SESSION_NO_BLOCK;
-	//FOR TEST INLY
+	//FOR TEST ONLY
 	sess->flags &= ~GF_NETIO_SESSION_NOT_THREADED;
 	//mutex may already be created for H2 sessions
 	if (!sess->mx)


### PR DESCRIPTION
The original issue can be reproduced:

```
gpac -i https://livesim2.dashif.org/livesim2/segtimeline_1/testpic_2s/Manifest.mpd dashin:forward=file -o mabr://234.1.1.1:1234 -logs=route@warning -ifce=127.0.0.1 -no-h2
```

and client that will stop playing by lack of seg timeline update:

```
gpac -i mabr://234.1.1.1:1234:repair=no vout -ifce=127.0.0.1
```