### PR TITLE
AVS2/3 initial support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,8 @@ ifeq ($(UNIT_TESTS),yes)
 	@if [ -e $(UT_CFG_PATH).h ]; then \
 		if ! diff -q $(UT_CFG_PATH).h $(UT_CFG_PATH).h.new >/dev/null ; then \
 			mv $(UT_CFG_PATH).h.new $(UT_CFG_PATH).h; \
+		else \
+			rm $(UT_CFG_PATH).h.new; \
 		fi; \
 	else \
 		mv $(UT_CFG_PATH).h.new $(UT_CFG_PATH).h; \

--- a/include/gpac/constants.h
+++ b/include/gpac/constants.h
@@ -607,6 +607,12 @@ typedef enum
 	GF_CODECID_VP9 = GF_4CC('V','P','0','9'),
 	GF_CODECID_VP10 = GF_4CC('V','P','1','0'),
 
+	/*AVS2/3*/
+	GF_CODECID_AVS2_VIDEO = GF_4CC('A','V','V','2'),
+	GF_CODECID_AVS2_AUDIO = GF_4CC('A','V','A','2'),
+	GF_CODECID_AVS3_VIDEO = GF_4CC('A','V','V','3'),
+	GF_CODECID_AVS3_AUDIO = GF_4CC('A','V','A','3'),
+
 	/*MPEG-H audio*/
 	GF_CODECID_MPHA = GF_4CC('m','p','h','a'),
 	/*MPEG-H mux audio*/

--- a/include/gpac/mpegts.h
+++ b/include/gpac/mpegts.h
@@ -282,6 +282,11 @@ typedef enum
 	GF_M2TS_HLS_AAC_CRYPT		= 0xcf,
 	GF_M2TS_HLS_AVC_CRYPT		= 0xdb,
 
+	GF_M2TS_VIDEO_AVS2          = 0xD2,
+	GF_M2TS_AUDIO_AVS2          = 0xD3,
+	GF_M2TS_VIDEO_AVS3          = 0xD4,
+	GF_M2TS_AUDIO_AVS3          = 0xD5,
+
 	/*the rest is internal use*/
 
 	GF_M2TS_VIDEO_VC1					= 0xEA,

--- a/src/filters/dmx_m2ts.c
+++ b/src/filters/dmx_m2ts.c
@@ -371,6 +371,22 @@ static void m2tsdmx_declare_pid(GF_M2TSDmxCtx *ctx, GF_M2TS_PES *stream, GF_ESD 
 			stype = GF_STREAM_AUDIO;
 			codecid = GF_CODECID_OPUS;
 			break;
+		case GF_M2TS_VIDEO_AVS2:
+			stype = GF_STREAM_VISUAL;
+			codecid = GF_CODECID_AVS2_VIDEO;
+			break;
+		case GF_M2TS_AUDIO_AVS2:
+			stype = GF_STREAM_AUDIO;
+			codecid = GF_CODECID_AVS2_AUDIO;
+			break;
+		case GF_M2TS_VIDEO_AVS3:
+			stype = GF_STREAM_VISUAL;
+			codecid = GF_CODECID_AVS3_VIDEO;
+			break;
+		case GF_M2TS_AUDIO_AVS3:
+			stype = GF_STREAM_AUDIO;
+			codecid = GF_CODECID_AVS3_AUDIO;
+			break;
 		case GF_M2TS_SYSTEMS_MPEG4_SECTIONS:
 			((GF_M2TS_ES*)stream)->flags |= GF_M2TS_ES_SEND_REPEATED_SECTIONS;
 			//fallthrough

--- a/src/media_tools/mpegts.c
+++ b/src/media_tools/mpegts.c
@@ -1400,6 +1400,10 @@ static void gf_m2ts_process_pmt(GF_M2TS_Demuxer *ts, GF_M2TS_SECTION_ES *pmt, GF
 		case GF_M2TS_HLS_AAC_CRYPT:
 		case GF_M2TS_HLS_AC3_CRYPT:
 		case GF_M2TS_HLS_EC3_CRYPT:
+		case GF_M2TS_VIDEO_AVS2:
+		case GF_M2TS_AUDIO_AVS2:
+		case GF_M2TS_VIDEO_AVS3:
+		case GF_M2TS_AUDIO_AVS3:
 		case 0xA1:
 			GF_SAFEALLOC(pes, GF_M2TS_PES);
 			if (!pes) {


### PR DESCRIPTION
We're starting to see some streams out there. I plan to support the TS inspect + MP4 remux. Not sure about reframing, opinion out there?

Specs:
- DVB: https://dvb.org/wp-content/uploads/2024/09/A168r8_MPEG-DASH-Profile-for-Transport-of-ISO-BMFF-Based-DVB-Services_Interim-Draft-ts_103-285-v151_December_2024.pdf
- AVS3 Video: http://standard.avswg.org.cn/avs3_download/doc/AVS3-P2-TAI09.2-2021-en.pdf
- AVS3 Audio muxing (TS/ISOBMFF): http://standard.avswg.org.cn/avs3_download/doc/AVS3-P7%20T-AI%20109.7-2024_en.pdf
- Missing AVS3 Video TS muxing. Not sure it is important at this stage.

Samples:
- https://dvb.org/specifications/verification-validation/avs3-video-test-content/
- https://dvb.org/avs3-audio-test-content/
- https://github.com/uavs3/avs3stream/tree/master

PS: there seems to have been trials to support AVS3 in several open-source software including DVB Inspector, TS Duck, MediaInfo (was merged last month after some resubmission), basic decoder support in FFmpeg, mp4box.js.