### PR TITLE
Fix stack buffer overflow in fileout_open_close() when copying output path

### DIFF
--- a/src/filters/out_file.c
+++ b/src/filters/out_file.c
@@ -178,9 +178,13 @@ static GF_Err fileout_open_close(GF_FileOutCtx *ctx, const char *filename, const
 		url = gf_fileio_translate_url(filename);
 		is_gfio=GF_TRUE;
 	}
+	if (url && (strlen(url) >= GF_MAX_PATH)) return GF_IO_ERR;
+	if (ctx->dst && (strlen(ctx->dst) >= GF_MAX_PATH)) return GF_IO_ERR;
 
 	if (ctx->dynext) {
 		const char *has_ext = gf_file_ext_start(url);
+
+		if (!has_ext && ext && (strlen(url) + strlen(ext) + 1 >= GF_MAX_PATH)) return GF_IO_ERR;
 
 		strcpy(szFinalName, url);
 		if (!has_ext && ext) {
@@ -243,6 +247,7 @@ static GF_Err fileout_open_close(GF_FileOutCtx *ctx, const char *filename, const
 	}
 	strcpy(szName, szFinalName);
 	if (ctx->use_move) {
+		if (strlen(szName) + strlen(ATOMIC_SUFFIX) >= GF_MAX_PATH) return GF_IO_ERR;
 		strcat(szName, ATOMIC_SUFFIX);
 	}
 


### PR DESCRIPTION
## Summary
- Fix stack-buffer-overflow in `fileout_open_close()` (`src/filters/out_file.c`)
- Root cause: unbounded `strcpy`/`strcat` copies user-supplied output path into fixed-size stack buffer `char szFinalName[GF_MAX_PATH]` without length validation
- Fix: add bounds checks (`strlen >= GF_MAX_PATH`) before each `strcpy`/`strcat`, returning `GF_IO_ERR` when the path is too long

## Reproduction
Build with `-fsanitize=address` (GCC), then:
```bash
gpac -i valid_input.mp4 -o "$(python3 -c 'print("X"*5996 + ".mp4")')"
```
Before: `AddressSanitizer: stack-buffer-overflow`, `WRITE of size 6001`.
After: FileOut gracefully rejects the too-long path, no sanitizer errors.


Fixes #3496