### PR TITLE
Fix kind box in gf_isom_get_user_data function

### DIFF
--- a/src/isomedia/isom_read.c
+++ b/src/isomedia/isom_read.c
@@ -2821,15 +2821,21 @@ found:
 			memcpy(*userData, p_uuid->data, sizeof(char)*p_uuid->dataSize);
 			*userDataSize = p_uuid->dataSize;
 			return GF_OK;
+		} else if (ptr->type == GF_ISOM_BOX_TYPE_KIND) {
+			GF_KindBox *kind = (GF_KindBox *)ptr;
+			u32 lenSchemeURI = (u32) strlen(kind->schemeURI) + 1;
+			u32 lenValue = (u32) strlen(kind->value) + 1;
+			*userData = (char *)gf_malloc(sizeof(char) * (lenSchemeURI+lenValue));
+			if (!*userData) return GF_OUT_OF_MEM;
+			memcpy(*userData, kind->schemeURI, sizeof(char)*lenSchemeURI);
+			memcpy(*userData + lenSchemeURI, kind->value, sizeof(char)*lenValue);
+			return GF_OK;
 		} else {
 			char *str = NULL;
 			switch (ptr->type) {
 			case GF_ISOM_BOX_TYPE_NAME:
 			//case GF_QT_BOX_TYPE_NAME: same as above
 				str = ((GF_NameBox *)ptr)->string;
-				break;
-			case GF_ISOM_BOX_TYPE_KIND:
-				str = ((GF_KindBox *)ptr)->value;
 				break;
 			}
 			if (str) {


### PR DESCRIPTION
I tried to use MP4box to cut an MP4 audio file (MP4Box -splitx 0:30 ...) and the kind box (moov/trak/udta/kind) of my input was not copied correctly to the output; the schemeURI was missing making it impossible to play.

This PR fixes this case.