### PR TITLE
`seiload` issues

### DIFF
--- a/src/filters/bsrw.c
+++ b/src/filters/bsrw.c
@@ -531,7 +531,6 @@ static GF_Err nalu_rewrite_packet(GF_BSRWCtx *ctx, BSRWPid *pctx, GF_FilterPacke
 	gf_bs_read_data(bs_w, output, pck_size);
 
 	//cleanup
-	gf_free(tc_in);
 	gf_free(rw_sei_payload);
 	gf_bs_del(bs_w);
 	gf_bs_del(bs);

--- a/src/filters/sei_load.c
+++ b/src/filters/sei_load.c
@@ -306,6 +306,7 @@ static GF_Err gf_sei_load_from_packet_nalu(GF_SEILoader *sei, GF_FilterPacket *p
 			case GF_HEVC_NALU_SEI_PREFIX:
 			case GF_HEVC_NALU_SEI_SUFFIX:
 				is_sei = GF_TRUE;
+				gf_hevc_parse_sei(data+pos+sei->nalu_size, size, sei->hevc_state);
 			case GF_HEVC_NALU_SEQ_PARAM: //for pic timing full parse we need SPS...
 				gf_hevc_parse_nalu_bs(sei->bs, sei->hevc_state, &nal_type, &temporal_id, &layer_id);
 				break;
@@ -315,9 +316,10 @@ static GF_Err gf_sei_load_from_packet_nalu(GF_SEILoader *sei, GF_FilterPacket *p
 			u8 temporal_id, layer_id;
 			u8 nal_unit_type = gf_bs_peek_bits(sei->bs, 8, 1) >> 3;
 			switch (nal_unit_type) {
-			case GF_HEVC_NALU_SEI_PREFIX:
-			case GF_HEVC_NALU_SEI_SUFFIX:
+			case GF_VVC_NALU_SEI_PREFIX:
+			case GF_VVC_NALU_SEI_SUFFIX:
 				is_sei = GF_TRUE;
+				gf_vvc_parse_sei(data+pos+sei->nalu_size, size, sei->vvc_state);
 				gf_vvc_parse_nalu_bs(sei->bs, sei->vvc_state, &nal_unit_type, &temporal_id, &layer_id);
 				break;
 			}

--- a/src/filters/sei_load.c
+++ b/src/filters/sei_load.c
@@ -195,6 +195,7 @@ GF_Err gf_sei_init_from_pid(GF_SEILoader *sei, GF_FilterPid *pid)
 			sei->av1_state->config = av1c;
 			//for now no need to load the OBUs
 		}
+		gf_odf_av1_cfg_del(av1c);
 	}
 		sei->is_identity = GF_FALSE;
 		break;

--- a/src/media_tools/av_parsers.c
+++ b/src/media_tools/av_parsers.c
@@ -4337,6 +4337,7 @@ static void av1_parse_timecode_obu(GF_SEIInfo *sei, GF_BitStream *bs)
 	AVCSeiPicTiming *pt = &sei->pic_timing;
 	pt->num_clock_ts = 1;
 	AVCSeiPicTimingTimecode *tc = &pt->timecodes[0];
+	tc->clock_timestamp_flag = 1;
 
 	tc->counting_type = gf_bs_read_int_log(bs, 5, "counting_type");
 	Bool full_timestamp_flag = gf_bs_read_int_log(bs, 1, "full_timestamp_flag");


### PR DESCRIPTION
refactored `bsrw` to use `seiload` but encountered bad_access errors from`seiload`.

Added HEVC/AV1 tests to the testsuite so that we can ensure everything is working as required. These hashes were generated with an earlier commit before #3169 was merged.

- gpac/testsuite/pull/30