### PR TITLE
cenc avc: cypher everything by default

### DIFF
--- a/include/gpac/crypt_tools.h
+++ b/include/gpac/crypt_tools.h
@@ -141,12 +141,12 @@ typedef enum
 /*! non-VCL crypt modes (for avc1 CTR CENC edition 1) */
 typedef enum
 {
+	/*! all encrypted (except nal header) */
+	GF_CRYPT_NONVCL_CLEAR_NONE = 0,
 	/*! keep SEI and AUD in clear */
-	GF_CRYPT_NONVCL_CLEAR_SEI_AUD = 0,
+	GF_CRYPT_NONVCL_CLEAR_SEI_AUD,
 	/*! all clear */
 	GF_CRYPT_NONVCL_CLEAR_ALL,
-	/*! all encrypted (except nal header) */
-	GF_CRYPT_NONVCL_CLEAR_NONE,
 } GF_CryptNonVCL;
 
 /*! Crypto information for one media stream*/


### PR DESCRIPTION
due to lack of compatibility with Apple devices (partially reverts #3274 by changing defaults when 'encryptNonVCLs' is absent from the encryption XML file)