### PR TITLE
ffmx: forwarding to protocol without remuxing

### DIFF
--- a/applications/gpac/gpac_help.c
+++ b/applications/gpac/gpac_help.c
@@ -3259,7 +3259,6 @@ void dump_all_proto_schemes(GF_SysArgMode argmode)
 		for (i=0; i<count; i++) {
 			const char *f = gf_opts_get_key_name(sname, i);
 			if (!f) continue;
-			if ((argmode<GF_ARGMODE_EXPERT) && strchr(f, ':')) continue;
 
 			char *proto = (char*)gf_opts_get_key(sname, f);
 			if (!proto) continue;
@@ -3318,13 +3317,19 @@ void dump_all_proto_schemes(GF_SysArgMode argmode)
 				if (gen_doc!=1)
 					gf_sys_format_help(helpout, help_flags, " %s", lab);
 
-				if ((gen_doc==1) || (argmode==GF_ARGMODE_ADVANCED) || (argmode==GF_ARGMODE_ALL)) {
+				if ((gen_doc==1) || (argmode>=GF_ARGMODE_ADVANCED) || (argmode==GF_ARGMODE_ALL)) {
 					if (gen_doc!=1)
 						gf_sys_format_help(helpout, help_flags, " (");
 					for (j=0;j<c2; j++) {
 						char *f = gf_list_get(list, j);
 						if (j) gf_sys_format_help(helpout, help_flags, " ");
+						char *sep = NULL;
+						if (!gen_doc && (argmode==GF_ARGMODE_ADVANCED)) {
+							sep = strchr(f, ':');
+							if (sep) sep[0]=0;
+						}
 						gf_sys_format_help(helpout, help_flags, "%s", f);
+						if (sep) sep[0]=':';
 					}
 					if (gen_doc!=1)
 						gf_sys_format_help(helpout, help_flags, ")");

--- a/include/gpac/constants.h
+++ b/include/gpac/constants.h
@@ -183,7 +183,7 @@ typedef enum
 	/*!RGB24 + depth plane (7 lower bits) + shape mask. Component ordering in bytes is R-G-B-(S+D).*/
 	GF_PIXEL_RGBDS		=	GF_4CC('3', 'C', 'D', 'S'),
 
-	/*internal format for OpenGL using pachek RGB 24 bit plus planar depth plane at the end of the image*/
+	/*internal format for OpenGL using packed RGB 24 bit plus planar depth plane at the end of the image*/
 	GF_PIXEL_RGB_DEPTH = GF_4CC('R', 'G', 'B', 'd'),
 
 	/*generic pixel format uncv from ISO/IEC 23001-17*/

--- a/src/filters/ff_dmx.c
+++ b/src/filters/ff_dmx.c
@@ -59,13 +59,13 @@ typedef struct
 typedef struct
 {
 	//options
-	const char *src;
+	const char *src, *ext, *mime;
 	u32 block_size;
 	GF_FFDemuxRawFrameCopyMode copy;
 	u32 probes;
 	Bool sclock;
 	const char *fmt, *dev;
-	Bool reparse;
+	Bool reparse, proto;
 
 	//internal data
 	const char *fname;
@@ -115,6 +115,12 @@ typedef struct
 	Bool in_eos, first_block;
 	s64 seek_offset;
 	u64 seek_ms;
+
+	//for ffdmx in proto mode
+	GF_FilterPid *opid;
+	GF_PropVec2i mwait;
+	u64 rcv_time_diff, last_pck_time;
+
 } GF_FFDemuxCtx;
 
 static void ffdmx_finalize(GF_Filter *filter)
@@ -451,6 +457,80 @@ static GF_Err ffdmx_process(GF_Filter *filter)
 	PidCtx *pctx;
 	int res;
 	GF_FFDemuxCtx *ctx = (GF_FFDemuxCtx *) gf_filter_get_udta(filter);
+
+	if (ctx->proto) {
+		u64 rcv_time = gf_sys_clock_high_res();
+		u32 nb_pck = 100;
+		while (nb_pck) {
+			u8 const_data[1880];
+			u8 *data = const_data;
+			u32 data_size = 1880;
+			GF_FilterPacket *pck = NULL;
+			if (ctx->opid) {
+				pck = gf_filter_pck_new_alloc(ctx->opid, ctx->block_size, &data);
+				if (!pck) return GF_OUT_OF_MEM;
+				data_size = ctx->block_size;
+			}
+
+			int size = avio_read_partial(ctx->avio_ctx, data, data_size);
+			if (!size)
+				size = ctx->avio_ctx->error;
+
+			if (size<0) {
+				if (ctx->avio_ctx->error == AVERROR(EAGAIN)) {
+					if (pck) gf_filter_pck_discard(pck);
+					//looks like some proto handlers set EOF when no packets and avio_read* will not attempt to read when flag is set
+					ctx->avio_ctx->eof_reached = 0;
+
+					u64 sleep_for = 2*ctx->rcv_time_diff/3000;
+					if (sleep_for > ctx->mwait.y) sleep_for = ctx->mwait.y;
+					if (sleep_for < ctx->mwait.x) sleep_for = ctx->mwait.x;
+					GF_LOG(GF_LOG_DEBUG, GF_LOG_NETWORK, ("[FFDMX] empty (got %u pck) - sleeping for "LLU" ms\n", nb_pck, sleep_for ));
+					gf_filter_ask_rt_reschedule(filter, sleep_for*1000);
+					return GF_OK;
+				}
+				if (ctx->avio_ctx->eof_reached) {
+					if (pck) gf_filter_pck_discard(pck);
+					if (ctx->opid)
+						gf_filter_pid_set_eos(ctx->opid);
+					return GF_EOS;
+				}
+				if (ctx->avio_ctx->error) {
+					if (pck) gf_filter_pck_discard(pck);
+					GF_LOG(GF_LOG_ERROR, GF_LOG_NETWORK, ("[FFDMX] Read error %s - aborting\n", av_err2str(ctx->avio_ctx->error)));
+					return GF_IO_ERR;
+				}
+			}
+			if (rcv_time) {
+				if (ctx->last_pck_time) {
+					ctx->rcv_time_diff = rcv_time - ctx->last_pck_time;
+				}
+				ctx->last_pck_time = rcv_time;
+				rcv_time = 0;
+			}
+
+			if (!ctx->opid) {
+				GF_Err e = gf_filter_pid_raw_new(filter, ctx->src, NULL, ctx->mime, ctx->ext, data, size, GF_FALSE, &ctx->opid);
+				if (e) {
+					if (pck) gf_filter_pck_discard(pck);
+					gf_filter_setup_failure(filter, e);
+					return e;
+				}
+			}
+			if (pck) {
+				gf_filter_pck_truncate(pck, size);
+			} else {
+				u8 *output;
+				pck = gf_filter_pck_new_alloc(ctx->opid, size, &output);
+				if (!pck) return GF_OUT_OF_MEM;
+				memcpy(output, data, size);
+				gf_filter_pck_set_framing(pck, GF_TRUE, GF_FALSE);
+			}
+			gf_filter_pck_send(pck);
+			nb_pck--;
+		}
+		return GF_OK;
+	}
 
 restart:
 	if (ctx->ipid) {
@@ -1363,6 +1443,19 @@ static GF_Err ffdmx_initialize(GF_Filter *filter)
 
 	GF_LOG(GF_LOG_DEBUG, ctx->log_class, ("[%s] opening file %s - av_in %08x\n", ctx->fname, ctx->src, av_in));
 
+	if (ctx->proto) {
+		//special mode: open protocol and bypass demuxer
+		AVDictionary *opts = NULL;
+		int ret = avio_open2(&ctx->avio_ctx, ctx->src, AVIO_FLAG_READ|AVIO_FLAG_NONBLOCK|AVIO_FLAG_DIRECT, NULL, &opts);
+		av_dict_free(&opts);
+		if (ret < 0) {
+			GF_LOG(GF_LOG_ERROR, GF_LOG_CONTAINER, ("[FFMux] Failed to open protocol URL %s, cannot run\n", ctx->src));
+			return GF_SERVICE_ERROR;
+		}
+		return GF_OK;
+	}
+
+
 	ctx->demuxer = avformat_alloc_context();
 	ffmpeg_set_mx_dmx_flags(ctx->options, ctx->demuxer);
 
@@ -1742,6 +1835,9 @@ static const GF_FilterCapability FFDmxCaps[] =
 	CAP_UINT(GF_CAPS_OUTPUT,GF_PROP_PID_STREAM_TYPE, GF_STREAM_VISUAL),
 	CAP_BOOL(GF_CAPS_OUTPUT,GF_PROP_PID_FORCE_UNFRAME, GF_TRUE),
 	CAP_BOOL(GF_CAPS_OUTPUT,GF_PROP_PID_UNFRAMED, GF_TRUE),
+	{0},
+	//for raw protocol access
+	CAP_UINT(GF_CAPS_OUTPUT,GF_PROP_PID_STREAM_TYPE, GF_STREAM_FILE),
 };
 
 
@@ -1755,6 +1851,13 @@ GF_FilterRegister FFDemuxRegister = {
 	"This will list both supported input formats and protocols.\n"
 	"Input protocols are listed with `Description: Input protocol`, and the subclass name identifies the protocol scheme.\n"
 	"For example, if `ffdmx:rtmp` is listed as input protocol, this means `rtmp://` source URLs are supported.\n"
+	"\n"
+	"# Raw protocol mode\n"
+	"The [-proto]() flag will disable FFmpeg demuxer and use GPAC instead. Default format is probed from initial data but can be set using [-ext]() or [-mime]() if probing is disabled.\n"
+	"EX gpac -i srt://127.0.0.1:1234:gpac:proto inspect"
+	"This will use the SRT protocol handler but GPAC demultiplexer\n"
+	"\n"
+	"In this mode, the filter uses the time between the last two received packets to estimates how often it should check for inputs. The maximum and minimum times to wait between two calls is given by the [-mwait]() option. The maximum time may need to be reduced for very high bitrates sources.\n"
 	)
 	.private_size = sizeof(GF_FFDemuxCtx),
 	SETCAPS(FFDmxCaps),
@@ -1777,6 +1880,11 @@ static const GF_FilterArgs FFDemuxArgs[] =
 	{ OFFS(reparse), "force reparsing of stream content (AVC,HEVC,VVC,AV1 only for now)", GF_PROP_BOOL, "false", NULL, 0},
 	{ OFFS(block_size), "block size used to read file when using GFIO context", GF_PROP_UINT, "4096", NULL, GF_FS_ARG_HINT_EXPERT},
 	{ OFFS(strbuf_min), "internal buffer size when demuxing from GPAC's input stream", GF_PROP_UINT, "1MB", NULL, GF_ARG_HINT_EXPERT},
+	{ OFFS(proto), "use protocol handler only and bypass FFmpeg demuxer", GF_PROP_BOOL, "false", NULL, GF_ARG_HINT_ADVANCED},
+	{ OFFS(mwait), "set min and max wait times in ms to avoid too frequent polling in proto mode", GF_PROP_VEC2I, "1x30", NULL, GF_FS_ARG_HINT_ADVANCED},
+	{ OFFS(ext), "indicate file extension of data in raw protocol mode", GF_PROP_STRING, NULL, NULL, 0},
+	{ OFFS(mime), "indicate mime type of data in raw protocol mode", GF_PROP_STRING, NULL, NULL, 0},
+
 	{ "*", -1, "any possible options defined for AVFormatContext and sub-classes. See `gpac -hx ffdmx` and `gpac -hx ffdmx:*`", GF_PROP_STRING, NULL, NULL, GF_FS_ARG_META},
 	{0}
 };

--- a/src/filters/ff_mx.c
+++ b/src/filters/ff_mx.c
@@ -505,20 +505,20 @@ static GF_Err ffmx_start_seg(GF_Filter *filter, GF_FFMuxCtx *ctx, const char *se
 	}
 	ctx->muxer->pb->seekable = 0;
 
-    if (ctx->muxer->oformat->priv_class && ctx->muxer->priv_data)
-        av_opt_set(ctx->muxer->priv_data, "mpegts_flags", "+resend_headers", 0);
+	if (ctx->muxer->oformat->priv_class && ctx->muxer->priv_data)
+		av_opt_set(ctx->muxer->priv_data, "mpegts_flags", "+resend_headers", 0);
 
-    if (ctx->ffiles) {
-        AVDictionary *options = NULL;
-        av_dict_copy(&options, ctx->options, 0);
-        av_dict_set(&options, "fflags", "-autobsf", 0);
-        res = avformat_write_header(ctx->muxer, &options);
+	if (ctx->ffiles) {
+		AVDictionary *options = NULL;
+		av_dict_copy(&options, ctx->options, 0);
+		av_dict_set(&options, "fflags", "-autobsf", 0);
+		res = avformat_write_header(ctx->muxer, &options);
 		if (options) av_dict_free(&options);
-        if (res < 0) {
+		if (res < 0) {
 			GF_LOG(GF_LOG_ERROR, GF_LOG_CONTAINER, ("[FFMux] Fail to configure segment %s - error %s\n", seg_name, av_err2str(res) ));
 			return GF_IO_ERR;
 		}
-    }
+	}
 	ctx->status = FFMX_STATE_HDR_DONE;
 	return GF_OK;
 }
@@ -958,14 +958,14 @@ static GF_Err ffmx_process(GF_Filter *filter)
 
 //dovi_meta.h not exported in old releases, just redefine
 typedef struct {
-    u8 dv_version_major;
-    u8 dv_version_minor;
-    u8 dv_profile;
-    u8 dv_level;
-    u8 rpu_present_flag;
-    u8 el_present_flag;
-    u8 bl_present_flag;
-    u8 dv_bl_signal_compatibility_id;
+	u8 dv_version_major;
+	u8 dv_version_minor;
+	u8 dv_profile;
+	u8 dv_level;
+	u8 rpu_present_flag;
+	u8 el_present_flag;
+	u8 bl_present_flag;
+	u8 dv_bl_signal_compatibility_id;
 } Ref_FFAVDoviRecord;
 
 
@@ -1392,8 +1392,8 @@ static GF_Err ffmx_configure_pid(GF_Filter *filter, GF_FilterPid *pid, Bool is_r
 			data->min_luminance.num = gf_bs_read_u32(bs);
 			data->min_luminance.den = luma_den;
 			av_stream_add_side_data(st->stream, AV_PKT_DATA_MASTERING_DISPLAY_METADATA, (u8*) data, sizeof(AVMasteringDisplayMetadata));
-    	}
-    	gf_bs_del(bs);
+		}
+		gf_bs_del(bs);
 	}
 	//dolby vision
 	p = gf_filter_pid_get_property(pid, GF_PROP_PID_DOLBY_VISION);

