### PR TITLE
API Additions for Filter and Constants

### DIFF
--- a/include/gpac/filters.h
+++ b/include/gpac/filters.h
@@ -4312,6 +4312,12 @@ GF_Err gf_filter_pid_allow_direct_dispatch(GF_FilterPid *PID);
 */
 void *gf_filter_pid_get_alias_udta(GF_FilterPid *PID);
 
+/*! Gets the filter owning the PID
+\param PID the target filter PID
+\return the filter owning the PID or NULL if error
+*/
+GF_Filter *gf_filter_pid_get_owner(GF_FilterPid *pid);
+
 /*! Gets the filter owning the  input PID
 \param PID the target filter PID
 \return the filter owning the PID or NULL if error

--- a/share/python/libgpac/libgpac.py
+++ b/share/python/libgpac/libgpac.py
@@ -1946,6 +1946,9 @@ _libgpac.gf_stream_type_name.restype = c_char_p
 _libgpac.gf_codecid_file_ext.argtypes = [c_uint]
 _libgpac.gf_codecid_file_ext.restype = c_char_p
 
+_libgpac.gf_filter_pid_get_owner.argtypes = [_gf_filter_pid]
+_libgpac.gf_filter_pid_get_owner.restype = _gf_filter
+
 _libgpac.gf_filter_pid_get_source_filter.argtypes = [_gf_filter_pid]
 _libgpac.gf_filter_pid_get_source_filter.restype = _gf_filter
 

--- a/src/export.cpp
+++ b/src/export.cpp
@@ -2696,6 +2696,7 @@
 #pragma comment (linker, EXPORT_SYMBOL(gf_filter_pid_negotiate_property ) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_filter_pid_negotiate_property_str) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_filter_pid_negotiate_property_dyn) )
+#pragma comment (linker, EXPORT_SYMBOL(gf_filter_pid_get_owner) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_filter_pid_get_source_filter) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_filter_pid_enum_destinations) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_filter_pid_discard_block) )

--- a/src/filter_core/filter_pid.c
+++ b/src/filter_core/filter_pid.c
@@ -9342,6 +9342,12 @@ void *gf_filter_pid_get_alias_udta(GF_FilterPid *_pid)
 }
 
 GF_EXPORT
+GF_Filter *gf_filter_pid_get_owner(GF_FilterPid *pid)
+{
+	return pid->filter;
+}
+
+GF_EXPORT
 GF_Filter *gf_filter_pid_get_source_filter(GF_FilterPid *pid)
 {
 	if (PID_IS_OUTPUT(pid)) {

--- a/src/utils/constants.c
+++ b/src/utils/constants.c
@@ -513,6 +513,8 @@ u32 gf_stream_type_by_name(const char *val)
 	for (i=0; i<nb_st; i++) {
 		if (!stricmp(GF_StreamTypes[i].name, val))
 			return GF_StreamTypes[i].st;
+		if (GF_StreamTypes[i].sname && !stricmp(GF_StreamTypes[i].sname, val))
+			return GF_StreamTypes[i].st;
 		if (GF_StreamTypes[i].alt_name && !stricmp(GF_StreamTypes[i].alt_name, val))
 			return GF_StreamTypes[i].st;
 	}


### PR DESCRIPTION
- **get the filter owning the pid**: If you only have access to the PID you don't have a way to get the owning filter, the new API adds that ability.
- **search stream type by their short name**: This is for easily understanding the stream type just by using the first part of MIME.
