### PR TITLE
enable -fstack-protector-strong by default where supported

### DIFF
--- a/configure
+++ b/configure
@@ -125,6 +125,7 @@ em_type="js"
 em_size="0"
 em_opt="2"
 fatal_assert="no"
+no_stack_prot="no"
 
 #flags not set by generic lib config
 has_x11="no"
@@ -384,6 +385,7 @@ GPAC build options:
   --extra-libs=ELIBS       add ELIBS [$ELIBS]
   --cpu=CPU                force cpu to CPU  [$cpu]
   --check-stack-size=SIZE  maximum stack size [$check_stack_size bytes]
+  --no-stack-protector     disables the default stack canaries
   --enable-debug           produce debug version
   --enable-gprof           enable profiling
   --enable-gcov            enable coverage
@@ -635,6 +637,8 @@ for opt do
         --cpu=*) cpu=`echo $opt | cut -d '=' -f 2`
             ;;
         --check-stack-size=*) check_stack_size=`echo $opt | cut -d '=' -f 2`
+            ;;
+        --no-stack-protector) no_stack_prot="yes"
             ;;
         --enable-debug) debuginfo="yes"; no_gcc_opt="yes"
             ;;
@@ -1150,10 +1154,21 @@ CFLAGS="$CFLAGS -Wall"
 if docc -fno-strict-aliasing ; then
     CFLAGS="$CFLAGS -fno-strict-aliasing"
 fi
+
+if test "$no_stack_prot" = "yes"; then
+    if docc -fno-stack-protector ; then
+        CFLAGS="$CFLAGS -fno-stack-protector"
+    fi
+else
+    if docc -fstack-protector-strong ; then
+        CFLAGS="$CFLAGS -fstack-protector-strong"
+    fi
+fi
 CXXFLAGS="$CFLAGS"
 if docc -lz -Wno-pointer-sign ; then
     CFLAGS="$CFLAGS -Wno-pointer-sign"
 fi
+
 
 
 #GCC opt
@@ -2633,7 +2648,7 @@ fi
 else
 
 if test "$enable_sanitizer" = "yes" ; then
-    CFLAGS="$CFLAGS -fsanitize=address,undefined -fno-sanitize-recover -g -fno-omit-frame-pointer -DASAN_ENABLED"
+    CFLAGS="$CFLAGS -fsanitize=address,undefined -fno-sanitize-recover -g -fno-omit-frame-pointer -fno-stack-protector -U_FORTIFY_SOURCE -DASAN_ENABLED"
     LDFLAGS="$LDFLAGS -fsanitize=address,undefined -ldl"
 fi
 


### PR DESCRIPTION
Hi, 

This PR enables stack canaries by default on compilers that supports `-fstack-protector-strong`.

I'm doing this as a PR in case there are some remarks or drawbacks I haven't considered, please comment. 

## some context

snack canaries are a mechanism that allows a program to detect stack overflows and abort if detected

it prevents exploitation of these bugs (and would support our argument that most reported overflows aren't really exploitable)

obviously it doesn't prevent the program from crashing in these cases, and we should still fix these bugs, but controlling the return address and doing arbitrary code execution with stack canaries becomes a whole lot harder

this adds a small overhead in terms of binary size (not really important) and execution time (basically adding a conditional jump to most functions which should be negligible in practice). 

## options

gcc has 4 levels of stack protection: (see https://mudongliang.github.io/2016/05/24/stack-protector.html for details)

- `-fno-stack-protector`: disables canaries
- `-fstack-protector`: conservatively enables them on some functions
- `-fstack-protector-all`: enables them on all functions
- `-fstack-protector-strong` is a more recent compromise between the last two, it enables canaries on more cases than the standard stack-protector while keeping the overhead smaller than -all

## current defaults

depending on the OS/distro, the compilers are set up with different defaults for stack protection

some examples: 

- **ubuntu:** `-fstack-protector-strong` is enabled by default in gcc
- **debian:** no stack protection in gcc by default, however when building .deb packages `-fstack-protector-strong` is automatically added
- **macos:** clang supports the same flags as gcc, by default is uses the equivalent of `-fstack-protector` 
- msvc: uses `/GS` by default which is equivalent to `-fstack-protector`

so most current builds of gpac already have some form of stack protection enabled, this PR just makes the default clearer

## impact

I'm not seeing an impact on the testsuite runtimes even on our debian32 builder where we go from no stack protection to -strong. 

## disabling it

if for some reason some people building gpac want to disable stack protection (maybe the overhead is not negligible in some configurations), they can use:

`./configure --no-stack-protector`

to disable it


