### PR TITLE
keep data of unknown sample entry types

### DIFF
--- a/src/isomedia/box_code_base.c
+++ b/src/isomedia/box_code_base.c
@@ -1583,9 +1583,18 @@ GF_Box *gnrm_box_new()
 	return (GF_Box *)tmp;
 }
 
-//dummy
 GF_Err gnrm_box_read(GF_Box *s, GF_BitStream *bs)
 {
+	GF_GenericSampleEntryBox *ptr = (GF_GenericSampleEntryBox *)s;
+	GF_Err e = gf_isom_base_sample_entry_read((GF_SampleEntryBox *)s, bs);
+	if (e) return e;
+	ISOM_DECREASE_SIZE(ptr, 8)
+	if (ptr->size) {
+		ptr->data_size = (u32) ptr->size;
+		ptr->data = (char*)gf_malloc(ptr->data_size * sizeof(char));
+		if (!ptr->data) return GF_OUT_OF_MEM;
+		gf_bs_read_data(bs, ptr->data, ptr->data_size);
+	}
 	return GF_OK;
 }
 
@@ -1633,9 +1642,18 @@ GF_Box *gnrv_box_new()
 	gf_isom_video_sample_entry_init((GF_VisualSampleEntryBox*) tmp);
 	return (GF_Box *)tmp;
 }
-//dummy
+
 GF_Err gnrv_box_read(GF_Box *s, GF_BitStream *bs)
 {
+	GF_GenericVisualSampleEntryBox *ptr = (GF_GenericVisualSampleEntryBox *)s;
+	GF_Err e = gf_isom_video_sample_entry_read((GF_VisualSampleEntryBox *)ptr, bs);
+	if (e) return e;
+	if (ptr->size) {
+		ptr->data_size = (u32) ptr->size;
+		ptr->data = (char*)gf_malloc(ptr->data_size * sizeof(char));
+		if (!ptr->data) return GF_OUT_OF_MEM;
+		gf_bs_read_data(bs, ptr->data, ptr->data_size);
+	}
 	return GF_OK;
 }
 
@@ -1686,9 +1704,18 @@ GF_Box *gnra_box_new()
 	gf_isom_audio_sample_entry_init((GF_AudioSampleEntryBox*) tmp);
 	return (GF_Box *)tmp;
 }
-//dummy
+
 GF_Err gnra_box_read(GF_Box *s, GF_BitStream *bs)
 {
+	GF_GenericAudioSampleEntryBox *ptr = (GF_GenericAudioSampleEntryBox *)s;
+	GF_Err e = gf_isom_audio_sample_entry_read((GF_AudioSampleEntryBox *)ptr, bs);
+	if (e) return e;
+	if (ptr->size) {
+		ptr->data_size = (u32) ptr->size;
+		ptr->data = (char*)gf_malloc(ptr->data_size * sizeof(char));
+		if (!ptr->data) return GF_OUT_OF_MEM;
+		gf_bs_read_data(bs, ptr->data, ptr->data_size);
+	}
 	return GF_OK;
 }
 #ifndef GPAC_DISABLE_ISOM_WRITE
@@ -7158,7 +7185,8 @@ static GF_Err gf_isom_check_sample_desc(GF_TrackBox *trak)
 			GF_GenericVisualSampleEntryBox *genv = (GF_GenericVisualSampleEntryBox *) gf_isom_box_new(GF_ISOM_BOX_TYPE_GNRV);
 			bs = gf_bs_new(a->data, a->dataSize, GF_BITSTREAM_READ);
 			genv->size = a->size-8;
-			gf_isom_video_sample_entry_read((GF_VisualSampleEntryBox *) genv, bs);
+			e = gnrv_box_read((GF_Box *) genv, bs);
+			if (e) return e;
 
 			stsd_switch_box(bs, (GF_Box *) genv, a, &genv->data, &genv->data_size, &genv->EntryType, trak->Media->information->sampleTable->SampleDescription, i-1);
 		}
@@ -7168,7 +7196,8 @@ static GF_Err gf_isom_check_sample_desc(GF_TrackBox *trak)
 			GF_GenericAudioSampleEntryBox *gena = (GF_GenericAudioSampleEntryBox *) gf_isom_box_new(GF_ISOM_BOX_TYPE_GNRA);
 			gena->size = a->size-8;
 			bs = gf_bs_new(a->data, a->dataSize, GF_BITSTREAM_READ);
-			gf_isom_audio_sample_entry_read((GF_AudioSampleEntryBox *) gena, bs);
+			e = gnra_box_read((GF_Box *) gena, bs);
+			if (e) return e;
 
 			stsd_switch_box(bs, (GF_Box *) gena, a, &gena->data, &gena->data_size, &gena->EntryType, trak->Media->information->sampleTable->SampleDescription, i-1);
 		}
@@ -7180,7 +7209,7 @@ static GF_Err gf_isom_check_sample_desc(GF_TrackBox *trak)
 			genm->size = a->size-8;
 			bs = gf_bs_new(a->data, a->dataSize, GF_BITSTREAM_READ);
 
-			e = gf_isom_base_sample_entry_read((GF_SampleEntryBox *)genm, bs);
+			e = gnrm_box_read((GF_Box *)genm, bs);
 			if (e) return e;
 
 			stsd_switch_box(bs, (GF_Box *) genm, a, &genm->data, &genm->data_size, &genm->EntryType, trak->Media->information->sampleTable->SampleDescription, i-1);

--- a/src/isomedia/box_dump.c
+++ b/src/isomedia/box_dump.c
@@ -910,7 +910,7 @@ static void gnr_dump_exts(u8 *data, u32 data_size, FILE *trace)
 			gf_isom_box_del(a);
 		}
 	} else {
-		dump_data_attribute(trace, "data", data, data_size);
+		dump_data_attribute(trace, " data", data, data_size);
 		gf_fprintf(trace, ">\n");
 	}
 	if (list)


### PR DESCRIPTION
Previously, unknown sample entries were first parsed as unknown boxes (unkn) which correctly store their raw data, but then reparsed and replaced with generic sample entry boxes (gnrm/gnrv/gnra) in a way that dropped the box's data.

Fix missing space when outputting these boxes to xml.
