### PR TITLE
MP4Box, fix FPS with `AddChapter(nb_frames,chapter name)`

### DIFF
--- a/src/media_tools/media_import.c
+++ b/src/media_tools/media_import.c
@@ -990,7 +990,7 @@ GF_Err gf_media_import_chapters_file(GF_MediaImporter *import)
 		if (!strnicmp(sL, "AddChapter(", 11)) {
 			u32 nb_fr;
 			sscanf(sL, "AddChapter(%u,%1023s)", &nb_fr, szTitle);
-			ts = gf_timestamp_rescale(nb_fr, 1000 * import->video_fps.den, import->video_fps.num);
+			ts = gf_timestamp_rescale(nb_fr, import->video_fps.num, 1000 * import->video_fps.den);
 			sL = strchr(sL, ',');
 			strcpy(szTitle, sL+1);
 			sL = strrchr(szTitle, ')');


### PR DESCRIPTION
I was using the MP4Box `-chap` option with ZoomPlayer's `AddChapter(nb_frames,chapter name)` (frame) syntax, and I noticed that I had to supply `-fps 1001000/60` to make it work correctly for 59.94 FPS (which, was correctly detected).

Looks like the issue is that the arguments are flipped, which makes some sense, given that $\frac{1}{\frac{1001000}{60}} \times 1000 \times 1000 = 59.941$.