### PR TITLE
add support for dumping unregistered SEI with timecode extraction

### DIFF
--- a/src/filters/inspect.c
+++ b/src/filters/inspect.c
@@ -587,7 +587,7 @@ static void dump_unregistered_sei(FILE *dump, GF_BitStream *bs, u32 sei_size)
 	//uuid
 	u32 i;
 	bin128 uuid = {0};
-	inspect_printf(dump, " uuid=\"");
+	inspect_printf(dump, " uuid=\"0x");
 	for (i=0; i<16; i++) {
 		uuid[i] = gf_bs_read_u8(bs);
 		inspect_printf(dump, "%02x", uuid[i]);
@@ -598,7 +598,7 @@ static void dump_unregistered_sei(FILE *dump, GF_BitStream *bs, u32 sei_size)
 	u32 nb_read = 0;
 	u8 *payload = gf_malloc(sei_size - 16);
 	if (!payload) return;
-	inspect_printf(dump, " payload=\"");
+	inspect_printf(dump, " payload=\"0x");
 	for (i=0; i<sei_size - 16 && gf_bs_available(bs); i++) {
 		payload[i] = gf_bs_read_u8(bs);
 		inspect_printf(dump, "%02x", payload[i]);

--- a/src/filters/inspect.c
+++ b/src/filters/inspect.c
@@ -606,7 +606,7 @@ static void dump_unregistered_sei(FILE *dump, GF_BitStream *bs, u32 sei_size)
 	}
 	inspect_printf(dump, "\"");
 
-	if (nb_read != sei_size - 16) {
+	if (nb_read < sei_size - 16) {
 		GF_LOG(GF_LOG_ERROR, GF_LOG_CONTAINER, ("Not enough data in unregistered SEI\n"));
 		goto finish;
 	}
@@ -617,7 +617,7 @@ static void dump_unregistered_sei(FILE *dump, GF_BitStream *bs, u32 sei_size)
 			goto finish;
 		}
 		inspect_printf(dump, " timecode=\"");
-		inspect_printf(dump, "%02x:%02x:%02x:%02x", payload[3], payload[2], payload[1], payload[0]);
+		inspect_printf(dump, "%02u:%02u:%02u:%02u", payload[3], payload[2], payload[1], payload[0]);
 		inspect_printf(dump, "\"");
 	}
 

--- a/src/filters/inspect.c
+++ b/src/filters/inspect.c
@@ -612,6 +612,10 @@ static void dump_unregistered_sei(FILE *dump, GF_BitStream *bs, u32 sei_size)
 	}
 
 	if (!memcmp(uuid, tmcd_uuid, 16)) {
+		if (nb_read < 4) {
+			GF_LOG(GF_LOG_ERROR, GF_LOG_CONTAINER, ("Not enough data in timecode unregistered SEI\n"));
+			goto finish;
+		}
 		inspect_printf(dump, " timecode=\"");
 		inspect_printf(dump, "%02x:%02x:%02x:%02x", payload[3], payload[2], payload[1], payload[0]);
 		inspect_printf(dump, "\"");


### PR DESCRIPTION
linked gpac/testsuite#28