### PR TITLE
Fix purging LL DASH/HLS with SF mode, as fragment number start from zero

### DIFF
--- a/src/filters/dasher.c
+++ b/src/filters/dasher.c
@@ -4733,7 +4733,7 @@ static void dasher_purge_segments(GF_DasherCtx *ctx, u64 *period_dur)
 					u32 k;
 					for (k=0; k<sctx->nb_frags; k++) {
 						char szTmp[100];
-						sprintf(szTmp, ".%u", k+1);
+						sprintf(szTmp, ".%u", k);
 						char *frag_url = gf_strdup(sctx->filepath);
 						gf_dynstrcat(&frag_url, szTmp, NULL);
 						evt.file_del.url = frag_url;
@@ -10557,7 +10557,7 @@ static Bool dasher_process_event(GF_Filter *filter, const GF_FilterEvent *evt)
 						for (k=0; k<prev_sctx->nb_frags; k++) {
 							GF_FilterEvent anevt;
 							char szPath[GF_MAX_PATH];
-							sprintf(szPath, "%s.%d", prev_sctx->filepath, k+1);
+							sprintf(szPath, "%s.%d", prev_sctx->filepath, k);
 							GF_FEVT_INIT(anevt, GF_FEVT_FILE_DELETE, ds->opid);
 							anevt.file_del.url = szPath;
 							gf_filter_pid_send_event(ds->opid, &anevt);


### PR DESCRIPTION
This fix the bug of purging old segment in dynamic live mode with low latency and separated file enabled