### PR TITLE
Make sure that `impa` boxes are sorted by item id

### DIFF
--- a/src/isomedia/isom_write.c
+++ b/src/isomedia/isom_write.c
@@ -8710,18 +8710,21 @@ GF_Err gf_isom_apply_box_patch(GF_ISOFile *file, GF_ISOTrackID globalTrackID, co
 						if (!item_id) {
 							GF_LOG(GF_LOG_WARNING, GF_LOG_CONTAINER, ("[ISOBMFF] Inserting box in ipco without itemID, no association added\n"));
 						} else if (ipma) {
-							u32 nb_asso, k;
+							u32 nb_asso, k, insert_pos;
 							GF_ItemPropertyAssociationEntry *entry = NULL;
 							nb_asso = gf_list_count(ipma->entries);
+							insert_pos = 0;
 							for (k=0; k<nb_asso;k++) {
 								entry = gf_list_get(ipma->entries, k);
 								if (entry->item_id==item_id) break;
+								// item ids must appear in increasing order
+								if (item_id>entry->item_id) ++insert_pos;
 								entry = NULL;
 							}
 							if (!entry) {
 								GF_SAFEALLOC(entry, GF_ItemPropertyAssociationEntry);
 								if (!entry) return GF_OUT_OF_MEM;
-								gf_list_add(ipma->entries, entry);
+								gf_list_insert(ipma->entries, entry, insert_pos);
 								entry->item_id = item_id;
 							}
 							entry->associations = gf_realloc(entry->associations, sizeof(GF_ItemPropertyAssociationSlot) * (entry->nb_associations+1));

--- a/src/isomedia/meta.c
+++ b/src/isomedia/meta.c
@@ -989,19 +989,22 @@ static s32 meta_find_prop(GF_ItemPropertyContainerBox *boxes, GF_ImageItemProper
 }
 
 static GF_Err meta_add_item_property_association(GF_ItemPropertyAssociationBox *ipma, u32 item_ID, u32 prop_index, Bool essential) {
-	u32 i, count;
+	u32 i, count, insert_pos;
 	GF_ItemPropertyAssociationEntry *found_entry = NULL;
 
 	count = gf_list_count(ipma->entries);
+	insert_pos = 0;
 	for (i = 0; i < count; i++) {
 		found_entry = (GF_ItemPropertyAssociationEntry *)gf_list_get(ipma->entries, i);
 		if (found_entry->item_id == item_ID) break;
+		// item ids must appear in increasing order
+		if (item_ID > found_entry->item_id) ++insert_pos;
 		found_entry = NULL;
 	}
 	if (!found_entry) {
 		GF_SAFEALLOC(found_entry, GF_ItemPropertyAssociationEntry);
 		if (!found_entry) return GF_OUT_OF_MEM;
-		gf_list_add(ipma->entries, found_entry);
+		gf_list_insert(ipma->entries, found_entry, insert_pos);
 		found_entry->item_id = item_ID;
 	}
 	found_entry->associations = gf_realloc(found_entry->associations, sizeof(GF_ItemPropertyAssociationSlot) * (found_entry->nb_associations+1));


### PR DESCRIPTION
From the HEIF specification (ISO/IEC 14496-12:2022), Section 8.11.14.1:

> Each ItemPropertyAssociationBox shall be ordered by increasing item_ID, and there shall
> be at most one occurrence of a given item_ID, in the set of ItemPropertyAssociationBox
> boxes.