### PR TITLE
Ability to Filter SEIs

### DIFF
--- a/include/gpac/internal/media_dev.h
+++ b/include/gpac/internal/media_dev.h
@@ -279,6 +279,12 @@ typedef struct
 	u32 data_length;
 } SVC_Extractor;
 
+typedef struct
+{
+	Bool is_whitelist;
+	GF_PropUIntList seis;
+} SEI_Filter;
+
 
 /*return sps ID or -1 if error*/
 s32 gf_avc_read_sps(const u8 *sps_data, u32 sps_size, AVCState *avc, u32 subseq_sps, u32 *vui_flag_pos);
@@ -297,7 +303,7 @@ Bool gf_avc_slice_is_intra(AVCState *avc);
 s32 gf_avc_parse_nalu(GF_BitStream *bs, AVCState *avc);
 /*remove SEI messages not allowed in MP4*/
 /*nota: 'buffer' remains unmodified but cannot be set const*/
-u32 gf_avc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, AVCState *avc, GF_PropUIntList seis, Bool is_remove);
+u32 gf_avc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, AVCState *avc, SEI_Filter *sei_filter);
 
 #ifndef GPAC_DISABLE_AV_PARSERS
 
@@ -625,7 +631,7 @@ GF_Err gf_hevc_get_sps_info_with_state(HEVCState *hevc_state, u8 *sps_data, u32 
 
 /*parses HEVC SEI and fill state accordingly*/
 void gf_hevc_parse_sei(char* buffer, u32 nal_size, HEVCState *hevc);
-u32 gf_hevc_reformat_sei(char* buffer, u32 nal_size, Bool isobmf_rewrite, HEVCState *hevc, GF_PropUIntList seis, Bool is_remove);
+u32 gf_hevc_reformat_sei(char* buffer, u32 nal_size, Bool isobmf_rewrite, SEI_Filter *sei_filter);
 
 
 
@@ -868,7 +874,7 @@ typedef struct _vvc_state
 
 s32 gf_vvc_parse_nalu_bs(GF_BitStream *bs, VVCState *vvc, u8 *nal_unit_type, u8 *temporal_id, u8 *layer_id);
 void gf_vvc_parse_sei(char* buffer, u32 nal_size, VVCState *vvc);
-u32 gf_vvc_reformat_sei(char *buffer, u32 nal_size, Bool isobmf_rewrite, VVCState *vvc, GF_PropUIntList seis, Bool is_remove);
+u32 gf_vvc_reformat_sei(char *buffer, u32 nal_size, Bool isobmf_rewrite, SEI_Filter *sei_filter);
 Bool gf_vvc_slice_is_ref(VVCState *vvc);
 s32 gf_vvc_parse_nalu(u8 *data, u32 size, VVCState *vvc, u8 *nal_unit_type, u8 *temporal_id, u8 *layer_id);
 

--- a/include/gpac/internal/media_dev.h
+++ b/include/gpac/internal/media_dev.h
@@ -297,7 +297,7 @@ Bool gf_avc_slice_is_intra(AVCState *avc);
 s32 gf_avc_parse_nalu(GF_BitStream *bs, AVCState *avc);
 /*remove SEI messages not allowed in MP4*/
 /*nota: 'buffer' remains unmodified but cannot be set const*/
-u32 gf_avc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, AVCState *avc, GF_PropUIntList seis);
+u32 gf_avc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, AVCState *avc, GF_PropUIntList seis, Bool is_remove);
 
 #ifndef GPAC_DISABLE_AV_PARSERS
 
@@ -625,7 +625,7 @@ GF_Err gf_hevc_get_sps_info_with_state(HEVCState *hevc_state, u8 *sps_data, u32 
 
 /*parses HEVC SEI and fill state accordingly*/
 void gf_hevc_parse_sei(char* buffer, u32 nal_size, HEVCState *hevc);
-u32 gf_hevc_reformat_sei(char* buffer, u32 nal_size, Bool isobmf_rewrite, HEVCState *hevc, GF_PropUIntList seis);
+u32 gf_hevc_reformat_sei(char* buffer, u32 nal_size, Bool isobmf_rewrite, HEVCState *hevc, GF_PropUIntList seis, Bool is_remove);
 
 
 
@@ -868,7 +868,7 @@ typedef struct _vvc_state
 
 s32 gf_vvc_parse_nalu_bs(GF_BitStream *bs, VVCState *vvc, u8 *nal_unit_type, u8 *temporal_id, u8 *layer_id);
 void gf_vvc_parse_sei(char* buffer, u32 nal_size, VVCState *vvc);
-u32 gf_vvc_reformat_sei(char *buffer, u32 nal_size, Bool isobmf_rewrite, VVCState *vvc, GF_PropUIntList seis);
+u32 gf_vvc_reformat_sei(char *buffer, u32 nal_size, Bool isobmf_rewrite, VVCState *vvc, GF_PropUIntList seis, Bool is_remove);
 Bool gf_vvc_slice_is_ref(VVCState *vvc);
 s32 gf_vvc_parse_nalu(u8 *data, u32 size, VVCState *vvc, u8 *nal_unit_type, u8 *temporal_id, u8 *layer_id);
 

--- a/include/gpac/internal/media_dev.h
+++ b/include/gpac/internal/media_dev.h
@@ -297,7 +297,7 @@ Bool gf_avc_slice_is_intra(AVCState *avc);
 s32 gf_avc_parse_nalu(GF_BitStream *bs, AVCState *avc);
 /*remove SEI messages not allowed in MP4*/
 /*nota: 'buffer' remains unmodified but cannot be set const*/
-u32 gf_avc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, AVCState *avc);
+u32 gf_avc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, AVCState *avc, GF_PropUIntList seis);
 
 #ifndef GPAC_DISABLE_AV_PARSERS
 
