### PR TITLE
Change default behavior of `noempty`

### DIFF
--- a/src/filters/write_vtt.c
+++ b/src/filters/write_vtt.c
@@ -343,7 +343,7 @@ static const GF_FilterArgs WebVTTMxArgs[] =
 {
 	{ OFFS(exporter), "compatibility with old exporter, displays export results", GF_PROP_BOOL, "false", NULL, GF_FS_ARG_HINT_ADVANCED},
 	{ OFFS(merge_cues), "merge VTT cues (undo ISOBMFF cue split)", GF_PROP_BOOL, "true", NULL, GF_FS_ARG_HINT_ADVANCED},
-	{ OFFS(noempty), "do not create an empty file if no VTT cues are present", GF_PROP_BOOL, "true", NULL, GF_FS_ARG_HINT_ADVANCED},
+	{ OFFS(noempty), "do not create an empty file if no VTT cues are present", GF_PROP_BOOL, "false", NULL, GF_FS_ARG_HINT_ADVANCED},
 	{0}
 };
 


### PR DESCRIPTION
Related to #2962, changed the default behaviour of `write_vtt` to export the WebVTT file even there are no cues present. Testsuite has also been updated to test this change.