### PR TITLE
Fix ABI version updater workflow

### DIFF
--- a/.github/workflows/abi-version.yml
+++ b/.github/workflows/abi-version.yml
@@ -14,12 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       latest_abi: ${{ steps.get-tags.outputs.latest_abi }}
+      skip_build: ${{ steps.check-abi-ahead.outputs.skip_build }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          sparse-checkout: ""
+          sparse-checkout: "include/gpac/version.h"
 
       - name: Get latest `abi-*` tags
         id: get-tags
@@ -28,8 +29,43 @@ jobs:
           latest_tag=$(git tag -l 'abi-*' --sort=-creatordate | head -n 1)
           echo "latest_abi=$(git rev-parse $latest_tag)" >> $GITHUB_OUTPUT
 
+      - name: Check if ABI on code is ahead of latest tag
+        id: check-abi-ahead
+        run: |
+          current_major=$(grep "define GPAC_VERSION_MAJOR" include/gpac/version.h | awk '{print $3}')
+          current_minor=$(grep "define GPAC_VERSION_MINOR" include/gpac/version.h | awk '{print $3}')
+
+          latest_tag=$(git tag -l 'abi-*.*' --sort=-creatordate | head -n 1)
+          latest_tag=${latest_tag:4}
+          tag_major=$(echo $latest_tag | cut -d. -f1)
+          tag_minor=$(echo $latest_tag | cut -d. -f2)
+
+          if [ "$current_major" -gt "$tag_major" ] || ([ "$current_major" -eq "$tag_major" ] && [ "$current_minor" -gt "$tag_minor" ]); then
+            echo "ABI version in code ($current_major.$current_minor) is ahead of latest tag ($tag_major.$tag_minor)"
+
+            git config --global user.name "github-actions[bot]"
+            git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+            new_minor=abi-$current_major.$current_minor
+            new_major=abi-$current_major
+
+            echo "Tagging current commit with $new_minor and $new_major"
+
+            if ! git rev-parse -q --verify "refs/tags/$new_minor" >/dev/null; then
+              git tag -a $new_minor -m "ABI version $current_major.$current_minor" ${{ github.sha }}
+              git push origin $new_minor
+            fi
+
+            if ! git rev-parse -q --verify "refs/tags/$new_major" >/dev/null; then
+              git tag -a $new_major -m "ABI version $current_major" ${{ github.sha }}
+              git push origin $new_major
+            fi
+
+            echo "skip_build=true" >> $GITHUB_OUTPUT
+          fi
+
   build-commits:
-    if: ${{ needs.prepare-matrix.outputs.latest_abi != github.sha }}
+    if: ${{ needs.prepare-matrix.outputs.latest_abi != github.sha && needs.prepare-matrix.outputs.skip_build != 'true' }}
     runs-on: ubuntu-latest
     container: gpac/ubuntu-deps:latest
     needs: prepare-matrix


### PR DESCRIPTION
ABI version updater workflow has been dormant since c72bcdfb3b5572ad91f3c80db58e68599303173a because `abipkgdiff` doesn't register SONAME changes as "incompatible ABI" and since that commit has bumped ABI major version, it stopped working.

04ccdf47f35cf439a198aaf1213180347b292354 has changed the way we bump ABI versions to be automatic. And since the ABI difference detection is pretty good (when you use the tool properly...) I believe it's time we make this automatic for good.

This PR fixes some issues from that commit and changes the tool we use (still from `abigail-tools`) to `abidiff`. This one uses the `.so` instead of the debian package.

When we merge this PR, any future ABI changes will be commited directly after that particular change. The body of the commit will contain the output of `abidiff`. The pending ABI 14.0 version will have the following body for instance: [abi-diff.txt](https://github.com/user-attachments/files/23814466/abi-diff.txt)