@@ -625,6 +625,7 @@ GF_Err gf_hevc_get_sps_info_with_state(HEVCState *hevc_state, u8 *sps_data, u32 
 
 /*parses HEVC SEI and fill state accordingly*/
 void gf_hevc_parse_sei(char* buffer, u32 nal_size, HEVCState *hevc);
+u32 gf_hevc_reformat_sei(char* buffer, u32 nal_size, Bool isobmf_rewrite, HEVCState *hevc, GF_PropUIntList seis);
 
 
 
@@ -867,6 +868,7 @@ typedef struct _vvc_state
 
 s32 gf_vvc_parse_nalu_bs(GF_BitStream *bs, VVCState *vvc, u8 *nal_unit_type, u8 *temporal_id, u8 *layer_id);
 void gf_vvc_parse_sei(char* buffer, u32 nal_size, VVCState *vvc);
+u32 gf_vvc_reformat_sei(char *buffer, u32 nal_size, Bool isobmf_rewrite, VVCState *vvc, GF_PropUIntList seis);
 Bool gf_vvc_slice_is_ref(VVCState *vvc);
 s32 gf_vvc_parse_nalu(u8 *data, u32 size, VVCState *vvc, u8 *nal_unit_type, u8 *temporal_id, u8 *layer_id);
 

--- a/src/filters/bsrw.c
+++ b/src/filters/bsrw.c
@@ -705,7 +705,7 @@ static GF_FilterArgs BSRWArgs[] =
 	{ OFFS(pidc), "profile IDC for HEVC and VVC", GF_PROP_SINT, "-1", NULL, GF_FS_ARG_UPDATE},
 	{ OFFS(pspace), "profile space for HEVC", GF_PROP_SINT, "-1", NULL, GF_FS_ARG_UPDATE},
 	{ OFFS(gpcflags), "general compatibility flags for HEVC", GF_PROP_SINT, "-1", NULL, GF_FS_ARG_UPDATE},
-	{ OFFS(seis), "list of SEI message types (4,137,144,...). If used with `rmsei`, this acts as a blacklist; otherwise, it acts as a whitelist", GF_PROP_UINT_LIST, NULL, NULL, GF_ARG_HINT_ADVANCED|GF_FS_ARG_UPDATE},
+	{ OFFS(seis), "list of SEI message types (4,137,144,...). When used with `rmsei`, this serves as a blacklist. If left empty, all SEIs will be removed. Otherwise, it serves as a whitelist", GF_PROP_UINT_LIST, NULL, NULL, GF_ARG_HINT_ADVANCED|GF_FS_ARG_UPDATE},
 	{ OFFS(rmsei), "remove SEI messages from bitstream for AVC|H264, HEVC and VVC", GF_PROP_BOOL, "false", NULL, GF_FS_ARG_UPDATE},
 	{ OFFS(vidfmt), "video format for AVC|H264, HEVC and VVC", GF_PROP_SINT, "-1", "component|pal|ntsc|secam|mac|undef", GF_FS_ARG_UPDATE},
 	{0}

--- a/src/filters/bsrw.c
+++ b/src/filters/bsrw.c
@@ -57,6 +57,7 @@ struct _bsrw_ctx
 	s32 m4vpl, prof, lev, pcomp, pidc, pspace, gpcflags;
 	s32 cprim, ctfc, cmx, vidfmt;
 	Bool rmsei, fullrange, novsi, novuitiming;
+	GF_PropUIntList seis;
 
 	GF_List *pids;
 	Bool reconfigure;
@@ -112,7 +113,7 @@ static GF_Err m4v_rewrite_pid_config(GF_BSRWCtx *ctx, BSRWPid *pctx)
 
 static GF_Err nalu_rewrite_packet(GF_BSRWCtx *ctx, BSRWPid *pctx, GF_FilterPacket *pck, u32 codec_type)
 {
-	Bool is_sei;
+	Bool is_sei = GF_FALSE;
 	u32 size, pck_size, final_size;
 	GF_FilterPacket *dst;
 	u8 *output;
@@ -120,10 +121,8 @@ static GF_Err nalu_rewrite_packet(GF_BSRWCtx *ctx, BSRWPid *pctx, GF_FilterPacke
 	if (!data)
 		return gf_filter_pck_forward(pck, pctx->opid);
 
-
-	final_size = 0;
 	size=0;
-	while (size<pck_size) {
+	while (size<pck_size && !is_sei) {
 		u8 nal_type=0;
 		u32 nal_hdr = pctx->nalu_size_length;
 		u32 nal_size = 0;
@@ -153,19 +152,24 @@ static GF_Err nalu_rewrite_packet(GF_BSRWCtx *ctx, BSRWPid *pctx, GF_FilterPacke
 				is_sei = GF_TRUE;
 		}
 
-		if (!is_sei) {
-			final_size += nal_size+pctx->nalu_size_length;
-		}
 		size += nal_size;
 	}
-	if (final_size == pck_size)
+	if (!is_sei)
 		return gf_filter_pck_forward(pck, pctx->opid);
 
-	dst = gf_filter_pck_new_alloc(pctx->opid, final_size, &output);
+	dst = gf_filter_pck_new_alloc(pctx->opid, pck_size, &output);
 	if (!dst) return GF_OUT_OF_MEM;
 
 	gf_filter_pck_merge_properties(pck, dst);
 
+	SEI_Filter sei_filter = {
+		.is_whitelist = !ctx->rmsei,
+		.seis = ctx->seis
+	};
+
+	u32 rw_sei_size = 0;
+	u8 *rw_sei_payload = NULL;
+	final_size=0;
 	size=0;
 	while (size<pck_size) {
 		u8 nal_type=0;
@@ -199,13 +203,50 @@ static GF_Err nalu_rewrite_packet(GF_BSRWCtx *ctx, BSRWPid *pctx, GF_FilterPacke
 		}
 
 		if (is_sei) {
-			size += nal_size;
-			continue;
+			rw_sei_size = nal_size;
+			if (rw_sei_payload) rw_sei_payload = gf_realloc(rw_sei_payload, rw_sei_size);
+			else rw_sei_payload = gf_malloc(rw_sei_size);
+			memcpy(rw_sei_payload, &data[size], rw_sei_size);
+
+			switch (codec_type)
+			{
+			case 0:
+				rw_sei_size = gf_avc_reformat_sei(rw_sei_payload, rw_sei_size, GF_TRUE, NULL, &sei_filter);
+				break;
+			case 1:
+				rw_sei_size = gf_hevc_reformat_sei(rw_sei_payload, rw_sei_size, GF_TRUE, &sei_filter);
+				break;
+			case 2:
+				rw_sei_size = gf_vvc_reformat_sei(rw_sei_payload, rw_sei_size, GF_TRUE, &sei_filter);
+				break;
+			default:
+				break;
+			}
+
+			if (rw_sei_size) {
+				// write the NAL length
+				u32 bytes = pctx->nalu_size_length;
+				while (bytes--) {
+					output[0] = (rw_sei_size >> (bytes * 8)) & 0xFF;
+					output++;
+					final_size++;
+				}
+
+				// write the NAL
+				memcpy(output, rw_sei_payload, rw_sei_size);
+				output += rw_sei_size;
+				final_size += rw_sei_size;
+			}
+		} else {
+			memcpy(output, &data[size-pctx->nalu_size_length], pctx->nalu_size_length+nal_size);
+			output += pctx->nalu_size_length+nal_size;
+			final_size += pctx->nalu_size_length+nal_size;
 		}
-		memcpy(output, &data[size-pctx->nalu_size_length], pctx->nalu_size_length+nal_size);
-		output += pctx->nalu_size_length+nal_size;
+
 		size += nal_size;
 	}
+	if (rw_sei_payload) gf_free(rw_sei_payload);
+	gf_filter_pck_truncate(dst, final_size);
 	return gf_filter_pck_send(dst);
 }
 
@@ -297,7 +338,7 @@ static GF_Err avc_rewrite_pid_config(GF_BSRWCtx *ctx, BSRWPid *pctx)
 
 	gf_filter_pid_set_property(pctx->opid, GF_PROP_PID_DECODER_CONFIG, &PROP_DATA_NO_COPY(dsi, dsi_size) );
 
-	if (ctx->rmsei) {
+	if (ctx->rmsei || ctx->seis.nb_items) {
 		pctx->rewrite_packet = avc_rewrite_packet;
 	} else {
 		pctx->rewrite_packet = none_rewrite_packet;
@@ -343,7 +384,7 @@ static GF_Err hevc_rewrite_pid_config(GF_BSRWCtx *ctx, BSRWPid *pctx)
 
 	gf_filter_pid_set_property(pctx->opid, GF_PROP_PID_DECODER_CONFIG, &PROP_DATA_NO_COPY(dsi, dsi_size) );
 
-	if (ctx->rmsei) {
+	if (ctx->rmsei || ctx->seis.nb_items) {
 		pctx->rewrite_packet = hevc_rewrite_packet;
 	} else {
 		pctx->rewrite_packet = none_rewrite_packet;
@@ -385,7 +426,7 @@ static GF_Err vvc_rewrite_pid_config(GF_BSRWCtx *ctx, BSRWPid *pctx)
 
 	gf_filter_pid_set_property(pctx->opid, GF_PROP_PID_DECODER_CONFIG, &PROP_DATA_NO_COPY(dsi, dsi_size) );
 
-	if (ctx->rmsei) {
+	if (ctx->rmsei || ctx->seis.nb_items) {
 		pctx->rewrite_packet = vvc_rewrite_packet;
 	} else {
 		pctx->rewrite_packet = none_rewrite_packet;
@@ -664,6 +705,7 @@ static GF_FilterArgs BSRWArgs[] =
 	{ OFFS(pidc), "profile IDC for HEVC and VVC", GF_PROP_SINT, "-1", NULL, GF_FS_ARG_UPDATE},
 	{ OFFS(pspace), "profile space for HEVC", GF_PROP_SINT, "-1", NULL, GF_FS_ARG_UPDATE},
 	{ OFFS(gpcflags), "general compatibility flags for HEVC", GF_PROP_SINT, "-1", NULL, GF_FS_ARG_UPDATE},
+	{ OFFS(seis), "list of SEI message types (4,137,144,...). If used with `rmsei`, this acts as a blacklist; otherwise, it acts as a whitelist", GF_PROP_UINT_LIST, NULL, NULL, GF_ARG_HINT_ADVANCED|GF_FS_ARG_UPDATE},
 	{ OFFS(rmsei), "remove SEI messages from bitstream for AVC|H264, HEVC and VVC", GF_PROP_BOOL, "false", NULL, GF_FS_ARG_UPDATE},
 	{ OFFS(vidfmt), "video format for AVC|H264, HEVC and VVC", GF_PROP_SINT, "-1", "component|pal|ntsc|secam|mac|undef", GF_FS_ARG_UPDATE},
 	{0}

--- a/src/filters/reframe_nalu.c
+++ b/src/filters/reframe_nalu.c
@@ -71,6 +71,7 @@ typedef struct
 	//filter args
 	GF_Fraction fps;
 	Double index;
+	GF_PropUIntList seis;
 	Bool explicit, force_sync, nosei, importer, subsamples, nosvc, novpsext, deps, seirw, audelim, analyze, notime, refs;
 	u32 nal_length;
 	u32 strict_poc;
@@ -2503,7 +2504,7 @@ void naludmx_add_subsample(GF_NALUDmxCtx *ctx, u32 subs_size, u8 subs_priority, 
 	ctx->subs_mapped_bytes += subs_size + ctx->nal_length;
 }
 
-static void naludmx_push_prefix(GF_NALUDmxCtx *ctx, u8 *data, u32 size, Bool avc_sei_rewrite)
+static Bool naludmx_push_prefix(GF_NALUDmxCtx *ctx, u8 *data, u32 size, Bool reformat)
 {
 	if (ctx->sei_buffer_alloc < ctx->sei_buffer_size + size + ctx->nal_length) {
 		ctx->sei_buffer_alloc = ctx->sei_buffer_size + size + ctx->nal_length;
@@ -2515,15 +2516,27 @@ static void naludmx_push_prefix(GF_NALUDmxCtx *ctx, u8 *data, u32 size, Bool avc
 	gf_bs_write_int(ctx->bs_w, size, 8*ctx->nal_length);
 	memcpy(ctx->sei_buffer + ctx->sei_buffer_size + ctx->nal_length, data, size);
 
-	if (avc_sei_rewrite) {
-		u32 rw_sei_size = gf_avc_reformat_sei(ctx->sei_buffer + ctx->sei_buffer_size + ctx->nal_length, size, ctx->seirw, ctx->avc_state);
-		if (rw_sei_size < size) {
-			gf_bs_seek(ctx->bs_w, 0);
-			gf_bs_write_int(ctx->bs_w, rw_sei_size, 8*ctx->nal_length);
-			size = rw_sei_size;
-		}
+	u32 rw_sei_size = size;
+	if (!reformat)
+		goto finish;
+
+	if (ctx->codecid==GF_CODECID_HEVC) {
+		rw_sei_size = gf_hevc_reformat_sei(ctx->sei_buffer + ctx->sei_buffer_size + ctx->nal_length, size, ctx->seirw, ctx->hevc_state, ctx->seis);
+	} else if (ctx->codecid==GF_CODECID_VVC) {
+		rw_sei_size = gf_vvc_reformat_sei(ctx->sei_buffer + ctx->sei_buffer_size + ctx->nal_length, size, ctx->seirw, ctx->vvc_state, ctx->seis);
+	} else {
+		rw_sei_size = gf_avc_reformat_sei(ctx->sei_buffer + ctx->sei_buffer_size + ctx->nal_length, size, ctx->seirw, ctx->avc_state, ctx->seis);
 	}
+
+	if (rw_sei_size < size) {
+		gf_bs_seek(ctx->bs_w, 0);
+		gf_bs_write_int(ctx->bs_w, rw_sei_size, 8*ctx->nal_length);
+		size = rw_sei_size;
+	}
+
+finish:
 	ctx->sei_buffer_size += size + ctx->nal_length;
+	return rw_sei_size > 0;
 }
 
 static s32 naludmx_parse_nal_hevc(GF_NALUDmxCtx *ctx, char *data, u32 size, Bool *skip_nal, u32 *is_slice, Bool *is_islice)
@@ -2589,11 +2602,12 @@ static s32 naludmx_parse_nal_hevc(GF_NALUDmxCtx *ctx, char *data, u32 size, Bool
 		if (ctx->hevc_state->has_3d_ref_disp_info) {
 			naludmx_queue_param_set(ctx, data, size, GF_HEVC_NALU_SEI_PREFIX, 0, temporal_id, layer_id);
 		}
-		if (!ctx->nosei) {
-			ctx->nb_sei++;
-			naludmx_push_prefix(ctx, data, size, GF_FALSE);
-		} else {
+		Bool still_has_sei = naludmx_push_prefix(ctx, data, size, GF_TRUE);
+		if (ctx->nosei || !still_has_sei) {
 			ctx->nb_nalus--;
+			ctx->sei_buffer_size = 0;
+		} else {
+			ctx->nb_sei++;
 		}
 		*skip_nal = GF_TRUE;
 		break;
@@ -2793,12 +2807,12 @@ static s32 naludmx_parse_nal_vvc(GF_NALUDmxCtx *ctx, char *data, u32 size, Bool 
 		break;
 	case GF_VVC_NALU_SEI_PREFIX:
 		gf_vvc_parse_sei(data, size, ctx->vvc_state);
-		if (!ctx->nosei) {
-			ctx->nb_sei++;
-
-			naludmx_push_prefix(ctx, data, size, GF_FALSE);
-		} else {
+		Bool still_has_sei = naludmx_push_prefix(ctx, data, size, GF_TRUE);
+		if (ctx->nosei || !still_has_sei) {
 			ctx->nb_nalus--;
+			ctx->sei_buffer_size = 0;
+		} else {
+			ctx->nb_sei++;
 		}
 		*skip_nal = GF_TRUE;
 		break;
@@ -2944,15 +2958,13 @@ static s32 naludmx_parse_nal_avc(GF_NALUDmxCtx *ctx, char *data, u32 size, u32 n
 
 	case GF_AVC_NALU_SEI:
 		if (ctx->avc_state->sps_active_idx != -1) {
-			naludmx_push_prefix(ctx, data, size, GF_TRUE);
-
-			*skip_nal = GF_TRUE;
-
-			if (ctx->nosei) {
+			Bool still_has_sei = naludmx_push_prefix(ctx, data, size, GF_TRUE);
+			if (ctx->nosei || !still_has_sei) {
 				ctx->sei_buffer_size = 0;
 			} else {
 				ctx->nb_sei++;
 			}
+			*skip_nal = GF_TRUE;
 		}
 		return 0;
 
@@ -4403,6 +4415,7 @@ static const GF_FilterArgs NALUDmxArgs[] =
 		"- off: disable GOP buffering\n"
 		"- on: enable GOP buffering, assuming no error in POC\n"
 		"- error: enable GOP buffering and try to detect lost frames", GF_PROP_UINT, "off", "off|on|error", GF_FS_ARG_HINT_ADVANCED},
+	{ OFFS(seis), "list of message types (4,137,144,...) to forward, other messages are dropped", GF_PROP_UINT_LIST, NULL, NULL, GF_FS_ARG_HINT_ADVANCED|GF_FS_ARG_UPDATE},
 	{ OFFS(nosei), "remove all sei messages", GF_PROP_BOOL, "false", NULL, GF_FS_ARG_HINT_ADVANCED},
 	{ OFFS(nosvc), "remove all SVC/MVC/LHVC data", GF_PROP_BOOL, "false", NULL, GF_FS_ARG_HINT_ADVANCED},
 	{ OFFS(novpsext), "remove all VPS extensions", GF_PROP_BOOL, "false", NULL, GF_FS_ARG_HINT_ADVANCED},

--- a/src/filters/reframe_nalu.c
+++ b/src/filters/reframe_nalu.c
@@ -2509,6 +2509,7 @@ static void naludmx_push_prefix(GF_NALUDmxCtx *ctx, u8 *data, u32 size, Bool avc
 		ctx->sei_buffer_alloc = ctx->sei_buffer_size + size + ctx->nal_length;
 		ctx->sei_buffer = gf_realloc(ctx->sei_buffer, ctx->sei_buffer_alloc);
 	}
+
 	if (!ctx->bs_w) ctx->bs_w = gf_bs_new(ctx->sei_buffer + ctx->sei_buffer_size, ctx->nal_length + size, GF_BITSTREAM_WRITE);
 	else gf_bs_reassign_buffer(ctx->bs_w, ctx->sei_buffer + ctx->sei_buffer_size, ctx->nal_length + size);
 	gf_bs_write_int(ctx->bs_w, size, 8*ctx->nal_length);

--- a/src/filters/reframe_nalu.c
+++ b/src/filters/reframe_nalu.c
@@ -2521,11 +2521,11 @@ static Bool naludmx_push_prefix(GF_NALUDmxCtx *ctx, u8 *data, u32 size, Bool ref
 		goto finish;
 
 	if (ctx->codecid==GF_CODECID_HEVC) {
-		rw_sei_size = gf_hevc_reformat_sei(ctx->sei_buffer + ctx->sei_buffer_size + ctx->nal_length, size, ctx->seirw, ctx->hevc_state, ctx->seis);
+		rw_sei_size = gf_hevc_reformat_sei(ctx->sei_buffer + ctx->sei_buffer_size + ctx->nal_length, size, ctx->seirw, ctx->hevc_state, ctx->seis, ctx->nosei);
 	} else if (ctx->codecid==GF_CODECID_VVC) {
-		rw_sei_size = gf_vvc_reformat_sei(ctx->sei_buffer + ctx->sei_buffer_size + ctx->nal_length, size, ctx->seirw, ctx->vvc_state, ctx->seis);
+		rw_sei_size = gf_vvc_reformat_sei(ctx->sei_buffer + ctx->sei_buffer_size + ctx->nal_length, size, ctx->seirw, ctx->vvc_state, ctx->seis, ctx->nosei);
 	} else {
-		rw_sei_size = gf_avc_reformat_sei(ctx->sei_buffer + ctx->sei_buffer_size + ctx->nal_length, size, ctx->seirw, ctx->avc_state, ctx->seis);
+		rw_sei_size = gf_avc_reformat_sei(ctx->sei_buffer + ctx->sei_buffer_size + ctx->nal_length, size, ctx->seirw, ctx->avc_state, ctx->seis, ctx->nosei);
 	}
 
 	if (rw_sei_size < size) {
@@ -3516,9 +3516,9 @@ naldmx_flush:
 		//reformat sei suffix
 		u32 original_nal_size = nal_size;
 		if (ctx->codecid==GF_CODECID_HEVC && nal_type==GF_HEVC_NALU_SEI_SUFFIX) {
-			nal_size = gf_hevc_reformat_sei(nal_data, nal_size, ctx->seirw, ctx->hevc_state, ctx->seis);
+			nal_size = gf_hevc_reformat_sei(nal_data, nal_size, ctx->seirw, ctx->hevc_state, ctx->seis, ctx->nosei);
 		} else if (ctx->codecid==GF_CODECID_VVC && nal_type==GF_VVC_NALU_SEI_SUFFIX) {
-			nal_size = gf_vvc_reformat_sei(nal_data, nal_size, ctx->seirw, ctx->vvc_state, ctx->seis);
+			nal_size = gf_vvc_reformat_sei(nal_data, nal_size, ctx->seirw, ctx->vvc_state, ctx->seis, ctx->nosei);
 		}
 
 		if (skip_nal || !nal_size) {
@@ -4422,8 +4422,8 @@ static const GF_FilterArgs NALUDmxArgs[] =
 		"- off: disable GOP buffering\n"
 		"- on: enable GOP buffering, assuming no error in POC\n"
 		"- error: enable GOP buffering and try to detect lost frames", GF_PROP_UINT, "off", "off|on|error", GF_FS_ARG_HINT_ADVANCED},
-	{ OFFS(seis), "list of sei message types (4,137,144,...) to drop", GF_PROP_UINT_LIST, NULL, NULL, GF_FS_ARG_HINT_ADVANCED|GF_FS_ARG_UPDATE},
-	{ OFFS(nosei), "remove all sei messages or pair with `seis` option to filter specific messages out", GF_PROP_BOOL, "false", NULL, GF_FS_ARG_HINT_ADVANCED},
+	{ OFFS(seis), "list of sei message types (4,137,144,...). If used with `nosei`, these types will be dropped. Otherwise, this acts as a whitelist to allow only the specified SEI message types", GF_PROP_UINT_LIST, NULL, NULL, GF_FS_ARG_HINT_ADVANCED|GF_FS_ARG_UPDATE},
+	{ OFFS(nosei), "removes all SEI messages. Combine with `seis` option to remove only specific sei messages", GF_PROP_BOOL, "false", NULL, GF_FS_ARG_HINT_ADVANCED},
 	{ OFFS(nosvc), "remove all SVC/MVC/LHVC data", GF_PROP_BOOL, "false", NULL, GF_FS_ARG_HINT_ADVANCED},
 	{ OFFS(novpsext), "remove all VPS extensions", GF_PROP_BOOL, "false", NULL, GF_FS_ARG_HINT_ADVANCED},
 	{ OFFS(importer), "compatibility with old importer, displays import results", GF_PROP_BOOL, "false", NULL, GF_FS_ARG_HINT_ADVANCED},

--- a/src/filters/reframe_nalu.c
+++ b/src/filters/reframe_nalu.c
@@ -3513,7 +3513,16 @@ naldmx_flush:
 			if (!ctx->opid) skip_nal = GF_TRUE;
 		}
 
-		if (skip_nal) {
+		//reformat sei suffix
+		u32 original_nal_size = nal_size;
+		if (ctx->codecid==GF_CODECID_HEVC && nal_type==GF_HEVC_NALU_SEI_SUFFIX) {
+			nal_size = gf_hevc_reformat_sei(nal_data, nal_size, ctx->seirw, ctx->hevc_state, ctx->seis);
+		} else if (ctx->codecid==GF_CODECID_VVC && nal_type==GF_VVC_NALU_SEI_SUFFIX) {
+			nal_size = gf_vvc_reformat_sei(nal_data, nal_size, ctx->seirw, ctx->vvc_state, ctx->seis);
+		}
+
+		if (skip_nal || !nal_size) {
+			nal_size = original_nal_size;
 			nal_size += sc_size;
 			gf_assert((u32) remain >= nal_size);
 			start += nal_size;

--- a/src/media_tools/av_parsers.c
+++ b/src/media_tools/av_parsers.c
@@ -6308,8 +6308,7 @@ s32 gf_avc_parse_nalu(GF_BitStream *bs, AVCState *avc)
 	return ret;
 }
 
-
-u32 gf_avc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, AVCState *avc)
+u32 gf_avc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, AVCState *avc, GF_PropUIntList seis)
 {
 	u32 ptype, psize, hdr, var;
 	u32 start;
@@ -6317,6 +6316,7 @@ u32 gf_avc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, AVCState 
 	GF_BitStream *bs_dest = NULL;
 	u8 nhdr;
 	Bool sei_removed = GF_FALSE;
+	Bool all_sei_removed = GF_TRUE;
 	char store;
 
 	hdr = buffer[0];
@@ -6347,10 +6347,15 @@ u32 gf_avc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, AVCState 
 			if (v != 0xFF) break;
 		}
 
+		do_copy = seis.nb_items == 0;
+		for (u32 i = 0; i < seis.nb_items; i++) {
+			if (seis.vals[i] == ptype) {
+				do_copy = GF_TRUE;
+				break;
+			}
+		}
+
 		start = (u32)gf_bs_get_position(bs);
-
-		do_copy = 1;
-
 		if (start + psize >= nal_size) {
 			GF_LOG(GF_LOG_WARNING, GF_LOG_CODING, ("[avc-h264] SEI user message type %d size error (%d but %d remain), keeping full SEI untouched\n", ptype, psize, nal_size - start));
 			if (bs_dest) gf_bs_del(bs_dest);
@@ -6363,8 +6368,7 @@ u32 gf_avc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, AVCState 
 		case 10: /*sub_seq info*/
 		case 11: /*sub_seq_layer char*/
 		case 12: /*sub_seq char*/
-			do_copy = 0;
-			sei_removed = GF_TRUE;
+			do_copy = GF_FALSE;
 			break;
 		case 5: /*user unregistered */
 			store = buffer[start + psize];
@@ -6398,6 +6402,7 @@ u32 gf_avc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, AVCState 
 		}
 
 		if (do_copy && bs_dest) {
+			all_sei_removed = GF_FALSE;
 			var = ptype;
 			while (var >= 255) {
 				gf_bs_write_int(bs_dest, 0xFF, 8);
@@ -6421,6 +6426,7 @@ u32 gf_avc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, AVCState 
 			}
 		}
 		else {
+			if (!do_copy) sei_removed = GF_TRUE;
 			gf_bs_seek(bs, start);
 
 			//bs_skip_bytes does not skip EPB, skip byte per byte
@@ -6444,7 +6450,7 @@ u32 gf_avc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, AVCState 
 	}
 	gf_bs_del(bs);
 	//we cannot compare final size and original size since original may have EPB and final does not yet have them
-	if (bs_dest && sei_removed) {
+	if (bs_dest && sei_removed && !all_sei_removed) {
 		u8 *dst_no_epb = NULL;
 		u32 dst_no_epb_size = 0;
 		gf_bs_get_content(bs_dest, &dst_no_epb, &dst_no_epb_size);
@@ -6459,6 +6465,7 @@ u32 gf_avc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, AVCState 
 		}
 	}
 	if (bs_dest) gf_bs_del(bs_dest);
+	if (all_sei_removed) return 0;
 	return nal_size;
 }
 
@@ -7668,6 +7675,124 @@ static void gf_hevc_compute_ref_list(HEVCState *hevc, HEVCSliceInfo *si)
 	}
 }
 
+u32 gf_hevc_vvc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, HEVCState *hevc, VVCState *vvc, GF_PropUIntList seis)
+{
+	u32 ptype, psize, hdr, var;
+	u64 start;
+	GF_BitStream *bs;
+	GF_BitStream *bs_dest = NULL;
+	Bool sei_removed = GF_FALSE;
+	Bool all_sei_removed = GF_TRUE;
+
+	hdr = buffer[0];
+	if (((hdr & 0x7e) >> 1) != GF_HEVC_NALU_SEI_PREFIX && ((hdr & 0x7e) >> 1) != GF_VVC_NALU_SEI_PREFIX)
+		return nal_size;
+
+	if (isobmf_rewrite) bs_dest = gf_bs_new(NULL, 0, GF_BITSTREAM_WRITE);
+
+	bs = gf_bs_new(buffer, nal_size, GF_BITSTREAM_READ);
+	gf_bs_enable_emulation_byte_removal(bs, GF_TRUE);
+
+	gf_bs_read_int(bs, 16);
+
+	/*parse SEI*/
+	while (gf_bs_available(bs)) {
+		Bool do_copy;
+		ptype = 0;
+		while (gf_bs_peek_bits(bs, 8, 0)==0xFF) {
+			gf_bs_read_int(bs, 8);
+			ptype += 255;
+		}
+		ptype += gf_bs_read_int(bs, 8);
+		psize = 0;
+		while (gf_bs_peek_bits(bs, 8, 0)==0xFF) {
+			gf_bs_read_int(bs, 8);
+			psize += 255;
+		}
+		psize += gf_bs_read_int(bs, 8);
+
+		do_copy = seis.nb_items == 0;
+		for (u32 i = 0; i < seis.nb_items; i++) {
+			if (seis.vals[i] == ptype) {
+				do_copy = GF_TRUE;
+				break;
+			}
+		}
+
+		start = gf_bs_get_position(bs);
+		if (start+psize >= nal_size) {
+			GF_LOG(GF_LOG_WARNING, GF_LOG_CODING, ("[%s] SEI user message type %d size error (%d but %d remain), skipping SEI message\n", hevc ? "HEVC" : "VVC", ptype, psize, nal_size-start));
+			break;
+		}
+
+		if (do_copy && bs_dest) {
+			all_sei_removed = GF_FALSE;
+			var = ptype;
+			while (var >= 255) {
+				gf_bs_write_int(bs_dest, 0xFF, 8);
+				var -= 255;
+			}
+			gf_bs_write_int(bs_dest, var, 8);
+
+			var = psize;
+			while (var >= 255) {
+				gf_bs_write_int(bs_dest, 0xFF, 8);
+				var -= 255;
+			}
+			gf_bs_write_int(bs_dest, var, 8);
+			gf_bs_seek(bs, start);
+
+			//bs_read_data does not skip EPB, read byte per byte
+			var = psize;
+			while (var) {
+				gf_bs_write_u8(bs_dest, gf_bs_read_u8(bs));
+				var--;
+			}
+		}
+		else {
+			if (!do_copy) sei_removed = GF_TRUE;
+			gf_bs_seek(bs, start);
+
+			//bs_skip_bytes does not skip EPB, skip byte per byte
+			while (psize) {
+				gf_bs_read_u8(bs);
+				psize--;
+			}
+		}
+
+		if (gf_bs_available(bs) <= 2) {
+			var = gf_bs_read_int(bs, 8);
+			if (var != 0x80) {
+				GF_LOG(GF_LOG_WARNING, GF_LOG_CODING, ("[%s] SEI user message has less than 2 bytes remaining but no end of sei found, keeping full SEI untouched\n", hevc ? "HEVC" : "VVC"));
+				if (bs_dest) gf_bs_del(bs_dest);
+				gf_bs_del(bs);
+				return nal_size;
+			}
+			if (bs_dest) gf_bs_write_int(bs_dest, 0x80, 8);
+			break;
+		}
+	}
+	gf_bs_del(bs);
+	//we cannot compare final size and original size since original may have EPB and final does not yet have them
+	if (bs_dest && sei_removed && !all_sei_removed) {
+		u8 *dst_no_epb = NULL;
+		u32 dst_no_epb_size = 0;
+		gf_bs_get_content(bs_dest, &dst_no_epb, &dst_no_epb_size);
+		if (dst_no_epb) {
+			u32 nb_bytes_add = gf_media_nalu_emulation_bytes_add_count(dst_no_epb, dst_no_epb_size);
+			//if result fits into source buffer, reformat
+			//otherwise ignore and return source (happens in some fuzzing cases, cf issue 1903)
+			if (dst_no_epb_size + nb_bytes_add <= nal_size)
+				nal_size = gf_media_nalu_add_emulation_bytes(dst_no_epb, buffer, dst_no_epb_size);
+
+			gf_free(dst_no_epb);
+		}
+	}
+	if (bs_dest) gf_bs_del(bs_dest);
+	if (all_sei_removed) return 0;
+	return nal_size;
+}
+
 static void gf_hevc_vvc_parse_sei(char *buffer, u32 nal_size, HEVCState *hevc, VVCState *vvc)
 {
 	u32 ptype, psize, hdr, i;
@@ -7774,6 +7899,11 @@ static void gf_hevc_vvc_parse_sei(char *buffer, u32 nal_size, HEVCState *hevc, V
 void gf_hevc_parse_sei(char *buffer, u32 nal_size, HEVCState *hevc)
 {
 	gf_hevc_vvc_parse_sei(buffer, nal_size, hevc, NULL);
+}
+
+u32 gf_hevc_reformat_sei(char *buffer, u32 nal_size, Bool isobmf_rewrite, HEVCState *hevc, GF_PropUIntList seis)
+{
+	return gf_hevc_vvc_reformat_sei(buffer, nal_size, isobmf_rewrite, hevc, NULL, seis);
 }
 
 static void hevc_compute_poc(HEVCSliceInfo *si)
@@ -10771,6 +10901,12 @@ GF_EXPORT
 void gf_vvc_parse_sei(char *buffer, u32 nal_size, VVCState *vvc)
 {
 	gf_hevc_vvc_parse_sei(buffer, nal_size, NULL, vvc);
+}
+
+GF_EXPORT
+u32 gf_vvc_reformat_sei(char *buffer, u32 nal_size, Bool isobmf_rewrite, VVCState *vvc, GF_PropUIntList seis)
+{
+	return gf_hevc_vvc_reformat_sei(buffer, nal_size, isobmf_rewrite, NULL, vvc, seis);
 }
 
 static Bool vvc_parse_nal_header(GF_BitStream *bs, u8 *nal_unit_type, u8 *temporal_id, u8 *layer_id)

--- a/src/media_tools/av_parsers.c
+++ b/src/media_tools/av_parsers.c
@@ -7686,7 +7686,7 @@ u32 gf_hevc_vvc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, HEVC
 	u64 start;
 	GF_BitStream *bs;
 	GF_BitStream *bs_dest = NULL;
-	u8 nhdr;
+	u16 nhdr;
 	Bool sei_removed = GF_FALSE;
 	Bool all_sei_removed = GF_TRUE;
 

--- a/src/media_tools/av_parsers.c
+++ b/src/media_tools/av_parsers.c
@@ -6347,10 +6347,10 @@ u32 gf_avc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, AVCState 
 			if (v != 0xFF) break;
 		}
 
-		do_copy = seis.nb_items == 0;
+		do_copy = GF_TRUE;
 		for (u32 i = 0; i < seis.nb_items; i++) {
 			if (seis.vals[i] == ptype) {
-				do_copy = GF_TRUE;
+				do_copy = GF_FALSE;
 				break;
 			}
 		}
@@ -7727,10 +7727,10 @@ u32 gf_hevc_vvc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, HEVC
 		}
 		psize += gf_bs_read_int(bs, 8);
 
-		do_copy = seis.nb_items == 0;
+		do_copy = GF_TRUE;
 		for (u32 i = 0; i < seis.nb_items; i++) {
 			if (seis.vals[i] == ptype) {
-				do_copy = GF_TRUE;
+				do_copy = GF_FALSE;
 				break;
 			}
 		}

--- a/src/media_tools/av_parsers.c
+++ b/src/media_tools/av_parsers.c
@@ -7736,9 +7736,11 @@ u32 gf_hevc_vvc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, HEVC
 		}
 
 		start = gf_bs_get_position(bs);
-		if (start+psize >= nal_size) {
-			GF_LOG(GF_LOG_WARNING, GF_LOG_CODING, ("[%s] SEI user message type %d size error (%d but %d remain), skipping SEI message\n", hevc ? "HEVC" : "VVC", ptype, psize, nal_size-start));
-			break;
+		if (start + psize >= nal_size) {
+			GF_LOG(GF_LOG_WARNING, GF_LOG_CODING, ("[%s] SEI user message type %d size error (%d but %d remain), keeping full SEI untouched\n", hevc ? "HEVC" : "VVC", ptype, psize, nal_size-start));
+			if (bs_dest) gf_bs_del(bs_dest);
+			gf_bs_del(bs);
+			return nal_size;
 		}
 
 		nb_zeros = gf_bs_get_emulation_byte_removed(bs);

--- a/src/media_tools/av_parsers.c
+++ b/src/media_tools/av_parsers.c
@@ -6308,7 +6308,7 @@ s32 gf_avc_parse_nalu(GF_BitStream *bs, AVCState *avc)
 	return ret;
 }
 
-u32 gf_avc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, AVCState *avc, GF_PropUIntList seis)
+u32 gf_avc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, AVCState *avc, GF_PropUIntList seis, Bool is_remove)
 {
 	u32 ptype, psize, hdr, var;
 	u32 start;
@@ -6347,10 +6347,10 @@ u32 gf_avc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, AVCState 
 			if (v != 0xFF) break;
 		}
 
-		do_copy = GF_TRUE;
+		do_copy = is_remove;
 		for (u32 i = 0; i < seis.nb_items; i++) {
 			if (seis.vals[i] == ptype) {
-				do_copy = GF_FALSE;
+				do_copy = !do_copy;
 				break;
 			}
 		}
@@ -7680,7 +7680,7 @@ static void gf_hevc_compute_ref_list(HEVCState *hevc, HEVCSliceInfo *si)
 	}
 }
 
-u32 gf_hevc_vvc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, HEVCState *hevc, VVCState *vvc, GF_PropUIntList seis)
+u32 gf_hevc_vvc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, HEVCState *hevc, VVCState *vvc, GF_PropUIntList seis, Bool is_remove)
 {
 	u32 ptype, psize, hdr, var;
 	u64 start;
@@ -7727,10 +7727,10 @@ u32 gf_hevc_vvc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, HEVC
 		}
 		psize += gf_bs_read_int(bs, 8);
 
-		do_copy = GF_TRUE;
+		do_copy = is_remove;
 		for (u32 i = 0; i < seis.nb_items; i++) {
 			if (seis.vals[i] == ptype) {
-				do_copy = GF_FALSE;
+				do_copy = !do_copy;
 				break;
 			}
 		}
@@ -7937,9 +7937,9 @@ void gf_hevc_parse_sei(char *buffer, u32 nal_size, HEVCState *hevc)
 	gf_hevc_vvc_parse_sei(buffer, nal_size, hevc, NULL);
 }
 
-u32 gf_hevc_reformat_sei(char *buffer, u32 nal_size, Bool isobmf_rewrite, HEVCState *hevc, GF_PropUIntList seis)
+u32 gf_hevc_reformat_sei(char *buffer, u32 nal_size, Bool isobmf_rewrite, HEVCState *hevc, GF_PropUIntList seis, Bool is_remove)
 {
-	return gf_hevc_vvc_reformat_sei(buffer, nal_size, isobmf_rewrite, hevc, NULL, seis);
+	return gf_hevc_vvc_reformat_sei(buffer, nal_size, isobmf_rewrite, hevc, NULL, seis, is_remove);
 }
 
 static void hevc_compute_poc(HEVCSliceInfo *si)
@@ -10940,9 +10940,9 @@ void gf_vvc_parse_sei(char *buffer, u32 nal_size, VVCState *vvc)
 }
 
 GF_EXPORT
-u32 gf_vvc_reformat_sei(char *buffer, u32 nal_size, Bool isobmf_rewrite, VVCState *vvc, GF_PropUIntList seis)
+u32 gf_vvc_reformat_sei(char *buffer, u32 nal_size, Bool isobmf_rewrite, VVCState *vvc, GF_PropUIntList seis, Bool is_remove)
 {
-	return gf_hevc_vvc_reformat_sei(buffer, nal_size, isobmf_rewrite, NULL, vvc, seis);
+	return gf_hevc_vvc_reformat_sei(buffer, nal_size, isobmf_rewrite, NULL, vvc, seis, is_remove);
 }
 
 static Bool vvc_parse_nal_header(GF_BitStream *bs, u8 *nal_unit_type, u8 *temporal_id, u8 *layer_id)

--- a/src/media_tools/av_parsers.c
+++ b/src/media_tools/av_parsers.c
@@ -7691,8 +7691,16 @@ u32 gf_hevc_vvc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, HEVC
 	Bool all_sei_removed = GF_TRUE;
 
 	hdr = buffer[0];
-	if (((hdr & 0x7e) >> 1) != GF_HEVC_NALU_SEI_PREFIX && ((hdr & 0x7e) >> 1) != GF_VVC_NALU_SEI_PREFIX)
+	switch ((hdr & 0x7e) >> 1)
+	{
+	case GF_HEVC_NALU_SEI_PREFIX:
+	case GF_HEVC_NALU_SEI_SUFFIX:
+	case GF_VVC_NALU_SEI_PREFIX:
+	case GF_VVC_NALU_SEI_SUFFIX:
+		break;
+	default:
 		return nal_size;
+	}
 
 	if (isobmf_rewrite) bs_dest = gf_bs_new(NULL, 0, GF_BITSTREAM_WRITE);
 

--- a/src/media_tools/av_parsers.c
+++ b/src/media_tools/av_parsers.c
@@ -6351,6 +6351,7 @@ u32 gf_avc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, AVCState 
 		do_copy = GF_TRUE;
 		if (sei_filter) {
 			do_copy = !sei_filter->is_whitelist;
+			do_copy &= (sei_filter->seis.nb_items > 0); // if no SEI type specified, drop all
 			for (u32 i = 0; i < sei_filter->seis.nb_items; i++) {
 				if (sei_filter->seis.vals[i] == ptype) {
 					do_copy = !do_copy;
@@ -6382,11 +6383,11 @@ u32 gf_avc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, AVCState 
 			break;
 
 		case 6: /*recovery point*/
-			avc_parse_recovery_point_sei(bs, avc);
+			if (avc) avc_parse_recovery_point_sei(bs, avc);
 			break;
 
 		case 1: /*pic_timing*/
-			avc_parse_pic_timing_sei(bs, avc);
+			if (avc) avc_parse_pic_timing_sei(bs, avc);
 			break;
 
 		case 0: /*buffering period*/
@@ -7694,8 +7695,8 @@ u32 gf_hevc_vvc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, Bool
 	Bool sei_removed = GF_FALSE;
 	Bool all_sei_removed = GF_TRUE;
 
-	hdr = buffer[0];
-	switch ((hdr & 0x7e) >> 1)
+	hdr = buffer[!is_hevc];
+	switch (is_hevc ? (hdr & 0x7e) >> 1 : hdr >> 3)
 	{
 	case GF_HEVC_NALU_SEI_PREFIX:
 	case GF_HEVC_NALU_SEI_SUFFIX:
@@ -7735,6 +7736,7 @@ u32 gf_hevc_vvc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, Bool
 		do_copy = GF_TRUE;
 		if (sei_filter) {
 			do_copy = !sei_filter->is_whitelist;
+			do_copy &= (sei_filter->seis.nb_items > 0); // if no SEI type specified, drop all
 			for (u32 i = 0; i < sei_filter->seis.nb_items; i++) {
 				if (sei_filter->seis.vals[i] == ptype) {
 					do_copy = !do_copy;


### PR DESCRIPTION
This PR adds a new option called `seis` to `bsrw`. The new option would allow filtering SEIs rather than removing them all or not (see `rmsei`)

## TODO
- [x] Filter Suffix SEIs for HEVC/VVC
- [x] HEVC rewrite is broken

Testsuite PR: https://github.com/gpac/testsuite/pull/24 https://github.com/gpac/testsuite/pull/25