### PR TITLE
DASH-IF Live Ingest capability

### DIFF
--- a/include/gpac/media_tools.h
+++ b/include/gpac/media_tools.h
@@ -719,6 +719,8 @@ GF_OPT_ENUM (GF_DashProfile,
 	GF_DASH_PROFILE_AVC264_ONDEMAND,
 	/*! industry profile DASH-IF ISOBMFF low latency */
 	GF_DASH_PROFILE_DASHIF_LL,
+	/*! industry profile DASH-IF CMAF Ingest */
+	GF_DASH_PROFILE_DASHIF_INGEST,
  );
 
 

--- a/src/filters/mux_isom.c
+++ b/src/filters/mux_isom.c
@@ -40,7 +40,7 @@
 
 #define GF_IMPORT_AUDIO_SAMPLE_ENTRY_v2_QTFF (GF_IMPORT_AUDIO_SAMPLE_ENTRY_v1_QTFF+1)
 
-#define ISOM_FILE_EXT "mp4|mpg4|m4a|m4i|3gp|3gpp|3g2|3gp2|iso|ismv|m4s|heif|heic|iff|avci|avif|mj2|mov|qt"
+#define ISOM_FILE_EXT "mp4|mpg4|m4a|m4i|3gp|3gpp|3g2|3gp2|iso|ismv|m4s|heif|heic|iff|avci|avif|mj2|mov|qt|cmfv|cmfa|cmft"
 #define ISOM_FILE_MIME "video/mp4|audio/mp4|application/mp4|video/3gpp|audio/3gpp|video/3gp2|audio/3gp2|video/iso.segment|audio/iso.segment|image/heif|image/heic|image/avci|video/jp2|video/quicktime"
 
 enum{


### PR DESCRIPTION
Adds `dashif.ingest` profile for configuring some prerequisites. Functionality tested with [cmaf-ingest-receiver](https://github.com/Dash-Industry-Forum/livesim2/tree/main/cmd/cmaf-ingest-receiver) from livesim2 project.

```
gpac -logs=dash@debug avgen:v:lock c=avc bsrw:tc=utc reframer:rt=on:utc_ref=tc:xs=2026-02-25T00:00:00Z -o http://localhost:8080/upload/channel/live.mpd:push:post:dashif.ingest:segdur=2:keep_utc
```

- `bsrw:tc=utc` to add UTC timestamps as timecode
- `reframer:utc_ref=tc` to use timecodes as reference and `reframer:xs=...` to define a epoch time
- `dasher:[profile=]dashif.ingest` to inherit `dashif.ll` profile and enable CMAF and use DASH-IF Ingest template.
- `dasher:keep_utc` to use the epoch time as `mvhd` creation/modification time