### PR TITLE
ddts_box_dump: fix start element name, ensure attributs end with '>'

### DIFF
--- a/src/isomedia/box_dump.c
+++ b/src/isomedia/box_dump.c
@@ -6986,12 +6986,12 @@ GF_Err ddts_box_dump(GF_Box *a, FILE * trace)
 {
 	GF_DTSSpecificBox *ptr = (GF_DTSSpecificBox *)a;
 
-	gf_isom_box_dump_start(a, "DTSpecificBox", trace);
+	gf_isom_box_dump_start(a, "DTSSpecificBox", trace);
 	gf_fprintf(trace, "SamplingFrequency=\"%d\" MaxBitrate=\"%d\" AvgBitrate=\"%d\" "
 		"SampleDepth=\"%d\" FrameDuration=\"%d\" StreamConstruction=\"%d\" "
 		"CoreLFEPresent=\"%d\" CoreLayout=\"%d\" CoreSize=\"%d\" StereoDownmix=\"%d\" "
 		"RepresentationType=\"%d\" ChannelLayout=\"%d\" MultiAssetFlag=\"%d\" "
-		"LBRDurationMod=\"%d\"",
+		"LBRDurationMod=\"%d\">\n",
 		ptr->cfg.SamplingFrequency, ptr->cfg.MaxBitrate, ptr->cfg.AvgBitrate,
 		ptr->cfg.SampleDepth, ptr->cfg.FrameDuration, ptr->cfg.StreamConstruction,
 		ptr->cfg.CoreLFEPresent, ptr->cfg.CoreLayout, ptr->cfg.CoreSize,


### PR DESCRIPTION
When dumping a mp4 file with DTS boxes, using `-diso` the resulting `_info.xml` file has invalid XML syntax. Report from `xmllint`:

```text
-:32: parser error : attributes construct error
 RepresentationType="4" ChannelLayout="15" MultiAssetFlag="0" LBRDurationMod="0"
                                                                               ^
-:32: parser error : Couldn't find end of Start Tag DTSpecificBox line 32
 RepresentationType="4" ChannelLayout="15" MultiAssetFlag="0" LBRDurationMod="0"
                                                                               ^
-:32: parser error : Opening and ending tag mismatch: AudioSampleDescriptionBox line 31 and DTSSpecificBox
ype="4" ChannelLayout="15" MultiAssetFlag="0" LBRDurationMod="0"</DTSSpecificBox
                                                                               ^
```

There are two problems:
* The opening element name is misspelled `DTSpecificBox`, which should be `DTSSpecificBox`
* The element is not properly terminated with a `>` character
