### PR TITLE
avoid error-level log message being split

### DIFF
--- a/applications/gpac/gpac_help.c
+++ b/applications/gpac/gpac_help.c
@@ -1212,10 +1212,11 @@ void gpac_suggest_arg(char *aname)
 			i++;
 			if (gf_sys_word_match(aname, arg->name)) {
 				if (!found) {
-					GF_LOG(GF_LOG_ERROR, GF_LOG_APP, ("Unrecognized option \"%s\", did you mean:\n", aname));
+					GF_LOG(GF_LOG_ERROR, GF_LOG_APP, ("Unrecognized option \"%s\", did you mean: %s? (see gpac -hx%s)", aname, arg->name, k ? " core" : ""));
 					found = GF_TRUE;
+				} else {
+					GF_LOG(GF_LOG_ERROR, GF_LOG_APP, ("\t-%s (see gpac -hx%s)\n", arg->name, k ? " core" : ""));
 				}
-				GF_LOG(GF_LOG_ERROR, GF_LOG_APP, ("\t-%s (see gpac -hx%s)\n", arg->name, k ? " core" : ""));
 			}
 		}
 	}
@@ -1225,10 +1226,11 @@ void gpac_suggest_arg(char *aname)
 		const char *key = gf_opts_get_key_name("gpac.alias", k);
 		if (gf_sys_word_match(aname, key)) {
 			if (!found) {
-				GF_LOG(GF_LOG_ERROR, GF_LOG_APP, ("Unrecognized option \"%s\", did you mean:\n", aname));
+				GF_LOG(GF_LOG_ERROR, GF_LOG_APP, ("Unrecognized option \"%s\", did you mean: %s? (see gpac -h)", aname, key));
 				found = GF_TRUE;
+			} else {
+				GF_LOG(GF_LOG_ERROR, GF_LOG_APP, ("\t%s (see gpac -h)\n", key));
 			}
-			GF_LOG(GF_LOG_ERROR, GF_LOG_APP, ("\t%s (see gpac -h)\n", key));
 		}
 	}
 

--- a/applications/mp4box/mp4box.c
+++ b/applications/mp4box/mp4box.c
@@ -6119,10 +6119,11 @@ static u32 mp4box_cleanup(u32 ret_code) {
 		for (i=1; i<count;i++) {
 			if (gf_sys_is_arg_used(i)) continue;
 			if (!found) {
-				GF_LOG(GF_LOG_ERROR, GF_LOG_APP, ("\nWarning: the following arguments have been set but not used:\n"));
+				GF_LOG(GF_LOG_ERROR, GF_LOG_APP, ("\nWarning: the following arguments have been set but not used: %s\n", gf_sys_get_arg(i)));
 				found = 1;
+			} else {
+				GF_LOG(GF_LOG_ERROR, GF_LOG_APP, ("%s\n", gf_sys_get_arg(i)));
 			}
-			GF_LOG(GF_LOG_ERROR, GF_LOG_APP, ("%s\n", gf_sys_get_arg(i)));
 		}
 	}
 

--- a/src/filter_core/filter_session.c
+++ b/src/filter_core/filter_session.c
@@ -3375,10 +3375,11 @@ void gf_fs_print_unused_args(GF_FilterSession *fsess, const char *ignore_args)
 		if (found) continue;
 
 		if (first) {
-			GF_LOG(GF_LOG_ERROR, GF_LOG_APP, ("\nWarning: the following arguments have been set but not used:\n"));
+			GF_LOG(GF_LOG_ERROR, GF_LOG_APP, ("\nWarning: the following arguments have been set but not used: %s\n", argname));
 			first=GF_FALSE;
+		} else {
+			GF_LOG(GF_LOG_ERROR, GF_LOG_APP, ("%s\n", argname));
 		}
-		GF_LOG(GF_LOG_ERROR, GF_LOG_APP, ("%s\n", argname));
 	}
 }
 


### PR DESCRIPTION
With strict error, the end of the message would never display.