### PR TITLE
`bsrw` timecode manipulation

### DIFF
--- a/include/gpac/internal/media_dev.h
+++ b/include/gpac/internal/media_dev.h
@@ -328,6 +328,8 @@ typedef struct
 	Bool remove_video_info;
 	//if set timing info is removed
 	Bool remove_vui_timing_info;
+	//if set pic_struct is enabled
+	Bool enable_pic_struct;
 	//new fullrange, -1 to use info from bitstream
 	s32 fullrange;
 	//new vidformat flag, -1 to use info from bitstream

--- a/include/gpac/internal/media_dev.h
+++ b/include/gpac/internal/media_dev.h
@@ -285,6 +285,7 @@ typedef struct
 {
 	Bool is_whitelist;
 	GF_PropUIntList seis;
+	s32 extra_filter; //- removes the sei, + keeps the sei
 } SEI_Filter;
 
 

--- a/include/gpac/internal/media_dev.h
+++ b/include/gpac/internal/media_dev.h
@@ -234,6 +234,7 @@ typedef struct
 	u16 n_frames;
 	Float max_fps;
 	u8 counting_type;
+	Bool clock_timestamp_flag;
 } AVCSeiPicTimingTimecode;
 
 typedef struct

--- a/include/gpac/tools.h
+++ b/include/gpac/tools.h
@@ -449,6 +449,56 @@ Formats a timecode into a string
 */
 const char* gf_format_timecode(GF_TimeCode *tc, char szTimecode[100]);
 
+/*!
+\brief compare timecodes
+
+Compares two timecodes
+\param value1 value to compare
+\param value2 value to compare
+\return GF_TRUE if value1 is stricly less than value2
+ */
+Bool gf_timecode_less(GF_TimeCode *value1, GF_TimeCode *value2);
+
+/*!
+\brief compare timecodes
+
+Compares two timecodes
+\param value1 value to compare
+\param value2 value to compare
+\return GF_TRUE if value1 is stricly less than or equal to value2
+ */
+Bool gf_timecode_less_or_equal(GF_TimeCode *value1, GF_TimeCode *value2);
+
+/*!
+\brief compare timecodes
+
+Compares two timecodes
+\param value1 value to compare
+\param value2 value to compare
+\return GF_TRUE if value1 is stricly greater than value2
+ */
+Bool gf_timecode_greater(GF_TimeCode *value1, GF_TimeCode *value2);
+
+/*!
+\brief compare timecodes
+
+Compares two timecodes
+\param value1 value to compare
+\param value2 value to compare
+\return GF_TRUE if value1 is stricly greater than or equal to value2
+ */
+Bool gf_timecode_greater_or_equal(GF_TimeCode *value1, GF_TimeCode *value2);
+
+/*!
+\brief compare timecodes
+
+Compares two timecodes
+\param value1 value to compare
+\param value2 value to compare
+\return GF_TRUE if value1 is equal to value2
+ */
+Bool gf_timecode_equal(GF_TimeCode *value1, GF_TimeCode *value2);
+
 /*! @} */
 
 /*!

--- a/include/gpac/tools.h
+++ b/include/gpac/tools.h
@@ -435,7 +435,7 @@ typedef struct
 	u8 hours, minutes, seconds;
 	u16 n_frames;
 	Float max_fps;
-	Bool drop_frame;
+	Bool drop_frame, negative;
 	u32 as_timestamp;
 } GF_TimeCode;
 

--- a/src/filters/bsrw.c
+++ b/src/filters/bsrw.c
@@ -548,6 +548,7 @@ static GF_Err nalu_rewrite_packet(GF_BSRWCtx *ctx, BSRWPid *pctx, GF_FilterPacke
 	gf_bs_read_data(bs_w, output, pck_size);
 
 	//cleanup
+	gf_free(tc_in);
 	gf_free(rw_sei_payload);
 	gf_bs_del(bs_w);
 	gf_bs_del(bs);

--- a/src/filters/bsrw.c
+++ b/src/filters/bsrw.c
@@ -447,12 +447,18 @@ static GF_Err nalu_rewrite_packet(GF_BSRWCtx *ctx, BSRWPid *pctx, GF_FilterPacke
 			gf_bs_write_int(bs_w, 0/*time_offset_length*/, 5);
 		}
 
-		gf_bs_write_int(bs_w, 0x80, 8);
+		//align to byte boundary
 		gf_bs_align(bs_w);
 
-		//write the SEI size
+		//store the payload size
 		u64 pos = gf_bs_get_position(bs_w);
-		u32 sei_size = pos - size_pos - 1;
+		u64 sei_size = pos - size_pos - 1;
+
+		//trailing bits
+		gf_bs_write_int(bs_w, 0x80, 8);
+
+		//write the SEI size
+		pos = gf_bs_get_position(bs_w);
 		gf_bs_seek(bs_w, size_pos);
 		gf_bs_write_int(bs_w, sei_size, 8);
 

