### PR TITLE
Fix --disable-jack, --disable-pulseaudio, --disable-alsa

### DIFF
--- a/configure
+++ b/configure
@@ -664,11 +664,11 @@ for opt do
             ;;
         --dxsdk-path=*) dxsdk_path=`echo $opt | cut -d '=' -f 2`
             ;;
-        --disable-pulseaudio) has_pulseaudio="no"
+        --disable-pulseaudio) append disabled_packages "pulseaudio"
             ;;
-        --disable-jack) has_jack="no"
+        --disable-jack) append disabled_packages "jack"
             ;;
-        --disable-alsa) has_alsa="no"
+        --disable-alsa) append disabled_packages "alsa"
             ;;
         --enable-gprof) gprof_build="yes";
             ;;


### PR DESCRIPTION
These options in the build were setting the has_jack, has_pulseaudio or has_alsa variables respectively.

However, their values were being later replaced inside the check_has_lib() function, resulting in those options not affecting the enable status of those libraries in anyway.

This patch fixes it by disabling these features with the disabled_packages list, as done for other features.