--- a/src/filters/ff_mx.c
+++ b/src/filters/ff_mx.c
@@ -364,7 +364,13 @@ static GF_Err ffmx_initialize_ex(GF_Filter *filter, Bool use_templates)
 		if (len>19) len=19;
 		strncpy(szProto, url, len);
 		szProto[len] = 0;
-		ofmt = av_guess_format(szProto, url, ctx->mime);
+		if (strncpy(szProto, "srt", len)) {
+			ofmt = av_guess_format("mpegts", url, ctx->mime);
+		} else if (strncpy(szProto, "rtmp", len)) {
+			ofmt = av_guess_format("flv", url, ctx->mime);
+		} else {
+			ofmt = av_guess_format(szProto, url, ctx->mime);
+		}
 	}
 	if (!ofmt) {
 		GF_LOG(GF_LOG_ERROR, GF_LOG_CONTAINER, ("[FFMux] Failed to guess output format for %s, cannot run\n", ctx->dst));

--- a/src/filters/mux_isom.c
+++ b/src/filters/mux_isom.c
@@ -5895,7 +5895,7 @@ static GF_Err mp4_mux_initialize_movie(GF_MP4MuxCtx *ctx)
 
 		pck = gf_filter_pid_get_packet(tkw->ipid);
 		if (!pck) {
-			//eos (wether real or flush event), continue setup
+			//eos (whether real or flush event), continue setup
 			if (gf_filter_pid_is_eos(tkw->ipid)) {
 				if (tkw->dgl_copy) {
 					gf_filter_pck_discard(tkw->dgl_copy);
@@ -6040,7 +6040,7 @@ static GF_Err mp4_mux_initialize_movie(GF_MP4MuxCtx *ctx)
 
 		mp4_mux_set_hevc_groups(ctx, tkw);
 
-		//use 1 for the default sample description index. If no multi stsd, this is always the case
+		//use GF_TRUE for the default sample description index. If no multi stsd, this is always the case
 		//otherwise we need to update the stsd idx in the traf headers
 		e = gf_isom_setup_track_fragment(ctx->file, tkw->track_id, tkw->stsd_idx, def_pck_dur, def_samp_size, def_is_rap, 0, 0, ctx->nofragdef ? GF_TRUE : GF_FALSE);
 		if (e) {
@@ -7290,7 +7290,7 @@ retry_pck:
 		}
 
 		if (!pck) {
-			//eos (wether real or flush event), setup cenc
+			//eos (whether real or flush event), setup cenc
 			if (gf_filter_pid_is_eos(tkw->ipid)) {
 				if (tkw->cenc_state==CENC_NEED_SETUP)
 					mp4_mux_cenc_update(ctx, tkw, NULL, CENC_CONFIG, 0, 0);


### PR DESCRIPTION
This PR introduces a new `proto` flag to the FFmpeg's [muxer](https://wiki.gpac.io/Filters/ffmx/) and [demuxer](https://wiki.gpac.io/Filters/ffdmx/) filters. The idea is to leverage FFmpeg's protocols (srt://, rtmp://, ... that are also visible in `gpac -h protocols`) while not using the corresponding muxer (resp. MPEG-TS, FLV, ...). This is useful if you want to pass a content that FFmpeg can't remux (or demux) properly.

Example forwarding some MPEG-TS over SRT (`reframer:rt=on` adds realtime regulation):
- Using GPAC's muxer: `gpac -i file.ts reframer:rt=on -o srt://127.0.0.1:9999\?mode=listener:gpac:proto` 
- By-passing all muxers: `gpac -i file.ts:block_size=1880 reframer:rt=on -o srt://127.0.0.1:9999\?mode=caller:gpac:proto`

You can also do fancy stuff such as putting some mp4 or some [gsf](https://wiki.gpac.io/Filters/gsfmx/) serialization format inside SRT to split your graph across remote instances:
- `gpac -i file.ts reframer:rt=on -o srt://127.0.0.1:9999\?mode=listener:gpac:proto:ext=gsf`

Output:
- Playback: `gpac -play srt://127.0.0.1:9999\?mode=listener`
- Inspection: `gpac -i srt://127.0.0.1:9999:gpac:proto inspect:deep -graph`