### PR TITLE
fix multi-key write format to use `use_mkey` flag

### DIFF
--- a/src/isomedia/box_code_base.c
+++ b/src/isomedia/box_code_base.c
@@ -10716,7 +10716,7 @@ void sgpd_write_entry(u32 grouping_type, void *entry, GF_BitStream *bs)
 			gf_bs_write_int(bs, seig->skip_byte_block, 4);
 		}
 		gf_bs_write_u8(bs, seig->IsProtected);
-		if (nb_keys>1) {
+		if (use_mkey) {
 			gf_bs_write_data(bs, seig->key_info+1, seig->key_info_size-1);
 		} else {
 			gf_bs_write_data(bs, seig->key_info+3, seig->key_info_size - 3);


### PR DESCRIPTION
`sgpd_write_entry()` checked nb_keys>1 to decide whether to write the multi-key format, but `sgpd_size_entry()` uses use_mkey. When multi-key is enabled with a single key (e.g. `multiKey="subs=1,0"` for per-subsample encryption), the write path skipped the 2-byte `key_count` field, causing a box size mismatch and corrupted output.

This change uses the same `use_mkey` flag that `sgpd_size_entry()` already uses.