### PR TITLE
Event Track passthrough

### DIFF
--- a/include/tests.h
+++ b/include/tests.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <gpac/tools.h>
+#include <gpac/tools.h> // Bool
 
 #define unittest(suffix) void test_##suffix(void)
 
@@ -10,25 +10,32 @@ extern int checks_failed;
 static Bool verbose_ut = GF_FALSE;
 static Bool fatal_ut = GF_TRUE;
 
-#define assert_true(expr)                                            \
+#define assert_generic(expr, trace)                                  \
     do {                                                             \
         if (expr) {                                                  \
-            if (verbose_ut) printf("Assertion passed: \"%s\", File: \"%s\", Line: %d, Function: \"%s\"\n", #expr, __FILE__, __LINE__, __func__); \
+            if (verbose_ut)                                          \
+                printf("Assertion passed: \"%s\", File: \"%s\", Line: %d, Function: \"%s\"\n", #expr, __FILE__, __LINE__, __func__); \
             checks_passed++;                                         \
         } else {                                                     \
             printf("Assertion failed: \"%s\", File: \"%s\", Line: %d, Function: \"%s\"\n", #expr, __FILE__, __LINE__, __func__); \
+            if (verbose_ut) trace;                                   \
             checks_failed++;                                         \
             if (fatal_ut) checks_failed|=0x8000000;                  \
         }                                                            \
     } while (0)
 
-#define assert_false(expr)                assert_true(!(expr))
-#define assert_equal_str(str1, str2)      assert_true(!strcmp((str1), (str2)))
-#define assert_equal_mem(m1, m2, sz)      assert_true(memcmp(m1, m2, sz) == 0)
-#define assert_not_equal_str(str1, str2)  assert_true(strcmp((str1), (str2)))
-#define assert_equal(a, b)                assert_true((a) == (b))
-#define assert_greater(a, b)              assert_true((a) > (b))
-#define assert_greater_equal(a, b)        assert_true((a) >= (b))
-#define assert_less(a, b)                 assert_true((a) < (b))
-#define assert_less_equal(a, b)           assert_true((a) <= (b))
-#define assert_not_null(ptr)              assert_true((ptr) != NULL)
+#define assert_true(expr)                assert_generic(expr, {})
+#define assert_false(expr)               assert_true(!(expr))
+
+#define SEP "                  "
+#define assert_equal_str(str1, str2)     assert_generic(!strcmp((str1), (str2)), printf(SEP #str1"(=\"%s\")\n" SEP #str2 "(=\"%s\")\n", str1, str2))
+#define assert_not_equal_str(str1, str2) assert_generic( strcmp((str1), (str2)), printf(SEP #str1"(=\"%s\")\n" SEP #str2 "(=\"%s\")\n", str1, str2))
+#define assert_equal_mem(m1, m2, sz)     assert_true(memcmp(m1, m2, sz) == 0)
+#define assert_not_null(ptr)             assert_true((ptr) != NULL)
+
+#define assert_equal_op(a, b, op, t)        assert_generic(a op b, { printf(SEP "\"" #a "\"(=" t  ") " #op " \""  #b "\"(=" t ")\n", a, b); })
+#define assert_equal(a, b, t)               assert_equal_op(a, b, ==, t)
+#define assert_greater(a, b, t)             assert_equal_op(a, b, > , t)
+#define assert_greater_equal(a, b, t)       assert_equal_op(a, b, >=, t)
+#define assert_less(a, b, t)                assert_equal_op(a, b, < , t)
+#define assert_less_equal(a, b, t)          assert_equal_op(a, b, <=, t)

--- a/src/filter_core/filter_pid.c
+++ b/src/filter_core/filter_pid.c
@@ -5740,7 +5740,7 @@ single_retry:
 		goto restart;
 	}
 
-	//special case: if we found a destination, ignore any  force_link filter that is an alias filter and has a matching sourceID
+	//special case: if we found a destination, ignore any force_link filter that is an alias filter and has a matching sourceID
 	//This is needed because a filter calling gf_filter_set_source on a alias filter
 	//will never modify the sourceID of the original (non-alias) filter
 	//eg [...] dasher -> scte35dec(injected) -> httpout(alias)

--- a/src/filters/dasher.c
+++ b/src/filters/dasher.c
@@ -11185,7 +11185,7 @@ static const GF_FilterArgs DasherArgs[] =
 		"- raw: uses raw media format (disables multiplexed representations)\n"
 		"- auto: guesses format based on extension, defaults to mp4 if no extension is provided", GF_PROP_UINT, "auto", "mp4|ts|mkv|webm|ogg|raw|auto", 0},
 	{ OFFS(rawsub), "use raw subtitle format instead of encapsulating in container", GF_PROP_BOOL, "no", NULL, GF_FS_ARG_HINT_ADVANCED},
-	{ OFFS(asto), "availabilityStartTimeOffset to use in seconds. A negative value simply increases the AST, a positive value sets the ASToffset to representations", GF_PROP_DOUBLE, "0", NULL, GF_FS_ARG_HINT_ADVANCED},
+	{ OFFS(asto), "availabilityTimeOffset to use in seconds. A negative value simply increases the AST, a positive value sets the ASToffset to representations", GF_PROP_DOUBLE, "0", NULL, GF_FS_ARG_HINT_ADVANCED},
 	{ OFFS(profile), "target DASH profile. This will set default option values to ensure conformance to the desired profile. For MPEG-2 TS, only main and live are used, others default to main\n"
 		"- auto: turns profile to live for dynamic and full for non-dynamic\n"
 		"- live: DASH live profile, using segment template\n"

--- a/src/filters/dasher.c
+++ b/src/filters/dasher.c
@@ -213,7 +213,7 @@ typedef struct
 	Bool check_dur, skip_seg, loop, reschedule, scope_deps, keep_src, tpl_force, keep_segs;
 	Double refresh, tsb, subdur;
 	u64 *_p_gentime, *_p_mpdtime;
-	Bool cmpd, dual, segcts, sreg, ttml_agg;
+	Bool cmpd, dual, segcts, sreg, ttml_agg, evte_agg;
 	char *styp;
 	Bool sigfrag;
 	DasherTSSHandlingMode sbound;
@@ -3758,7 +3758,7 @@ static void dasher_open_pid(GF_Filter *filter, GF_DasherCtx *ctx, GF_DashStream 
 	}
 
 	//inject scte35dec filter
-	if (ds->codec_id==GF_CODECID_SCTE35 || ds->codec_id==GF_CODECID_EVTE)
+	if (ctx->evte_agg && (ds->codec_id==GF_CODECID_SCTE35 || ds->codec_id==GF_CODECID_EVTE))
 		dasher_inject_scte35_processor(filter, ds, szSRC);
 }
 
@@ -11320,6 +11320,7 @@ static const GF_FilterArgs DasherArgs[] =
 	{ OFFS(tpl_force), "use template string as is without trying to add extension or solve conflicts in names", GF_PROP_BOOL, "false", NULL, GF_FS_ARG_HINT_EXPERT},
 	{ OFFS(inband_event), "insert a default inband event stream in the DASH manifest", GF_PROP_BOOL, "false", NULL, 0 },
 	{ OFFS(ttml_agg), "force aggregation of TTML samples of a DASH segment into a single sample", GF_PROP_BOOL, "false", NULL, GF_FS_ARG_HINT_EXPERT},
+	{ OFFS(evte_agg), "force aggregation of Event Track samples of a DASH segment into a single sample", GF_PROP_BOOL, "false", NULL, GF_FS_ARG_HINT_EXPERT},
 
 	{ OFFS(force_flush), "deprecated - use sflush instead", GF_PROP_BOOL, "false", NULL, GF_FS_ARG_HINT_HIDE},
 

--- a/src/filters/unittests/ut_dec_cc.c
+++ b/src/filters/unittests/ut_dec_cc.c
@@ -34,13 +34,13 @@ static void ccdec_test_template(int agg, Bool text_with_overlaps, GF_Err (*pck_s
 	ctx.pck_truncate = pck_truncate;
 	ctx.pck_new_alloc = pck_new_alloc;
 
-	for (size_t i=0; i<strlen(txt); ++i) {
+	for (u32 i=0; i<strlen(txt); ++i) {
 		//we write to ctx.txtdata+ctx.txtlen like dec_cc.c does
 		if (text_with_overlaps) {
 			strncpy(ctx.txtdata+ctx.txtlen, txt, i+1);
 			text_aggregate_and_post(&ctx, i+1, i);
 		} else {
-			assert_equal(ctx.txtlen, i);
+			assert_equal(ctx.txtlen, i, "%u");
 			strncpy(ctx.txtdata+ctx.txtlen, txt+i, 1);
 			text_aggregate_and_post(&ctx, 1, i);
 		}
@@ -60,7 +60,7 @@ static GF_Err pck_send_default(GF_FilterPacket *pck)
 	const int num_expected = sizeof(expected)/sizeof(const char*);
 	
 	if (!pck) {
-		assert_equal(calls, num_expected);
+		assert_equal(calls, num_expected, "%d");
 		return GF_OK;
 	}
 	if (calls >= num_expected)
@@ -72,7 +72,7 @@ static GF_Err pck_send_default(GF_FilterPacket *pck)
 	gf_free((u8*)data);
 	gf_free(pck);
 	calls++;
-	assert_equal(size, calls);
+	assert_equal(size, calls, "%u");
 	return GF_OK;
 }
 
@@ -89,7 +89,7 @@ static GF_Err pck_send_aggregation(GF_FilterPacket *pck)
 	const int num_expected = sizeof(expected)/sizeof(const char*);
 
 	if (!pck) {
-		assert_equal(calls, num_expected);
+		assert_equal(calls, num_expected, "%d");
 		calls = 0;
 		return GF_OK;
 	}
@@ -123,7 +123,7 @@ static GF_Err pck_send_several_entries(GF_FilterPacket *pck)
 	const int num_expected = sizeof(expected)/sizeof(const char*);
 
 	if (!pck) {
-		assert_equal(calls, num_expected);
+		assert_equal(calls, num_expected, "%d");
 		return GF_OK;
 	}
 	if (calls >= num_expected)

--- a/unittests/README.md
+++ b/unittests/README.md
@@ -53,7 +53,7 @@ You can include the filter source code file in your test file. This has the adva
 unittest(scte35dec_segmentation_end)
 {
     SCTE35DecCtx ctx = {0};
-    assert_equal(scte35dec_initialize_internal(&ctx), GF_OK);
+    assert_equal(scte35dec_initialize_internal(&ctx), GF_OK, "%d");
 
     ctx.segdur = (GF_Fraction){1, 1};
 


### PR DESCRIPTION
Even Tracks can be used for data that can't be parsed e.g. custom event tracks, nhml inputs, or data that GPAC can't handle. Tests will be added to the non-reg testsuite.