### PR TITLE
Fix off-by-one stack overflow in gf_cache_create_entry()

### DIFF
--- a/src/utils/downloader_cache.c
+++ b/src/utils/downloader_cache.c
@@ -531,7 +531,7 @@ DownloadedCacheEntry gf_cache_create_entry(const char * cache_directory, const c
 	if (!url || !cache_directory) return NULL;
 
 	sz = (u32) strlen ( url );
-	if ( sz > GF_MAX_PATH ) {
+	if ( sz >= GF_MAX_PATH ) {
 		GF_LOG(GF_LOG_WARNING, GF_LOG_CACHE,
 		       ("[CACHE] ERROR, URL is too long (%d chars), more than %d chars.\n", sz, GF_MAX_PATH ));
 		return NULL;
@@ -631,7 +631,7 @@ DownloadedCacheEntry gf_cache_create_entry(const char * cache_directory, const c
 	gf_dynstrcat(&entry->cfg_filename, cache_file_info_suffix, NULL);
 
 	char szLOCK[GF_MAX_PATH];
-	sprintf(szLOCK, "%s.lock", entry->cfg_filename);
+	snprintf(szLOCK, sizeof(szLOCK), "%s.lock", entry->cfg_filename);
 	GF_LockStatus lock_type = cache_entry_lock(szLOCK);
 	if (!lock_type) {
 		GF_LOG(GF_LOG_ERROR, GF_LOG_CACHE, ("[CACHE] Failed to grab cache lock for entry %s, request will not be cached\n", url));


### PR DESCRIPTION
## Summary
- Fix off-by-one stack-buffer-overflow in `gf_cache_create_entry()` (`src/utils/downloader_cache.c`)
- Root cause: boundary check `sz > GF_MAX_PATH` allows `strlen(url) == GF_MAX_PATH` to pass, then `strcpy(tmp, url)` writes `GF_MAX_PATH + 1` bytes (including NUL) into a `GF_MAX_PATH`-sized stack buffer
- Fix: change check to `sz >= GF_MAX_PATH`; also harden nearby `sprintf` → `snprintf` for `szLOCK` buffer

## Reproduction
Build with `-fsanitize=address` (GCC), then:
```bash
python3 -m http.server 8000 --directory /tmp &
URL=$(python3 -c "print('http://127.0.0.1:8000/' + 'A'*(4096-22))")
gpac -i "${URL}:gpac:cache=disk" -o null
```
Before: `AddressSanitizer: stack-buffer-overflow`, `WRITE of size 4097`.
After: URL correctly rejected with `[CACHE] ERROR, URL is too long`, no sanitizer errors.

Fixes #3497

This patch is generated by ASKRepair, an agentic automated vulnerability repair framework.