### PR TITLE
iff: add text and font properties

### DIFF
--- a/include/gpac/internal/isomedia_dev.h
+++ b/include/gpac/internal/isomedia_dev.h
@@ -451,6 +451,8 @@ enum
 	GF_ISOM_BOX_TYPE_IENC	= GF_4CC( 'i', 'e', 'n', 'c' ),
 	GF_ISOM_BOX_TYPE_IAUX 	= GF_4CC('i', 'a', 'u', 'x'),
 	GF_ISOM_BOX_TYPE_ILCE   = GF_4CC( 'i', 'l', 'c', 'e' ),
+	GF_ISOM_BOX_TYPE_TXLO   = GF_4CC( 't', 'x', 'l', 'o' ),
+	GF_ISOM_BOX_TYPE_FNCH   = GF_4CC( 'f', 'n', 'c', 'h' ),
 
 	/* MIAF Boxes */
 	GF_ISOM_BOX_TYPE_CLLI	= GF_4CC('c', 'l', 'l', 'i'),
@@ -3989,6 +3991,29 @@ typedef struct {
 	u32 aux_info_type;
 	u32 aux_info_parameter;
 } GF_AuxiliaryInfoPropertyBox;
+
+
+typedef struct {
+	GF_ISOM_FULL_BOX
+	char* font_family;
+	char* font_style;
+	char* font_weight;
+} GF_FontCharacteristicsPropertyBox;
+
+
+typedef struct {
+	GF_ISOM_FULL_BOX
+	u32 reference_width;
+	u32 reference_height;
+	s32 x;
+	s32 y;
+	u32 width;
+	u32 height;
+	s16 font_size;
+	char* direction;
+	char* writing_mode;
+} GF_TextLayoutPropertyBox;
+
 
 typedef struct {
 	GF_ISOM_FULL_BOX

--- a/src/isomedia/box_dump.c
+++ b/src/isomedia/box_dump.c
@@ -6394,6 +6394,30 @@ GF_Err imir_box_dump(GF_Box *a, FILE * trace)
 	return GF_OK;
 }
 
