### PR TITLE
fix integer overflow in NHML zlib compress allocation

### DIFF
--- a/src/filters/dmx_nhml.c
+++ b/src/filters/dmx_nhml.c
@@ -549,6 +549,10 @@ static GF_Err compress_sample_data(GF_NHMLDmxCtx *ctx, u32 compress_type, char *
 
 	if (!ctx) return GF_OK;
 
+	if (ctx->samp_buffer_size > GF_UINT_MAX / ZLIB_COMPRESS_SAFE) {
+		GF_LOG(GF_LOG_ERROR, GF_LOG_PARSER, ("[NHMLDmx] sample buffer size %u too large for zlib allocation\n", ctx->samp_buffer_size));
+		return GF_OUT_OF_MEM;
+	}
 	size = ctx->samp_buffer_size*ZLIB_COMPRESS_SAFE;
 	if (ctx->zlib_buffer_alloc < size) {
 		ctx->zlib_buffer_alloc = size;


### PR DESCRIPTION
## Summary

  `compress_sample_data()` in `dmx_nhml.c` computes the zlib output buffer size as `samp_buffer_size * ZLIB_COMPRESS_SAFE` (4).
  When `samp_buffer_size` exceeds `GF_UINT_MAX / 4` (~1 GB), the `u32` multiplication wraps to a small value, allocating a tiny buffer while `deflate()` writes the full compressed output — heap buffer overflow.
  `samp_buffer_size` is set from the `dataLength` XML attribute in NHML input, which is attacker-controlled.

  ## Fix

  Add an overflow guard before the multiplication, returning `GF_OUT_OF_MEM` if the size would wrap.

  ## Testing

  - Full build with `./configure --unittests && make` — clean, no warnings
  - Unit tests: 14/14 pass, 191/191 checks pass
  - cppcheck with `--check-level=exhaustive` — no overflow warnings on fixed file