### PR TITLE
Fix IAMF-FLAC sample size and sample rate.

### DIFF
--- a/src/media_tools/av_parsers.c
+++ b/src/media_tools/av_parsers.c
@@ -4753,9 +4753,9 @@ static GF_Err iamf_parse_codec_config(GF_BitStream *bs, IAMFState *state)
 		gf_bs_read_int_log(bs, 16, "maximum_block_size");
 		gf_bs_read_int_log(bs, 24, "minimum_frame_size");
 		gf_bs_read_int_log(bs, 24, "maximum_frame_size");
-		state->sample_rate = gf_bs_read_int_log(bs, 24, "sample_rate");
+		state->sample_rate = gf_bs_read_int_log(bs, 20, "sample_rate");
 		gf_bs_read_int_log(bs, 3, "num_of_channels");
-		state->sample_size = gf_bs_read_int_log(bs, 5, "bits_per_sample");
+		state->sample_size = gf_bs_read_int_log(bs, 5, "bits_per_sample") + 1;
 		break;
 	// LPCM.
 	case GF_4CC('i', 'p', 'c', 'm'):


### PR DESCRIPTION
  - Fixes unexpected timescales and possible AV sync issues in IAMF-FLAC.
  - Sample rate is 20 bytes in section 8.1 of RFC 9639.
  - The coded sample size is offset by 1.