### PR TITLE
make utc_ref work with timecodes

### DIFF
--- a/src/filters/reframer.c
+++ b/src/filters/reframer.c
@@ -1842,15 +1842,17 @@ GF_Err reframer_process(GF_Filter *filter)
 					// Start from the first frame since timecode is out-of-bounds
 					frac->num = ts;
 					frac->den = pck_ts;
-					if (tc == ctx->cur_start_tc)
+					if (tc == ctx->cur_start_tc) {
 						ctx->ts_tc_offset.num = cur_ts - target_ts;
 						ctx->ts_tc_offset.den = pck_ts;
+					}
 				} else {
 					frac->num = ts + (target_ts - cur_ts);
 					frac->den = pck_ts;
-					if (tc == ctx->cur_start_tc)
+					if (tc == ctx->cur_start_tc) {
 						ctx->ts_tc_offset.num = 0;
 						ctx->ts_tc_offset.den = pck_ts;
+					}
 				}
 
 				*valid = GF_TRUE;


### PR DESCRIPTION
This PR brings support for using timecodes when `xs` is set to a XML DateTime. Timecodes within media stream are converted to UTC using current UTC date. If the given `xs` value is out-of-bounds for the media stream, then CTS of the packets will reflect that difference. As if the video was playing since `xs` but packets just started to arrive.

## Example

Assume that current UTC time is `2025-04-16T12:16:06Z` (time is not important) and our media stream starts at `14:00:00:00` timecode. The video is running at `60fps`. For simplicity sake there is only video in this example but other streams going through `reframer` will be adjusted so that they follow along the video.

We instruct the reframer to split from `2025-04-16T13:00:00Z` and since timecodes start 1 hour after that time the first CTS will be calculated as follows:

```
1h = 3600s
3600s = 3600 * 60fps = 216000ts
```

First CTS will therefore be **216000**.

```bash
# Create a sample video stream with timecodes starting from 14h
gpac avgen:v:dur=1:fps=60 c=avc:bf=0 bsrw:tc=insert:tcsc=TC14:00:00:00 \
# Split the video stream at 2025-04-16T13:00:00Z, regardless of if first frame is SAP or not
reframer:nosap:utc_ref=tc:xs=2025-04-16T13:00:00Z \
# Inspect the video timestamps
inspect:deep
```

**Output**:
```
PID 1 ID 2 video timescale 60 1280x720 fps 60 SAR 1/1 100 kbps codec avc1.640020 AVC|H264 PL High@3.2 YUV 4:2:0 8 bpp
PID 1 PCK 1 cts 216000 dur 1 sap 1 size 45735
PID 1 PCK 2 cts 216001 dur 1 size 4288
PID 1 PCK 3 cts 216002 dur 1 size 2460
...
```
