### PR TITLE
isomedia: implement cslg version 1

### DIFF
--- a/include/gpac/internal/isomedia_dev.h
+++ b/include/gpac/internal/isomedia_dev.h
@@ -2100,16 +2100,16 @@ u32  gf_isom_sample_get_subsample_entry(GF_ISOFile *movie, u32 track, u32 sample
 GF_Err gf_isom_add_subsample_info(GF_SubSampleInformationBox *sub_samples, u32 sampleNumber, u32 subSampleSize, u8 priority, u32 reserved, Bool discardable);
 #endif
 
-/* Use to relate the composition and decoding timeline when signed composition is used*/
+/* Use to relate the composition and decoding timeline when signed composition is used */
 typedef struct
 {
 	GF_ISOM_FULL_BOX
 
-	s32 compositionToDTSShift;
-	s32 leastDecodeToDisplayDelta;
-	s32 greatestDecodeToDisplayDelta;
-	s32 compositionStartTime;
-	s32 compositionEndTime;
+	s64 compositionToDTSShift;
+	s64 leastDecodeToDisplayDelta;
+	s64 greatestDecodeToDisplayDelta;
+	s64 compositionStartTime;
+	s64 compositionEndTime;
 } GF_CompositionToDecodeBox;
 
 typedef struct

--- a/src/isomedia/box_code_base.c
+++ b/src/isomedia/box_code_base.c
@@ -494,13 +494,24 @@ GF_Err cslg_box_read(GF_Box *s, GF_BitStream *bs)
 {
 	GF_CompositionToDecodeBox *ptr = (GF_CompositionToDecodeBox *)s;
 
-	ISOM_DECREASE_SIZE(ptr, 20);
-	ptr->compositionToDTSShift = gf_bs_read_int(bs, 32);
-	ptr->leastDecodeToDisplayDelta = gf_bs_read_int(bs, 32);
-	ptr->greatestDecodeToDisplayDelta = gf_bs_read_int(bs, 32);
-	ptr->compositionStartTime = gf_bs_read_int(bs, 32);
-	ptr->compositionEndTime = gf_bs_read_int(bs, 32);
-	return GF_OK;
+	if (s->version == 0) {
+		ISOM_DECREASE_SIZE(ptr, 20);
+		ptr->compositionToDTSShift = gf_bs_read_int(bs, 32);
+		ptr->leastDecodeToDisplayDelta = gf_bs_read_int(bs, 32);
+		ptr->greatestDecodeToDisplayDelta = gf_bs_read_int(bs, 32);
+		ptr->compositionStartTime = gf_bs_read_int(bs, 32);
+		ptr->compositionEndTime = gf_bs_read_int(bs, 32);
+		return GF_OK;
+	} else if (s->version == 1) {
+		ISOM_DECREASE_SIZE(ptr, 40);
+		ptr->compositionToDTSShift = gf_bs_read_int(bs, 64);
+		ptr->leastDecodeToDisplayDelta = gf_bs_read_int(bs, 64);
+		ptr->greatestDecodeToDisplayDelta = gf_bs_read_int(bs, 64);
+		ptr->compositionStartTime = gf_bs_read_int(bs, 64);
+		ptr->compositionEndTime = gf_bs_read_int(bs, 64);
+		return GF_OK;
+	}
+	return GF_NOT_SUPPORTED;
 }
 
 GF_Box *cslg_box_new()
@@ -518,20 +529,36 @@ GF_Err cslg_box_write(GF_Box *s, GF_BitStream *bs)
 
 	e = gf_isom_full_box_write(s, bs);
 	if (e) return e;
-	gf_bs_write_int(bs, ptr->compositionToDTSShift, 32);
-	gf_bs_write_int(bs, ptr->leastDecodeToDisplayDelta, 32);
-	gf_bs_write_int(bs, ptr->greatestDecodeToDisplayDelta, 32);
-	gf_bs_write_int(bs, ptr->compositionStartTime, 32);
-	gf_bs_write_int(bs, ptr->compositionEndTime, 32);
-	return GF_OK;
+	if (s->version == 0) {
+		gf_bs_write_int(bs, ptr->compositionToDTSShift, 32);
+		gf_bs_write_int(bs, ptr->leastDecodeToDisplayDelta, 32);
+		gf_bs_write_int(bs, ptr->greatestDecodeToDisplayDelta, 32);
+		gf_bs_write_int(bs, ptr->compositionStartTime, 32);
+		gf_bs_write_int(bs, ptr->compositionEndTime, 32);
+		return GF_OK;
+	} else if (s->version == 1) {
+		gf_bs_write_long_int(bs, ptr->compositionToDTSShift, 64);
+		gf_bs_write_long_int(bs, ptr->leastDecodeToDisplayDelta, 64);
+		gf_bs_write_long_int(bs, ptr->greatestDecodeToDisplayDelta, 64);
+		gf_bs_write_long_int(bs, ptr->compositionStartTime, 64);
+		gf_bs_write_long_int(bs, ptr->compositionEndTime, 64);
+		return GF_OK;
+	}
+	return GF_NOT_SUPPORTED;
 }
 
 GF_Err cslg_box_size(GF_Box *s)
 {
 	GF_CompositionToDecodeBox *ptr = (GF_CompositionToDecodeBox *)s;
+	if (s->version == 0) {
+		ptr->size += 20;
+		return GF_OK;
+	} else if (s->version == 1) {
+		ptr->size += 40;
+		return GF_OK;
+	}
+	return GF_NOT_SUPPORTED;
 
-	ptr->size += 20;
-	return GF_OK;
 }
 #endif /*GPAC_DISABLE_ISOM_WRITE*/
 


### PR DESCRIPTION
This adds version 1 support for the CompositionToDecodeBox (`cslg`) as described in ISO/IEC 14496-12:2022 Section 8.6.1.4.

This is used by the GStreamer rust muxer, and is not properly parsed. Instead, there is a command line warning about 20 extra bytes.