### PR TITLE
Makefile: don't install dynamic libs with --static-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,7 +279,7 @@ uninstall:
 
 
 installdylib:
-ifneq ($(STATIC_BINARY),yes)
+ifneq ($(STATIC_BUILD),yes)
 
 	$(INSTALL) -d "$(DESTDIR)$(prefix)/$(lib_dir)"
 


### PR DESCRIPTION
`$(STATIC_BUILD)` is `yes` for `--static-build` and `static-bin`

Fixes #3338 