--- a/src/filters/bsrw.c
+++ b/src/filters/bsrw.c
@@ -139,8 +139,8 @@ static Bool bsrw_manipulate_tc(GF_FilterPacket *pck, GF_BSRWCtx *ctx, BSRWPid *p
 	}
 
 	//get the current timecode components
-	u64 cts = gf_timestamp_rescale(gf_filter_pck_get_cts(pck), pctx->fps.den * gf_filter_pck_get_timescale(pck), pctx->fps.num);
-	u16 n_frames = (cts * pctx->fps.den) % pctx->fps.num;
+	u64 cts = gf_timestamp_rescale(gf_filter_pck_get_cts(pck), (u64) pctx->fps.den * gf_filter_pck_get_timescale(pck), pctx->fps.num);
+	u64 n_frames = (cts * pctx->fps.den) % pctx->fps.num;
 	n_frames /= pctx->fps.den;
 	cts = cts * pctx->fps.den / pctx->fps.num;
 	u8 seconds = cts % 60;

--- a/src/filters/bsrw.c
+++ b/src/filters/bsrw.c
@@ -947,6 +947,7 @@ GF_FilterRegister BSRWRegister = {
 	"  - profile, level, profile compatibility\n"
 	"  - video format, video fullrange\n"
 	"  - color primaries, transfer characteristics and matrix coefficients (or remove all info)\n"
+	"  - (HEVC|VVC only) timecode"
 	"- AV1:\n"
 	"  - timecode\n"
 	"- ProRes:\n"

--- a/src/filters/bsrw.c
+++ b/src/filters/bsrw.c
@@ -936,11 +936,6 @@ static GF_Err vvc_rewrite_pid_config(GF_BSRWCtx *ctx, BSRWPid *pctx)
 	u32 dsi_size;
 	const GF_PropertyValue *prop;
 
-	if (ctx->tc) {
-		GF_LOG(GF_LOG_WARNING, GF_LOG_MEDIA, ("[BSRW] Timecode manipulation is not supported for VVC\n"));
-		return GF_BAD_PARAM;
-	}
-
 	prop = gf_filter_pid_get_property(pctx->ipid, GF_PROP_PID_DECODER_CONFIG);
 	if (!prop) return GF_OK;
 	pctx->reconfigure = GF_FALSE;
@@ -966,7 +961,7 @@ static GF_Err vvc_rewrite_pid_config(GF_BSRWCtx *ctx, BSRWPid *pctx)
 
 	gf_filter_pid_set_property(pctx->opid, GF_PROP_PID_DECODER_CONFIG, &PROP_DATA_NO_COPY(dsi, dsi_size) );
 
-	if (ctx->rmsei || ctx->seis.nb_items || ctx->tc) {
+	if (ctx->rmsei || ctx->seis.nb_items) {
 		pctx->rewrite_packet = vvc_rewrite_packet;
 	} else {
 		pctx->rewrite_packet = none_rewrite_packet;

--- a/src/filters/bsrw.c
+++ b/src/filters/bsrw.c
@@ -175,8 +175,10 @@ static GF_Err nalu_rewrite_packet(GF_BSRWCtx *ctx, BSRWPid *pctx, GF_FilterPacke
 		}
 		gf_bs_seek(bs, pos + nal_size);
 	}
-	if (!is_sei)
+	if (!is_sei) {
+		gf_bs_del(bs);
 		return gf_filter_pck_forward(pck, pctx->opid);
+	}
 
 	SEI_Filter sei_filter = {
 		.is_whitelist = !ctx->rmsei,
@@ -324,6 +326,8 @@ static GF_Err nalu_rewrite_packet(GF_BSRWCtx *ctx, BSRWPid *pctx, GF_FilterPacke
 	//copy the new data
 	gf_bs_seek(bs_w, 0);
 	gf_bs_read_data(bs_w, output, pck_size);
+
+	//cleanup
 	gf_free(rw_sei_payload);
 	gf_bs_del(bs_w);
 	gf_bs_del(bs);

--- a/src/filters/inspect.c
+++ b/src/filters/inspect.c
@@ -5472,6 +5472,11 @@ GF_Err inspect_initialize(GF_Filter *filter)
 		ctx->mode = INSPECT_MODE_REFRAME;
 	}
 
+	//force reframer if working with "tmcd"
+	if (ctx->fmt && strstr(ctx->fmt, "$tmcd$") && (ctx->mode!=INSPECT_MODE_RAW)) {
+		ctx->mode = INSPECT_MODE_REFRAME;
+	}
+
 	switch (ctx->mode) {
 	case INSPECT_MODE_RAW:
 		gf_filter_override_caps(filter, InspecterRawCaps,  sizeof(InspecterRawCaps)/sizeof(GF_FilterCapability) );

--- a/src/media_tools/av_parsers.c
+++ b/src/media_tools/av_parsers.c
@@ -6530,8 +6530,10 @@ static s32 avc_parse_pic_timing_sei(GF_BitStream *bs, AVCState *avc)
 
 		pt->num_clock_ts = NumClockTS[pt->pic_struct];
 		for (i = 0; i < NumClockTS[pt->pic_struct]; i++) {
-			if (gf_bs_read_int_log_idx(bs, 1, "clock_timestamp_flag", i)) {
+			Bool clock_timestamp_flag = gf_bs_read_int_log_idx(bs, 1, "clock_timestamp_flag", i);
+			if (clock_timestamp_flag) {
 				AVCSeiPicTimingTimecode *tc = &pt->timecodes[i];
+				tc->clock_timestamp_flag = clock_timestamp_flag;
 				gf_bs_read_int_log_idx(bs, 2, "ct_type", i);
 				Bool unit_field_based_flag = gf_bs_read_int_log_idx(bs, 1, "unit_field_based_flag", i);
 				tc->counting_type = gf_bs_read_int_log_idx(bs, 5, "counting_type", i);
@@ -6579,9 +6581,9 @@ static s32 hevc_parse_pic_timing_sei(GF_BitStream *bs, HEVCState *hevc)
 	for (int i = 0; i < pt->num_clock_ts; i++) {
 		Bool clock_timestamp_flag = gf_bs_read_int(bs, 1);
 		if (clock_timestamp_flag) {
-			Bool unit_field_based_flag = gf_bs_read_int_log_idx(bs, 1, "units_field_based_flag", i);
-
 			AVCSeiPicTimingTimecode *tc = &pt->timecodes[i];
+			tc->clock_timestamp_flag = clock_timestamp_flag;
+			Bool unit_field_based_flag = gf_bs_read_int_log_idx(bs, 1, "units_field_based_flag", i);
 			tc->counting_type = gf_bs_read_int_log_idx(bs, 5, "counting_type", i);
 			Bool full_timestamp_flag = gf_bs_read_int(bs, 1);
 			gf_bs_read_int_log_idx(bs, 1, "discontinuity_flag", i);

--- a/src/media_tools/av_parsers.c
+++ b/src/media_tools/av_parsers.c
@@ -6970,6 +6970,8 @@ u32 gf_avc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, AVCState 
 					break;
 				}
 			}
+			if (sei_filter->extra_filter == -ptype)
+				do_copy = GF_FALSE;
 		}
 
 		start = (u32)gf_bs_get_position(bs);
@@ -8355,6 +8357,8 @@ u32 gf_hevc_vvc_reformat_sei(u8 *buffer, u32 nal_size, Bool isobmf_rewrite, Bool
 					break;
 				}
 			}
+			if (sei_filter->extra_filter == -ptype)
+				do_copy = GF_FALSE;
 		}
 
 		start = gf_bs_get_position(bs);

--- a/src/utils/constants.c
+++ b/src/utils/constants.c
@@ -2825,3 +2825,39 @@ const char* gf_format_timecode(GF_TimeCode *tc, char szTimecode[100])
 	snprintf(szTimecode, 99, "%02d:%02d:%02d%c%0*d", tc->hours, tc->minutes, tc->seconds, tc->drop_frame ? ';' : '.', frame_digits, tc->n_frames);
 	return szTimecode;
 }
+
+#define TIMECODE_COMPARE(_op) \
+	if (value1->hours != value2->hours) return value1->hours _op value2->hours; \
+	if (value1->minutes != value2->minutes) return value1->minutes _op value2->minutes; \
+	if (value1->seconds != value2->seconds) return value1->seconds _op value2->seconds; \
+	return value1->n_frames _op value2->n_frames;
+
+GF_EXPORT
+Bool gf_timecode_less(GF_TimeCode *value1, GF_TimeCode *value2)
+{
+	TIMECODE_COMPARE(<)
+}
+
+GF_EXPORT
+Bool gf_timecode_less_or_equal(GF_TimeCode *value1, GF_TimeCode *value2)
+{
+	TIMECODE_COMPARE(<=)
+}
+
+GF_EXPORT
+Bool gf_timecode_greater(GF_TimeCode *value1, GF_TimeCode *value2)
+{
+	TIMECODE_COMPARE(>)
+}
+
+GF_EXPORT
+Bool gf_timecode_greater_or_equal(GF_TimeCode *value1, GF_TimeCode *value2)
+{
+	TIMECODE_COMPARE(>=)
+}
+
+GF_EXPORT
+Bool gf_timecode_equal(GF_TimeCode *value1, GF_TimeCode *value2)
+{
+	TIMECODE_COMPARE(==)
+}


### PR DESCRIPTION
Add time_code (136) SEI to HEVC/AVC. And equivalent for AV1.

- **force reframer when working with timecodes**
- **move `tc` from `ufobu` to `bsrw` and support removing of tc**
