### PR TITLE
Fix memory leak in gf_media_change_par() for non-MPEG4_PART2 codecs

### DIFF
--- a/src/media_tools/isom_tools.c
+++ b/src/media_tools/isom_tools.c
@@ -144,10 +144,10 @@ GF_Err gf_media_change_par(GF_ISOFile *file, u32 track, s32 ar_num, s32 ar_den, 
 					ar_num = dsi.par_num;
 					ar_den = dsi.par_den;
 				}
-				gf_odf_desc_del((GF_Descriptor *) esd);
-				if (e) return e;
 			}
 #endif
+			gf_odf_desc_del((GF_Descriptor *) esd);
+			if (e) return e;
 		} else {
 			u32 mtype = gf_isom_get_media_type(file, track);
 			if (gf_isom_is_video_handler_type(mtype)) {


### PR DESCRIPTION
In gf_media_change_par(), when processing MPEG4 subtype tracks with visual stream type, the GF_ESD allocated by gf_isom_get_esd() is only freed inside the objectTypeIndication==GF_CODECID_MPEG4_PART2 branch. For any other codec (AVC, HEVC, JPEG, PNG, etc.), the esd pointer leaks 322 bytes per invocation across 9 allocations.

Move gf_odf_desc_del() and the error check outside the conditional block and past #endif, so esd is freed on all code paths regardless of codec type or GPAC_DISABLE_AV_PARSERS build configuration.

Fixes #3448

_This patch is generated by ASKRepair, an agentic automated vulnerability repair framework._