### PR TITLE
Github Actions: Update wiki on gpac push

### DIFF
--- a/.github/workflows/abi-version.yml
+++ b/.github/workflows/abi-version.yml
@@ -1,4 +1,5 @@
 name: abi version updater
+run-name: abi version updater
 on:
   push:
     branches:

--- a/.github/workflows/updatewiki.yml
+++ b/.github/workflows/updatewiki.yml
@@ -1,0 +1,32 @@
+name: update wiki
+run-name: update wiki
+on:
+  workflow_run:
+    workflows: [master actions]
+    types:
+      - completed
+
+
+jobs:
+    update-wiki:
+      runs-on: ubuntu-latest
+      container: gpac/ubuntu:latest
+      steps:
+        - name: Check out wiki
+          run:
+            git clone https://ga:${{ secrets.GPAC_WIKI_TOKEN }}@github.com/$GITHUB_REPOSITORY_OWNER/wiki.git wiki
+        - name: Run genmd
+          working-directory: wiki/scripts
+          run: sh -x ./genmd.sh
+        - name: Commit if changes
+          working-directory: wiki
+          run: |
+            env
+            git config --unset-all http.https://github.com/.extraheader  || true
+            git config user.name "GitHub Actions Bot"
+            git config user.email "<>"
+            git status
+            git commit -m "update from $GITHUB_REPOSITORY@$GITHUB_SHA" || true
+        - name: Push wiki
+          working-directory: wiki
+          run: git push


### PR DESCRIPTION
Hi all, 

This is linked to https://github.com/gpac/wiki/issues/7

This PR contains a github actions that does the following on a push to master: 
- waits for the new docker image to be built and uploaded
- uses this docker image as a container with latest gpac
- clones the wiki in this container
- runs the genmd.sh script from the wiki
- commits and pushes to the wiki if there are changes

You can see an example run with changes here: https://github.com/aureliendavid/gpac/actions/runs/14863298639/job/41733595309

Leading to this commit: https://github.com/aureliendavid/wiki/commit/2c3bde6be461cbff2762874f7025dbf3952b5a14

And an example of run with no change here: https://github.com/aureliendavid/gpac/actions/runs/14863341530/job/41733749576

Note that I have not checked the genmd.sh script and assumed it did what it is supposed to do. 

33ff082b0d5e90623da414295554a76750099e34 was a prerequisite here because enum_directory() is not guaranteed to return files in the same order every time, so it was leading to random changes of order in the output when generating the docs multiple times in a row without changing anything to the input


Don't hesitate if you have remarks/suggestions/corrections. 


Thanks