+GF_Err txlo_box_dump(GF_Box *a, FILE *trace)
+{
+    GF_TextLayoutPropertyBox *ptr = (GF_TextLayoutPropertyBox *)a;
+    if (!a)
+        return GF_BAD_PARAM;
+    gf_isom_box_dump_start(a, "TextLayoutPropertyBox", trace);
+    gf_fprintf(trace, "reference_width=\"%d\" reference_height=\"%d\" x=\"%d\" y=\"%d\" width=\"%d\" height=\"%d\" font_size=\"%d\" direction=\"%s\" writing_mode=\"%s\">\n",
+               ptr->reference_width, ptr->reference_height, ptr->x, ptr->y, ptr->width, ptr->height, ptr->font_size, ptr->direction, ptr->writing_mode);
+    gf_isom_box_dump_done("TextLayoutPropertyBox", a, trace);
+    return GF_OK;
+}
+
+GF_Err fnch_box_dump(GF_Box *a, FILE *trace)
+{
+    GF_FontCharacteristicsPropertyBox *ptr = (GF_FontCharacteristicsPropertyBox *)a;
+    if (!a)
+        return GF_BAD_PARAM;
+    gf_isom_box_dump_start(a, "FontCharacteristicsPropertyBox", trace);
+    gf_fprintf(trace, "font_family=\"%s\" font_style=\"%s\" font_weight=\"%s\">\n",
+               ptr->font_family, ptr->font_style, ptr->font_weight);
+    gf_isom_box_dump_done("FontCharacteristicsPropertyBox", a, trace);
+    return GF_OK;
+}
+
 GF_Err clli_box_dump(GF_Box *a, FILE * trace)
 {
 	GF_ContentLightLevelBox *ptr = (GF_ContentLightLevelBox *)a;

--- a/src/isomedia/box_funcs.c
+++ b/src/isomedia/box_funcs.c
@@ -945,6 +945,8 @@ ISOM_BOX_IMPL_DECL_CHILD(trgr)
 ISOM_BOX_IMPL_DECL(trgt)
 ISOM_BOX_IMPL_DECL(ienc)
 ISOM_BOX_IMPL_DECL(iaux)
+ISOM_BOX_IMPL_DECL(txlo)
+ISOM_BOX_IMPL_DECL(fnch)
 
 /* MIAF declarations */
 ISOM_BOX_IMPL_DECL(clli)
@@ -1229,7 +1231,7 @@ static struct box_registry_entry {
 	BOX_DEFINE_CHILD( GF_ISOM_BOX_TYPE_MFRA, mfra, "file"),
 	FBOX_DEFINE( GF_ISOM_BOX_TYPE_MFRO, mfro, "mfra", 0),
 	FBOX_DEFINE( GF_ISOM_BOX_TYPE_TFRA, tfra, "mfra", 1),
-	FBOX_DEFINE( GF_ISOM_BOX_TYPE_ELNG, elng, "mdia extk", 0),
+	FBOX_DEFINE( GF_ISOM_BOX_TYPE_ELNG, elng, "mdia extk ipco", 0),
 	FBOX_DEFINE( GF_ISOM_BOX_TYPE_PDIN, pdin, "file", 0),
 	FBOX_DEFINE( GF_ISOM_BOX_TYPE_SBGP, sbgp, "stbl traf", 1),
 	FBOX_DEFINE( GF_ISOM_BOX_TYPE_SGPD, sgpd, "stbl traf", 2),
@@ -1497,6 +1499,8 @@ static struct box_registry_entry {
 	FBOX_DEFINE_S( GF_ISOM_BOX_TYPE_AUXC, auxc, "ipco", 0, "iff"),
 	FBOX_DEFINE_S( GF_ISOM_BOX_TYPE_OINF, oinf, "ipco", 0, "iff"),
 	FBOX_DEFINE_S( GF_ISOM_BOX_TYPE_TOLS, tols, "ipco", 0, "iff"),
+	FBOX_DEFINE_S( GF_ISOM_BOX_TYPE_TXLO, txlo, "ipco", 0, "iff"),
+	FBOX_DEFINE_S( GF_ISOM_BOX_TYPE_FNCH, fnch, "ipco", 0, "iff"),
 	FBOX_DEFINE_S( GF_ISOM_BOX_TYPE_IENC, ienc, "ipco", 0, "cenc"),
 	FBOX_DEFINE_S( GF_ISOM_BOX_TYPE_IAUX, iaux, "ipco", 0, "cenc"),
 

--- a/src/isomedia/iff.c
+++ b/src/isomedia/iff.c
@@ -1236,6 +1236,134 @@ GF_Err iaux_box_size(GF_Box *s)
 
 #endif /*GPAC_DISABLE_ISOM_WRITE*/
 
+GF_Box *fnch_box_new()
+{
+    ISOM_DECL_BOX_ALLOC(GF_FontCharacteristicsPropertyBox, GF_ISOM_BOX_TYPE_FNCH);
+    return (GF_Box *)tmp;
+}
+
+void fnch_box_del(GF_Box *a)
+{
+    GF_FontCharacteristicsPropertyBox *p = (GF_FontCharacteristicsPropertyBox *)a;
+    if (p->font_family)
+        gf_free(p->font_family);
+    if (p->font_style)
+        gf_free(p->font_style);
+    if (p->font_weight)
+        gf_free(p->font_weight);
+    gf_free(p);
+}
+
+GF_Err fnch_box_read(GF_Box *s, GF_BitStream *bs)
+{
+    GF_FontCharacteristicsPropertyBox *p = (GF_FontCharacteristicsPropertyBox *)s;
+
+    p->font_family = gf_bs_read_utf8(bs);
+    p->font_style = gf_bs_read_utf8(bs);
+    p->font_weight = gf_bs_read_utf8(bs);
+    return GF_OK;
+}
+
+#ifndef GPAC_DISABLE_ISOM_WRITE
+GF_Err fnch_box_write(GF_Box *s, GF_BitStream *bs)
+{
+    GF_Err e;
+    GF_FontCharacteristicsPropertyBox *p = (GF_FontCharacteristicsPropertyBox *)s;
+
+    e = gf_isom_full_box_write(s, bs);
+    if (e)
+        return e;
+    gf_bs_write_utf8(bs, p->font_family);
+    gf_bs_write_utf8(bs, p->font_style);
+    gf_bs_write_utf8(bs, p->font_weight);
+    return GF_OK;
+}
+
+GF_Box *fnch_box_size(GF_Box *s)
+{
+    GF_FontCharacteristicsPropertyBox *p = (GF_FontCharacteristicsPropertyBox *)s;
+    p->size += (p->font_family ? strlen(p->font_family) : 0) + 1;
+    p->size += (p->font_style ? strlen(p->font_style) : 0) + 1;
+    p->size += (p->font_weight ? strlen(p->font_weight) : 0) + 1;
+    return GF_OK;
+}
+#endif /*GPAC_DISABLE_ISOM_WRITE*/
+
+GF_Box *txlo_box_new()
+{
+    ISOM_DECL_BOX_ALLOC(GF_TextLayoutPropertyBox, GF_ISOM_BOX_TYPE_TXLO);
+    return (GF_Box *)tmp;
+}
+
+void txlo_box_del(GF_Box *a)
+{
+    GF_TextLayoutPropertyBox *p = (GF_TextLayoutPropertyBox *)a;
+    if (p->direction)
+        gf_free(p->direction);
+    if (p->writing_mode)
+        gf_free(p->writing_mode);
+    gf_free(p);
+}
+
+GF_Err txlo_box_read(GF_Box *s, GF_BitStream *bs)
+{
+    GF_TextLayoutPropertyBox *p = (GF_TextLayoutPropertyBox *)s;
+
+    if ((p->flags & 0x1) == 1)
+    {
+        p->reference_width = gf_bs_read_u32(bs);
+        p->reference_height = gf_bs_read_u32(bs);
+        p->x = (s32)gf_bs_read_u32(bs);
+        p->y = (s32)gf_bs_read_u32(bs);
+        p->width = gf_bs_read_u32(bs);
+        p->height = gf_bs_read_u32(bs);
+    }
+    else
+    {
+        p->reference_width = gf_bs_read_u16(bs);
+        p->reference_height = gf_bs_read_u16(bs);
+        p->x = (s16)gf_bs_read_u16(bs);
+        p->y = (s16)gf_bs_read_u16(bs);
+        p->width = gf_bs_read_u16(bs);
+        p->height = gf_bs_read_u16(bs);
+    }
+    p->font_size = gf_bs_read_u16(bs);
+    p->direction = gf_bs_read_utf8(bs);
+    p->writing_mode = gf_bs_read_utf8(bs);
+    return GF_OK;
+}
+
+#ifndef GPAC_DISABLE_ISOM_WRITE
+GF_Err txlo_box_write(GF_Box *s, GF_BitStream *bs)
+{
+    GF_Err e;
+    GF_TextLayoutPropertyBox *p = (GF_TextLayoutPropertyBox *)s;
+    p->flags = 0x01;
+
+    e = gf_isom_full_box_write(s, bs);
+    if (e)
+        return e;
+    gf_bs_write_u32(bs, p->reference_width);
+    gf_bs_write_u32(bs, p->reference_height);
+    gf_bs_write_u32(bs, (u32)p->x);
+    gf_bs_write_u32(bs, (u32)p->y);
+    gf_bs_write_u32(bs, p->width);
+    gf_bs_write_u32(bs, p->height);
+    gf_bs_write_u16(bs, p->font_size);
+    gf_bs_write_utf8(bs, p->direction);
+    gf_bs_write_utf8(bs, p->writing_mode);
+    return GF_OK;
+}
+
+GF_Err txlo_box_size(GF_Box *s)
+{
+    GF_TextLayoutPropertyBox *p = (GF_TextLayoutPropertyBox *)s;
+    p->size += 26;
+    p->size += (p->direction ? strlen(p->direction) : 0) + 1;
+    p->size += (p->writing_mode ? strlen(p->writing_mode) : 0) + 1;
+    return GF_OK;
+}
+#endif /*GPAC_DISABLE_ISOM_WRITE*/
 
 #ifndef GPAC_DISABLE_ISOM_WRITE
 


### PR DESCRIPTION
This adds support for the item properties in ISO/IEC 23008-12:2025 Section 6.10 "Text and font items", which was recently published.

There are three properties - `txlo`, `elng` and `fnch`. `elng` is borrowed from 14496-12, and the implementation in this PR does the same. 

I could not find sample data that matches the spec. There is a sample at https://github.com/MPEGGroup/FileFormatConformance/pull/133/files#diff-1bddd1e6a414e35db8bedca0a507c50e4b8288a72b33dd19e67860d4bf8df0be that is close, but the `txlo` appears to be from an earlier iteration - there is is no `writing_mode` string, and the `width` and `height` values look a bit strange.

The XML dump from gpac with this PR against that sample looks (in part) like this:

```
<ItemPropertyContainerBox Size="270" Type="ipco" Specification="iff" Container="iprp" >
<HEVCConfigurationBox Size="140" Type="hvcC" Specification="p15" Container="hvc1 hev1 hvc2 hev2 encv resv ipco dvh1 dvhe" >
<HEVCDecoderConfigurationRecord nal_unit_size="4" configurationVersion="1" profile_space="0" tier_flag="0" profile_idc="1" general_profile_compatibility_flags="6" progressive_source_flag="0" interlaced_source_flag="0" non_packed_constraint_flag="0" frame_only_constraint_flag="0" constraint_indicator_flags="0" level_idc="0" min_spatial_segmentation_idc="0" parallelismType="0" chroma_format="YUV 4:2:0" luma_bit_depth="8" chroma_bit_depth="8" avgFrameRate="0" constantFrameRate="0" numTemporalLayers="1" temporalIdNested="0">
<ParameterSetArray nalu_type="32" complete_set="1">
<ParameterSet size="25" content="data:application/octet-string,40010C01FFFF01600000030000030000030000030000970240"/>
</ParameterSetArray>
<ParameterSetArray nalu_type="33" complete_set="1">
<ParameterSet size="62" content="data:application/octet-string,42010101600000030000030000030000030000A002D0803C165979246D8365E222223F9E7F3F9FCFE7F3CBFFFFFF3F9FCFE7F3F9FCFCFE7F3F9FCFE76C80"/>
</ParameterSetArray>
<ParameterSetArray nalu_type="34" complete_set="1">
<ParameterSet size="7" content="data:application/octet-string,4401C190958112"/>
</ParameterSetArray>
</HEVCDecoderConfigurationRecord>
</HEVCConfigurationBox>
<ImageSpatialExtentsPropertyBox Size="20" Type="ispe" Version="0" Flags="0" Specification="iff" Container="ipco" image_width="1440" image_height="960">
</ImageSpatialExtentsPropertyBox>
<TextLayoutPropertyBox Size="30" Type="txlo" Version="0" Flags="0" Specification="iff" Container="ipco" reference_width="1440" reference_height="960" x="128" y="128" width="0" height="0" font_size="0" direction="ltr" writing_mode="(null)">
</TextLayoutPropertyBox>
<ImageSpatialExtentsPropertyBox Size="20" Type="ispe" Version="0" Flags="0" Specification="iff" Container="ipco" image_width="128" image_height="64">
</ImageSpatialExtentsPropertyBox>
<ExtendedLanguageBox Size="18" Type="elng" Version="0" Flags="0" Specification="p12" Container="mdia extk ipco" LanguageCode="en-US">
</ExtendedLanguageBox>
<FontCharacteristicsPropertyBox Size="34" Type="fnch" Version="0" Flags="0" Specification="iff" Container="ipco" font_family="Calibre" font_style="normal" font_weight="normal">
</FontCharacteristicsPropertyBox>
</ItemPropertyContainerBox>
```