### PR TITLE
GPAC H3 & H2/1: add metrics collection and QUIC tuning options (ngtcp2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,16 @@
+# Certificates / keys
+*.pem
+*.key
+*.csr
+
+# Media / outputs
+*.mp4
+
+# Benchmark outputs
+*.csv
+
+# Local scripts
+benchmark.py
 
 *.o
 *.suo

--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,3 @@
-# Certificates / keys
-*.pem
-*.key
-*.csr
-
-# Media / outputs
-*.mp4
-
-# Benchmark outputs
-*.csv
-
-# Local scripts
-benchmark.py
 
 *.o
 *.suo

--- a/src/utils/downloader.c
+++ b/src/utils/downloader.c
@@ -22,8 +22,9 @@
  *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
  *
  */
-
+#include <inttypes.h>
 #include "downloader.h"
+#include <sys/resource.h>
 
 #ifndef GPAC_DISABLE_NETWORK
 
@@ -2354,44 +2355,86 @@ void gf_dm_data_received(GF_DownloadSession *sess, u8 *payload, u32 payload_size
 		u64 run_time;
 
 #ifdef GPAC_HTTPMUX
-		if (sess->hmux_sess && !sess->server_mode)
-			sess->hmux_stream_id = -1;
+        if (sess->hmux_sess && !sess->server_mode)
+            sess->hmux_stream_id = -1;
 #endif
 
-		if (sess->use_cache_file) {
-			//for chunk transfer or H2/H3
-			gf_cache_set_content_length(sess->cache_entry, sess->total_size);
-			gf_cache_close_write_cache(sess->cache_entry, sess, GF_TRUE);
-			GF_LOG(GF_LOG_DEBUG, GF_LOG_CACHE,
-			       ("[CACHE] url %s saved as %s\n", gf_cache_get_url(sess->cache_entry), gf_cache_get_cache_filename(sess->cache_entry)));
+        if (sess->use_cache_file) {
+            //for chunk transfer or H2/H3
+            gf_cache_set_content_length(sess->cache_entry, sess->total_size);
+            gf_cache_close_write_cache(sess->cache_entry, sess, GF_TRUE);
+            GF_LOG(GF_LOG_DEBUG, GF_LOG_CACHE,
+                   ("[CACHE] url %s saved as %s\n", gf_cache_get_url(sess->cache_entry), gf_cache_get_cache_filename(sess->cache_entry)));
 
-			if (sess->dm && sess->dm->cache_clean_ms) {
-				sess->dm->cur_cache_size += sess->total_size;
-				if (sess->dm->cur_cache_size > sess->dm->max_cache_size) {
-					if (!sess->dm->next_cache_clean) sess->dm->next_cache_clean = gf_sys_clock()+sess->dm->cache_clean_ms;
-					else if (gf_sys_clock()>sess->dm->next_cache_clean) {
-						sess->dm->cur_cache_size = gf_cache_cleanup(sess->dm->cache_directory, sess->dm->max_cache_size);
-						sess->dm->next_cache_clean = 0;
-					}
-				}
-			}
-		}
+            if (sess->dm && sess->dm->cache_clean_ms) {
+                sess->dm->cur_cache_size += sess->total_size;
+                if (sess->dm->cur_cache_size > sess->dm->max_cache_size) {
+                    if (!sess->dm->next_cache_clean) sess->dm->next_cache_clean = gf_sys_clock()+sess->dm->cache_clean_ms;
+                    else if (gf_sys_clock()>sess->dm->next_cache_clean) {
+                        sess->dm->cur_cache_size = gf_cache_cleanup(sess->dm->cache_directory, sess->dm->max_cache_size);
+                        sess->dm->next_cache_clean = 0;
+                    }
+                }
+            }
+        }
 
-		gf_dm_disconnect(sess, HTTP_NO_CLOSE);
-		par.msg_type = GF_NETIO_DATA_TRANSFERED;
-		par.error = GF_OK;
+        gf_dm_disconnect(sess, HTTP_NO_CLOSE);
+        par.msg_type = GF_NETIO_DATA_TRANSFERED;
+        par.error = GF_OK;
 
-		gf_dm_sess_user_io(sess, &par);
-		sess->total_time_since_req = (u32) (gf_sys_clock_high_res() - sess->request_start_time);
-		run_time = gf_sys_clock_high_res() - sess->start_time;
+        gf_dm_sess_user_io(sess, &par);
+        sess->total_time_since_req = (u32) (gf_sys_clock_high_res() - sess->request_start_time);
+        run_time = gf_sys_clock_high_res() - sess->start_time;
 
-		GF_LOG(GF_LOG_INFO, GF_LOG_HTTP, ("[%s] %s (%d bytes) downloaded in "LLU" us (%d kbps) (%d us since request - got response in %d us)\n", sess->log_name, gf_file_basename(gf_cache_get_url(sess->cache_entry)), sess->bytes_done,
-		                                     run_time, 8*sess->bytes_per_sec/1000, sess->total_time_since_req, sess->reply_time));
+        GF_LOG(GF_LOG_INFO, GF_LOG_HTTP,
+   ("[%s] %s (%d bytes) downloaded in "LLU" us (%d kbps) (%d us since request - got response in %d us)\n",
+    sess->log_name,
+    gf_file_basename(gf_cache_get_url(sess->cache_entry)),
+    sess->bytes_done,
+    run_time,
+    8*sess->bytes_per_sec/1000,
+    sess->total_time_since_req,
+    sess->reply_time));
 
-		if (sess->chunked && (payload_size==2))
-			payload_size=0;
-		sess->last_error = GF_OK;
-	}
+/*  H1-METRICS (only for true H1)  */
+{
+    Bool is_h1 = GF_TRUE;
+    /* If HTTP/2 mux is present 1 */
+#if defined(GPAC_HTTPMUX)
+    if (sess->hmux_sess) is_h1 = GF_FALSE;
+#endif
+    /* If QUIC/H3 flag is set */
+    if (sess->flags & GF_NETIO_SESSION_USE_QUIC) is_h1 = GF_FALSE;
+
+    if (is_h1) {
+        struct rusage usage;
+        getrusage(RUSAGE_SELF, &usage);
+
+        double dur_s = (double)sess->total_time_since_req / 1e6;
+        double thr   = (dur_s > 0) ? (8.0 * (double)sess->bytes_done / dur_s / 1e6) : 0.0;
+
+        GF_LOG(GF_LOG_INFO, GF_LOG_HTTP,
+           ("[H1-METRICS] mode=%s url=%s bytes=%" PRIu64 " ttfb_us=%u dur_us=%u thr=%.3fMb/s "
+            "cpu_user_ms=%ld cpu_sys_ms=%ld mem=%ld phase=%s\n",
+            sess->server_mode ? "server" : "client",
+            sess->orig_url ? sess->orig_url : "",
+            sess->bytes_done,
+            sess->reply_time,
+            sess->total_time_since_req,
+            thr,
+            usage.ru_utime.tv_sec*1000 + usage.ru_utime.tv_usec/1000,
+            usage.ru_stime.tv_sec*1000 + usage.ru_stime.tv_usec/1000,
+            usage.ru_maxrss,
+            sess->last_error ? "error" : "close"));
+    }
+}
+/* end H1-METRICS  */
+
+        if (sess->chunked && (payload_size==2))
+            payload_size = 0;
+        sess->last_error = GF_OK;
+
+    }
 
 	if (rewrite_size && sess->chunked && data) {
 		if (original_payload) {

--- a/src/utils/downloader.c
+++ b/src/utils/downloader.c
@@ -2355,8 +2355,8 @@ void gf_dm_data_received(GF_DownloadSession *sess, u8 *payload, u32 payload_size
 		u64 run_time;
 
 #ifdef GPAC_HTTPMUX
-        if (sess->hmux_sess && !sess->server_mode)
-            sess->hmux_stream_id = -1;
+if (sess->hmux_sess && !sess->server_mode)
+    sess->hmux_stream_id = -1;
 #endif
 
         if (sess->use_cache_file) {

--- a/src/utils/downloader.h
+++ b/src/utils/downloader.h
@@ -40,14 +40,14 @@
 #include <gpac/crypt.h>
 
 #ifdef GPAC_HAS_SSL
-#ifdef GPAC_HAS_NGTCP2
-#include <openssl/types.h>
-#endif
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
+#ifdef GPAC_HAS_NGTCP2
+//#include <openssl/types.h>
+#endif
 #endif
 
 #ifdef GPAC_HAS_CURL
@@ -360,6 +360,9 @@ struct __gf_download_session
 	u8 *local_buf;
 	u32 local_buf_len, local_buf_alloc;
 #endif
+    /* Custom metrics storage for H3 (and H2) */
+    void *metrics_priv;
+
 
 };
 

--- a/src/utils/downloader_nghttp2.c
+++ b/src/utils/downloader_nghttp2.c
@@ -36,8 +36,106 @@
 #pragma comment(lib, "nghttp2")
 #endif
 
+/* 
+ * Inline metrics collection
+ *
+ * Emits one CSV line per transfer if GPAC_METRICS is set, otherwise emits a single log line.
+ * Collected:
+ *  - bytes
+ *  - ttfb_us (submit -> first data)
+ *  - duration_us (submit -> end)
+ *  - throughput_mbps (computed)
+ *  - cpu_user_ms, cpu_sys_ms, maxrss_kb (best-effort via getrusage on POSIX)
+ */
+
+#if !defined(_WIN32)
+#include <sys/time.h>
+#include <sys/resource.h>
+#endif
+#include <stdio.h>
+
+typedef struct {
+	u64 t_submit_us;    /* request submit time */
+	u64 t_first_us;     /* first byte time (0 until set) */
+	u64 t_end_us;       /* end time */
+	u64 bytes;          /* payload bytes received/sent */
+	/* process resource snapshot at end (best-effort) */
+	long ru_maxrss_kb;
+	long user_ms;
+	long sys_ms;
+} H2Metrics;
+
+static inline u64 h2_now_us(void) { return gf_sys_clock_high_res(); }
+
+static inline const char *h2_mode_str(const GF_DownloadSession *sess) {
+    return (sess && sess->server_mode) ? "server" : "client";
+}
+
+
+static void h2_metrics_capture_rusage(H2Metrics *m)
+{
+	if (!m) return;
+#if !defined(_WIN32)
+	struct rusage ru;
+	if (getrusage(RUSAGE_SELF, &ru)==0) {
+		m->ru_maxrss_kb = ru.ru_maxrss; /* KB on Linux */
+		m->user_ms = (long)(ru.ru_utime.tv_sec*1000L + ru.ru_utime.tv_usec/1000);
+		m->sys_ms  = (long)(ru.ru_stime.tv_sec*1000L + ru.ru_stime.tv_usec/1000);
+	}
+#endif
+}
+
+static void h2_metrics_emit(const GF_DownloadSession *sess, const H2Metrics *m, const char *phase)
+{
+	if (!m) return;
+
+	double dur_s  = (m->t_end_us > m->t_submit_us) ? (m->t_end_us - m->t_submit_us)/1e6 : 0.0;
+	double ttfb_s = (m->t_first_us && (m->t_first_us >= m->t_submit_us)) ? (m->t_first_us - m->t_submit_us)/1e6 : 0.0;
+	double mbps   = (dur_s>0) ? ((double)m->bytes * 8.0 / dur_s / 1e6) : 0.0;
+
+	const char *csv = getenv("GPAC_METRICS");
+
+	const char *url  = (sess && sess->orig_url) ? sess->orig_url : "";
+	const char *mode = h2_mode_str(sess);
+	const char *ph   = phase ? phase : "";
+
+	if (csv && csv[0]) {
+		FILE *f = fopen(csv, "a");
+		if (f) {
+			/* proto,mode,url,bytes,ttfb_us,duration_us,throughput_mbps,cpu_user_ms,cpu_sys_ms,maxrss_kb,phase */
+			fprintf(f, "h2,%s,%s,%llu,%llu,%llu,%.3f,%ld,%ld,%ld,%s\n",
+				mode, url,
+				(unsigned long long)m->bytes,
+				(unsigned long long)(m->t_first_us ? (m->t_first_us - m->t_submit_us) : 0),
+				(unsigned long long)(m->t_end_us - m->t_submit_us),
+				mbps, m->user_ms, m->sys_ms, m->ru_maxrss_kb, ph);
+			fclose(f);
+		}
+	} else {
+		GF_LOG(GF_LOG_INFO, GF_LOG_HTTP,
+			("[H2-METRICS] mode=%s url=%s bytes=%llu ttfb_us=%llu dur_us=%llu thr=%.3fMb/s cpu_user_ms=%ld cpu_sys_ms=%ld rss_kb=%ld phase=%s\n",
+			 mode, url,
+			 (unsigned long long)m->bytes,
+			 (unsigned long long)(m->t_first_us ? (m->t_first_us - m->t_submit_us) : 0),
+			 (unsigned long long)(m->t_end_us - m->t_submit_us),
+			 mbps, m->user_ms, m->sys_ms, m->ru_maxrss_kb, ph));
+	}
+}
+
+/* Accessor: pack metrics right after nghttp2_data_provider in hmux_priv */
+static inline H2Metrics *h2_metrics_ptr(GF_DownloadSession *sess)
+{
+    if (!sess || !sess->hmux_priv) return NULL;
+    return (H2Metrics *)((u8*)sess->hmux_priv + sizeof(nghttp2_data_provider));
+}
+
 
 static void h2_flush_send_ex(GF_DownloadSession *sess, Bool flush_local_buf);
+
+/* 
+ * Original code follows,
+ * with small hooks for metrics + restored h2c gate
+ */
 
 static int h2_header_callback(nghttp2_session *session,
 								const nghttp2_frame *frame, const uint8_t *name,
@@ -114,68 +212,95 @@ static int h2_begin_headers_callback(nghttp2_session *session, const nghttp2_fra
 
 static int h2_frame_recv_callback(nghttp2_session *session, const nghttp2_frame *frame, void *user_data)
 {
-	GF_DownloadSession *sess;
-	switch (frame->hd.type) {
-	case NGHTTP2_HEADERS:
-		sess = hmux_get_session(user_data, frame->hd.stream_id, GF_FALSE);
-		if (!sess)
-			return NGHTTP2_ERR_CALLBACK_FAILURE;
+    GF_DownloadSession *sess;
+    switch (frame->hd.type) {
+    case NGHTTP2_HEADERS:
+        sess = hmux_get_session(user_data, frame->hd.stream_id, GF_FALSE);
+        if (!sess)
+            return NGHTTP2_ERR_CALLBACK_FAILURE;
 
-		if (
-			(!sess->server_mode && (frame->headers.cat == NGHTTP2_HCAT_RESPONSE))
-			|| (sess->server_mode && ((frame->headers.cat == NGHTTP2_HCAT_HEADERS) || (frame->headers.cat == NGHTTP2_HCAT_REQUEST)))
-		) {
-			sess->hmux_headers_seen = 1;
-			if (sess->server_mode) {
-				GF_LOG(GF_LOG_DEBUG, GF_LOG_HTTP, ("[HTTP/2] All headers received for stream ID "LLD"\n", sess->hmux_stream_id));
-			} else {
-				GF_LOG(GF_LOG_DEBUG, GF_LOG_HTTP, ("[HTTP/2] All headers received for stream ID "LLD"\n", sess->hmux_stream_id));
-			}
-		}
-		if (frame->hd.flags & NGHTTP2_FLAG_END_STREAM) {
-			GF_LOG(GF_LOG_DEBUG, GF_LOG_HTTP, ("[HTTP/2] stream_id %d (%s) data done\n", frame->hd.stream_id, sess->remote_path ? sess->remote_path : sess->orig_url));
-			sess->hmux_data_done = 1;
-			sess->hmux_is_eos = 0;
-			sess->hmux_send_data = NULL;
-			sess->hmux_send_data_len = 0;
-		}
-		break;
-	case NGHTTP2_DATA:
-		if (frame->hd.flags & NGHTTP2_FLAG_END_STREAM) {
-			sess = hmux_get_session(user_data, frame->hd.stream_id, GF_FALSE);
-			//if no session with such ID this means we got all our bytes and considered the session done, do not throw an error
-			if (sess) {
-				GF_LOG(GF_LOG_DEBUG, GF_LOG_HTTP, ("[HTTP/2] stream_id %d (%s) data done\n", frame->hd.stream_id, sess->remote_path ? sess->remote_path : sess->orig_url));
-				sess->hmux_data_done = 1;
-			}
-		}
-		break;
-	case NGHTTP2_RST_STREAM:
-		sess = hmux_get_session(user_data, frame->hd.stream_id, GF_FALSE);
-		// cancel from remote peer, signal if not done
-		if (sess && sess->server_mode && !sess->hmux_is_eos) {
-			GF_NETIO_Parameter param;
-			GF_LOG(GF_LOG_DEBUG, GF_LOG_HTTP, ("[HTTP/2] stream_id %d (%s) canceled\n", frame->hd.stream_id, sess->remote_path ? sess->remote_path : sess->orig_url));
-			memset(&param, 0, sizeof(GF_NETIO_Parameter));
-			param.msg_type = GF_NETIO_CANCEL_STREAM;
-			gf_mx_p(sess->mx);
-			sess->in_callback = GF_TRUE;
-			param.sess = sess;
-			sess->user_proc(sess->usr_cbk, &param);
-			sess->in_callback = GF_FALSE;
-			gf_mx_v(sess->mx);
-		}
-		break;
-	}
+        if (
+            (!sess->server_mode && (frame->headers.cat == NGHTTP2_HCAT_RESPONSE))
+            || (sess->server_mode && ((frame->headers.cat == NGHTTP2_HCAT_HEADERS) || (frame->headers.cat == NGHTTP2_HCAT_REQUEST)))
+        ) {
+            sess->hmux_headers_seen = 1;
 
-	return 0;
+            /* Set TTFB at first response headers (submit -> headers) */
+            if (!sess->server_mode && !sess->reply_time) {
+                H2Metrics *m = h2_metrics_ptr(sess);
+                if (m && m->t_submit_us) {
+                    u64 now = h2_now_us();
+                    sess->reply_time = (u32)(now - m->t_submit_us);
+                }
+            }
+
+            if (sess->server_mode) {
+                GF_LOG(GF_LOG_DEBUG, GF_LOG_HTTP, ("[HTTP/2] All headers received for stream ID "LLD"\n", sess->hmux_stream_id));
+            } else {
+                GF_LOG(GF_LOG_DEBUG, GF_LOG_HTTP, ("[HTTP/2] All headers received for stream ID "LLD"\n", sess->hmux_stream_id));
+            }
+        }
+        if (frame->hd.flags & NGHTTP2_FLAG_END_STREAM) {
+            GF_LOG(GF_LOG_DEBUG, GF_LOG_HTTP, ("[HTTP/2] stream_id %d (%s) data done\n", frame->hd.stream_id, sess->remote_path ? sess->remote_path : sess->orig_url));
+            sess->hmux_data_done = 1;
+            sess->hmux_is_eos = 0;
+            sess->hmux_send_data = NULL;
+            sess->hmux_send_data_len = 0;
+        }
+        break;
+
+    case NGHTTP2_DATA:
+        if (frame->hd.flags & NGHTTP2_FLAG_END_STREAM) {
+            sess = hmux_get_session(user_data, frame->hd.stream_id, GF_FALSE);
+            // if no session with such ID this means we got all our bytes and considered the session done, do not throw an error
+            if (sess) {
+                GF_LOG(GF_LOG_DEBUG, GF_LOG_HTTP, ("[HTTP/2] stream_id %d (%s) data done\n", frame->hd.stream_id, sess->remote_path ? sess->remote_path : sess->orig_url));
+                sess->hmux_data_done = 1;
+            }
+        }
+        break;
+
+    case NGHTTP2_RST_STREAM:
+        sess = hmux_get_session(user_data, frame->hd.stream_id, GF_FALSE);
+        // cancel from remote peer, signal if not done
+        if (sess && sess->server_mode && !sess->hmux_is_eos) {
+            GF_NETIO_Parameter param;
+            GF_LOG(GF_LOG_DEBUG, GF_LOG_HTTP, ("[HTTP/2] stream_id %d (%s) canceled\n", frame->hd.stream_id, sess->remote_path ? sess->remote_path : sess->orig_url));
+            memset(&param, 0, sizeof(GF_NETIO_Parameter));
+            param.msg_type = GF_NETIO_CANCEL_STREAM;
+            gf_mx_p(sess->mx);
+            sess->in_callback = GF_TRUE;
+            param.sess = sess;
+            sess->user_proc(sess->usr_cbk, &param);
+            sess->in_callback = GF_FALSE;
+            gf_mx_v(sess->mx);
+        }
+        break;
+    }
+
+    return 0;
 }
+
 
 static int h2_data_chunk_recv_callback(nghttp2_session *session, uint8_t flags, int32_t stream_id, const uint8_t *data, size_t len, void *user_data)
 {
 	GF_DownloadSession *sess = hmux_get_session(user_data, stream_id, GF_FALSE);
 	if (!sess)
 		return NGHTTP2_ERR_CALLBACK_FAILURE;
+
+	/* Metrics: first byte + accumulate bytes */
+	{
+		H2Metrics *m = h2_metrics_ptr(sess);
+if (m) {
+    if (!m->t_first_us) {
+        m->t_first_us = h2_now_us();
+        /* Fallback TTFB if HEADERS didn’t set it */
+        if (!sess->reply_time && m->t_submit_us)
+            sess->reply_time = (u32)(m->t_first_us - m->t_submit_us);
+    }
+    m->bytes += (u64)len;
+}
+	}
 
 	if (sess->hmux_buf.size + len > sess->hmux_buf.alloc) {
 		sess->hmux_buf.alloc = sess->hmux_buf.size + (u32) len;
@@ -184,7 +309,7 @@ static int h2_data_chunk_recv_callback(nghttp2_session *session, uint8_t flags, 
 	}
 	memcpy(sess->hmux_buf.data + sess->hmux_buf.size, data, len);
 	sess->hmux_buf.size += (u32) len;
-	GF_LOG(GF_LOG_DEBUG, GF_LOG_HTTP, ("[HTTP/2] stream_id "LLD" received %d bytes (%d/%d total) - flags %d\n", sess->hmux_stream_id, len, sess->hmux_buf.size, sess->total_size, flags));
+	GF_LOG(GF_LOG_DEBUG, GF_LOG_HTTP, ("[HTTP/2] stream_id "LLD" received %d bytes (%d/%d total) - flags %d\n", sess->hmux_stream_id, (int)len, (int)sess->hmux_buf.size, (int)sess->total_size, (int)flags));
 	return 0;
 }
 
@@ -227,6 +352,16 @@ static int h2_stream_close_callback(nghttp2_session *session, int32_t stream_id,
 		}
 	}
 
+	/* Metrics: finalize and emit on close (with error or success) */
+	{
+		H2Metrics *m = h2_metrics_ptr(sess);
+		if (m) {
+			if (!m->t_end_us) m->t_end_us = h2_now_us();
+			h2_metrics_capture_rusage(m);
+			h2_metrics_emit(sess, m, error_code ? "error" : "close");
+		}
+	}
+
 	//stream closed
 	sess->hmux_stream_id = -1;
 	gf_mx_v(sess->mx);
@@ -245,10 +380,10 @@ static ssize_t h2_write_data(GF_DownloadSession *sess, const uint8_t *data, size
 	GF_Err e = dm_sess_write(sess, data, (u32) length);
 	switch (e) {
 	case GF_OK:
-		return length;
+		return (ssize_t)length;
 	case GF_IP_NETWORK_EMPTY:
 		if (sess->flags & GF_NETIO_SESSION_NO_BLOCK)
-			return length;
+			return (ssize_t)length;
 		return NGHTTP2_ERR_WOULDBLOCK;
 	case GF_IP_CONNECTION_CLOSED:
 		SET_LAST_ERR(GF_IP_CONNECTION_CLOSED)
@@ -300,14 +435,14 @@ ssize_t h2_data_source_read_callback(nghttp2_session *session, int32_t stream_id
 		memcpy(buf, sess->hmux_send_data, copy);
 		sess->hmux_send_data += copy;
 		sess->hmux_send_data_len -= copy;
-		return copy;
+		return (ssize_t)copy;
 	}
 
 	*data_flags = NGHTTP2_DATA_FLAG_NO_COPY;
 	if (sess->hmux_send_data_len > length) {
-		return length;
+		return (ssize_t)length;
 	}
-	return sess->hmux_send_data_len;
+	return (ssize_t)sess->hmux_send_data_len;
 }
 
 
@@ -341,7 +476,7 @@ static int h2_send_data_callback(nghttp2_session *session, nghttp2_frame *frame,
 
 	while (frame->data.padlen > 0) {
 		u32 padlen = (u32) frame->data.padlen - 1;
-		rv = h2_write_data(sess, padding, padlen);
+		rv = h2_write_data(sess, (const uint8_t*)padding, padlen);
 		if (rv<0) {
 			if (rv==NGHTTP2_ERR_WOULDBLOCK) continue;
 			goto err;
@@ -469,6 +604,17 @@ GF_Err h2_submit_request(GF_DownloadSession *sess, char *req_name, const char *u
 		gf_assert(data_io->source.ptr != NULL);
 	}
 #endif
+
+	/* Metrics: mark request submit time and reset counters */
+	{
+		H2Metrics *m = h2_metrics_ptr(sess);
+		if (m) {
+			memset(m, 0, sizeof(*m));
+			m->t_submit_us = h2_now_us();
+			m->bytes = 0;
+		}
+	}
+
 	sess->hmux_data_done = 0;
 	sess->hmux_headers_seen = 0;
 	sess->hmux_stream_id = nghttp2_submit_request(sess->hmux_sess->hmux_udta, NULL, hdrs, nb_hdrs+4,
@@ -615,12 +761,21 @@ static GF_Err h2_setup_session(GF_DownloadSession *sess, Bool is_destroy)
 		return GF_OK;
 	}
 	if (!sess->hmux_priv) {
-		GF_SAFEALLOC(sess->hmux_priv, nghttp2_data_provider);
-		if (!sess->hmux_priv) return GF_OUT_OF_MEM;
+		/* Allocate a single block for nghttp2_data_provider + inline H2Metrics */
+		void *blk = gf_malloc(sizeof(nghttp2_data_provider) + sizeof(H2Metrics));
+		if (!blk) return GF_OUT_OF_MEM;
+		memset(blk, 0, sizeof(nghttp2_data_provider) + sizeof(H2Metrics));
+		sess->hmux_priv = blk;
 	}
-	nghttp2_data_provider *data_io = sess->hmux_priv;
+	nghttp2_data_provider *data_io = (nghttp2_data_provider*)sess->hmux_priv;
 	data_io->read_callback = h2_data_source_read_callback;
 	data_io->source.ptr = sess;
+
+	/* Metrics: clear on (re)setup */
+	{
+		H2Metrics *m = h2_metrics_ptr(sess);
+		if (m) memset(m, 0, sizeof(*m));
+	}
 	return GF_OK;
 }
 
@@ -739,24 +894,58 @@ void h2_initialize_session(GF_DownloadSession *sess)
 		nghttp2_session_callbacks_set_send_data_callback(callbacks, h2_send_data_callback);
 
 	if (sess->server_mode) {
-		nghttp2_session_server_new((nghttp2_session**) &sess->hmux_sess->hmux_udta, callbacks, sess->hmux_sess);
-	} else {
-		nghttp2_session_client_new((nghttp2_session**) &sess->hmux_sess->hmux_udta, callbacks, sess->hmux_sess);
-	}
-	nghttp2_session_callbacks_del(callbacks);
-	sess->hmux_sess->net_sess = sess;
-	//setup function pointers
-	sess->hmux_sess->submit_request = h2_submit_request;
-	sess->hmux_sess->send_reply = h2_send_reply;
-	sess->hmux_sess->write = h2_session_write;
-	sess->hmux_sess->destroy = h2_destroy;
-	sess->hmux_sess->stream_reset = h2_stream_reset;
-	sess->hmux_sess->resume = h2_resume_stream;
-	sess->hmux_sess->data_received = h2_data_received;
-	sess->hmux_sess->setup_session = h2_setup_session;
-	sess->hmux_sess->send_pending_data = h2_data_pending;
-	sess->hmux_sess->async_flush = h2_async_flush;
-	sess->hmux_sess->close_session = h2_close_session;
+    nghttp2_session_server_new((nghttp2_session**)&sess->hmux_sess->hmux_udta, callbacks, sess->hmux_sess);
+} else {
+    nghttp2_session_client_new((nghttp2_session**)&sess->hmux_sess->hmux_udta, callbacks, sess->hmux_sess);
+}
+
+/* H2 THROUGHPUT TUNING */
+{
+    nghttp2_session *h2 = (nghttp2_session*)sess->hmux_sess->hmux_udta;
+
+    /* Big windows to avoid stop-and-go (tune as you like) */
+    const uint32_t H2_STREAM_WIN = 32u * 1024u * 1024u;  /* 32 MB per stream */
+    const uint32_t H2_CONN_WIN   = 64u * 1024u * 1024u;  /* 64 MB per connection */
+    const uint32_t H2_MAX_FRAME  = 1u  * 1024u * 1024u;  /* 1 MB frame size (optional, <= 16,777,215) */
+
+    /*  peer  use a large INITIAL_WINDOW_SIZE (fixing the bootleneck that we had earlier) */
+    nghttp2_settings_entry iv[] = {
+        { NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE,   H2_STREAM_WIN },
+        { NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, 256 },
+        { NGHTTP2_SETTINGS_MAX_FRAME_SIZE,        H2_MAX_FRAME }, /* optional but helps on localhost */
+    };
+    int rv = nghttp2_submit_settings(h2, NGHTTP2_FLAG_NONE, iv, (size_t)(sizeof(iv)/sizeof(iv[0])));
+    if (rv) {
+        GF_LOG(GF_LOG_WARNING, GF_LOG_HTTP, ("[HTTP/2] submit_settings failed: %d\n", rv));
+    }
+
+    /* Also enlarge OUR local receive window (connection level). Do this early. */
+    rv = nghttp2_session_set_local_window_size(h2, NGHTTP2_FLAG_NONE, 0 /* connection */, (int32_t)H2_CONN_WIN);
+    if (rv) {
+        GF_LOG(GF_LOG_WARNING, GF_LOG_HTTP, ("[HTTP/2] set_local_window_size(conn) failed: %d\n", rv));
+    }
+
+    /* Note: Per-stream local window for streams created later will use the advertised INITIAL_WINDOW_SIZE.
+       If you want to bump window for an already-open inbound stream, also call:
+         nghttp2_session_set_local_window_size(h2, NGHTTP2_FLAG_NONE, stream_id, (int32_t)H2_STREAM_WIN);
+       right after you accept/see its HEADERS. */
+}
+	
+nghttp2_session_callbacks_del(callbacks);
+
+sess->hmux_sess->net_sess = sess;
+/* setup function pointers */
+sess->hmux_sess->submit_request   = h2_submit_request;
+sess->hmux_sess->send_reply       = h2_send_reply;
+sess->hmux_sess->write            = h2_session_write;
+sess->hmux_sess->destroy          = h2_destroy;
+sess->hmux_sess->stream_reset     = h2_stream_reset;
+sess->hmux_sess->resume           = h2_resume_stream;
+sess->hmux_sess->data_received    = h2_data_received;
+sess->hmux_sess->setup_session    = h2_setup_session;
+sess->hmux_sess->send_pending_data= h2_data_pending;
+sess->hmux_sess->async_flush      = h2_async_flush;
+sess->hmux_sess->close_session    = h2_close_session;
 
 	sess->hmux_sess->connected = GF_TRUE;
 
@@ -812,6 +1001,17 @@ void http2_set_upgrade_headers(GF_DownloadSession *sess)
 		{NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, 100},
 		{NGHTTP2_SETTINGS_ENABLE_PUSH, 0}
 	};
+
+	/* Restore original gate:
+	   If GPAC_NO_H2=1, do NOT attempt clear-text HTTP/2 upgrade here.
+	   (Your boss noted the feature is already enabled elsewhere.) */
+	{
+		const char *env = getenv("GPAC_NO_H2");
+		if (env && !strcmp(env, "1")) {
+			GF_LOG(GF_LOG_INFO, GF_LOG_HTTP, ("[HTTP] HTTP/2 upgrade disabled via env var GPAC_NO_H2=1\n"));
+			return;
+		}
+	}
 
 	PUSH_HDR("Connection", "Upgrade, HTTP2-Settings")
 	PUSH_HDR("Upgrade", "h2c")

--- a/src/utils/downloader_nghttp2.c
+++ b/src/utils/downloader_nghttp2.c
@@ -88,9 +88,7 @@ static void h2_metrics_capture_rusage(H2Metrics *m)
 static void h2_metrics_emit(const GF_DownloadSession *sess, const H2Metrics *m, const char *phase)
 {
 	if (!m) return;
-
 	double dur_s  = (m->t_end_us > m->t_submit_us) ? (m->t_end_us - m->t_submit_us)/1e6 : 0.0;
-	double ttfb_s = (m->t_first_us && (m->t_first_us >= m->t_submit_us)) ? (m->t_first_us - m->t_submit_us)/1e6 : 0.0;
 	double mbps   = (dur_s>0) ? ((double)m->bytes * 8.0 / dur_s / 1e6) : 0.0;
 
 	const char *csv = getenv("GPAC_METRICS");

--- a/src/utils/downloader_nghttp2.c
+++ b/src/utils/downloader_nghttp2.c
@@ -36,7 +36,7 @@
 #pragma comment(lib, "nghttp2")
 #endif
 
-/* 
+/*
  * Inline metrics collection
  *
  * Emits one CSV line per transfer if GPAC_METRICS is set, otherwise emits a single log line.
@@ -122,7 +122,7 @@ static void h2_metrics_emit(const GF_DownloadSession *sess, const H2Metrics *m, 
 	}
 }
 
-/* Accessor: pack metrics right after nghttp2_data_provider in hmux_priv */
+/* Pack metrics right after nghttp2_data_provider in hmux_priv */
 static inline H2Metrics *h2_metrics_ptr(GF_DownloadSession *sess)
 {
     if (!sess || !sess->hmux_priv) return NULL;
@@ -132,8 +132,8 @@ static inline H2Metrics *h2_metrics_ptr(GF_DownloadSession *sess)
 
 static void h2_flush_send_ex(GF_DownloadSession *sess, Bool flush_local_buf);
 
-/* 
- * Original code follows,
+/*
+ * Original code,
  * with small hooks for metrics + restored h2c gate
  */
 
@@ -548,7 +548,7 @@ static GF_Err h2_data_received(GF_DownloadSession *sess, const u8 *data, u32 nb_
 	}
 	/* send pending frames - hmux_sess may be NULL at this point if the connection was reset during processing of the above
 		this typically happens if we have a refused stream
-	*/
+		*/
 	h2_session_write(sess);
 	return GF_OK;
 }
@@ -903,10 +903,10 @@ void h2_initialize_session(GF_DownloadSession *sess)
 {
     nghttp2_session *h2 = (nghttp2_session*)sess->hmux_sess->hmux_udta;
 
-    /* Big windows to avoid stop-and-go (tune as you like) */
+    /* Big windows to avoid stop-and-go */
     const uint32_t H2_STREAM_WIN = 32u * 1024u * 1024u;  /* 32 MB per stream */
     const uint32_t H2_CONN_WIN   = 64u * 1024u * 1024u;  /* 64 MB per connection */
-    const uint32_t H2_MAX_FRAME  = 1u  * 1024u * 1024u;  /* 1 MB frame size (optional, <= 16,777,215) */
+    const uint32_t H2_MAX_FRAME  = 1u  * 1024u * 1024u;  /* 1 MB frame size */
 
     /*  peer  use a large INITIAL_WINDOW_SIZE (fixing the bootleneck that we had earlier) */
     nghttp2_settings_entry iv[] = {
@@ -930,7 +930,7 @@ void h2_initialize_session(GF_DownloadSession *sess)
          nghttp2_session_set_local_window_size(h2, NGHTTP2_FLAG_NONE, stream_id, (int32_t)H2_STREAM_WIN);
        right after you accept/see its HEADERS. */
 }
-	
+
 nghttp2_session_callbacks_del(callbacks);
 
 sess->hmux_sess->net_sess = sess;
@@ -1003,8 +1003,7 @@ void http2_set_upgrade_headers(GF_DownloadSession *sess)
 	};
 
 	/* Restore original gate:
-	   If GPAC_NO_H2=1, do NOT attempt clear-text HTTP/2 upgrade here.
-	   (Your boss noted the feature is already enabled elsewhere.) */
+	   If GPAC_NO_H2=1, do NOT attempt clear-text HTTP/2 upgrade here.*/
 	{
 		const char *env = getenv("GPAC_NO_H2");
 		if (env && !strcmp(env, "1")) {

--- a/src/utils/downloader_ngtcp2.c
+++ b/src/utils/downloader_ngtcp2.c
@@ -46,10 +46,67 @@
 #include <ngtcp2/ngtcp2_crypto_quictls.h>
 #include <nghttp3/nghttp3.h>
 
+#if !defined(_WIN32)
+#include <sys/time.h>
+#include <sys/resource.h>
+#endif
+#include <stdio.h>
+
 #define NGTCP2_STATELESS_RESET_BURST 100
 #define NGTCP2_SV_SCIDLEN 18
 #define MAX_CONNID_LEN	255
 #define MAX_ADDR_LEN	100
+
+//amount of bytes we store internally
+#define SOCK_BUF_SIZE	200000
+
+// METRCIS TEST
+typedef struct {
+	u64 t_submit_us;    /* request submit time */
+	u64 t_first_us;     /* first byte time (0 until set) */
+	u64 t_end_us;       /* end time */
+	u64 bytes;          /* payload bytes received */
+	long ru_maxrss_kb;
+	long user_ms;
+	long sys_ms;
+} H3Metrics;
+static inline u64 h3_now_us(void) { return gf_sys_clock_high_res(); }
+
+static void h3_metrics_capture_rusage(H3Metrics *m)
+{
+    if (!m) return;
+#if !defined(_WIN32)
+    struct rusage ru;
+    if (getrusage(RUSAGE_SELF, &ru)==0) {
+        m->ru_maxrss_kb = ru.ru_maxrss;
+        m->user_ms = (long)(ru.ru_utime.tv_sec*1000L + ru.ru_utime.tv_usec/1000);
+        m->sys_ms  = (long)(ru.ru_stime.tv_sec*1000L + ru.ru_stime.tv_usec/1000);
+    }
+#endif
+}
+
+static void h3_metrics_emit(const GF_DownloadSession *sess, const H3Metrics *m, const char *phase)
+{
+    if (!m) return;
+
+    double dur_s  = (m->t_end_us > m->t_submit_us) ? (m->t_end_us - m->t_submit_us)/1e6 : 0.0;
+    double ttfb_s = (m->t_first_us && (m->t_first_us >= m->t_submit_us)) ? (m->t_first_us - m->t_submit_us)/1e6 : 0.0;
+    double mbps   = (dur_s>0) ? ((double)m->bytes * 8.0 / dur_s / 1e6) : 0.0;
+
+    const char *url  = (sess && sess->orig_url) ? sess->orig_url : "";
+    const char *mode = (sess && sess->server_mode) ? "server" : "client";
+    const char *ph   = phase ? phase : "";
+
+    GF_LOG(GF_LOG_INFO, GF_LOG_HTTP,
+        ("[H3-METRICS] mode=%s url=%s bytes=%llu ttfb_us=%llu dur_us=%llu thr=%.3fMb/s "
+         "cpu_user_ms=%ld cpu_sys_ms=%ld rss_kb=%ld phase=%s\n",
+         mode, url,
+         (unsigned long long)m->bytes,
+         (unsigned long long)(m->t_first_us ? (m->t_first_us - m->t_submit_us) : 0),
+         (unsigned long long)(m->t_end_us - m->t_submit_us),
+         mbps, m->user_ms, m->sys_ms, m->ru_maxrss_kb, ph));
+}
+
 
 const u8 *gf_sk_get_address(GF_Socket *sock, u32 *addr_size);
 
@@ -291,26 +348,44 @@ static nghttp3_ssize ngh3_data_source_read_callback(
 
 static GF_Err h3_setup_session(GF_DownloadSession *sess, Bool is_destroy)
 {
-	if (is_destroy) {
-		if (sess->hmux_priv) {
-			GF_QuicDataRead *qr = sess->hmux_priv;
-			if (qr->second_local_buf) gf_free(qr->second_local_buf);
-			gf_free(sess->hmux_priv);
-			sess->hmux_priv = NULL;
-		}
-		return GF_OK;
-	}
+    if (is_destroy) {
+        // destroy path 
+        if (sess->metrics_priv) {
+            gf_free(sess->metrics_priv);
+            sess->metrics_priv = NULL;
+        }
 
-	if (!sess->hmux_priv) {
-		GF_SAFEALLOC(sess->hmux_priv, GF_QuicDataRead);
-		if (!sess->hmux_priv) return GF_OUT_OF_MEM;
-		if (sess->log_name) gf_free(sess->log_name);
-		sess->log_name = gf_strdup("HTTP/3");
-	}
-	GF_QuicDataRead *qr = sess->hmux_priv;
-	qr->data_read.read_data = ngh3_data_source_read_callback;
-	return GF_OK;
+        if (sess->hmux_priv) {
+            GF_QuicDataRead *qr = sess->hmux_priv;
+            if (qr->second_local_buf) gf_free(qr->second_local_buf);
+            gf_free(sess->hmux_priv);
+            sess->hmux_priv = NULL;
+        }
+
+        return GF_OK;
+    }
+
+    // init path 
+    if (!sess->metrics_priv) {
+        sess->metrics_priv = gf_malloc(sizeof(H3Metrics));
+        if (!sess->metrics_priv) return GF_OUT_OF_MEM;
+        memset(sess->metrics_priv, 0, sizeof(H3Metrics));
+    }
+
+    if (!sess->hmux_priv) {
+        GF_SAFEALLOC(sess->hmux_priv, GF_QuicDataRead);
+        if (!sess->hmux_priv) return GF_OUT_OF_MEM;
+
+        if (sess->log_name) gf_free(sess->log_name);
+        sess->log_name = gf_strdup("HTTP/3");
+    }
+
+    GF_QuicDataRead *qr = sess->hmux_priv;
+    qr->data_read.read_data = ngh3_data_source_read_callback;
+
+    return GF_OK;
 }
+
 
 static int ngh3_recv_data(nghttp3_conn *conn, int64_t stream_id, const uint8_t *data,
                    size_t datalen, void *conn_user_data, void *stream_user_data)
@@ -331,6 +406,19 @@ static int ngh3_recv_data(nghttp3_conn *conn, int64_t stream_id, const uint8_t *
 	}
 	memcpy(sess->hmux_buf.data + sess->hmux_buf.size, data, datalen);
 	sess->hmux_buf.size += (u32) datalen;
+	/*  Metrics: first byte + accumulate  */
+    H3Metrics *m = (H3Metrics*)sess->metrics_priv;
+	if (m) {
+		if (!m->t_first_us) {
+			m->t_first_us = h3_now_us();
+			/* NEW: also feed the generic TTFB used by summary logs */
+			if (!sess->reply_time)
+			sess->reply_time = (u32)(m->t_first_us - sess->request_start_time);
+		}
+		m->bytes += datalen;
+	}
+
+	
 	GF_LOG(GF_LOG_DEBUG, GF_LOG_HTTP, ("[HTTP/3] stream_id "LLD" received %d bytes (%d/%d total)\n", sess->hmux_stream_id, (u32) datalen, sess->hmux_buf.size, sess->total_size));
 	return 0;
 }
@@ -432,24 +520,39 @@ static int ngh3_recv_header(nghttp3_conn *conn, int64_t stream_id, int32_t token
 }
 
 static int ngh3_end_headers(nghttp3_conn *conn, int64_t stream_id, int fin,
-	void *conn_user_data, void *stream_user_data)
+    void *conn_user_data, void *stream_user_data)
 {
-	GF_DownloadSession *sess = stream_user_data;
-	sess->hmux_headers_seen = 1;
-	if (sess->server_mode) {
-		GF_LOG(GF_LOG_DEBUG, GF_LOG_HTTP, ("[HTTP/3] All headers received for stream ID "LLD"\n", sess->hmux_stream_id));
-	} else {
-		GF_LOG(GF_LOG_DEBUG, GF_LOG_HTTP, ("[HTTP/3] All headers received for stream ID "LLD"\n", sess->hmux_stream_id));
-	}
-	if (fin && !sess->server_mode) {
-		GF_LOG(GF_LOG_DEBUG, GF_LOG_HTTP, ("[HTTP/3] stream_id "LLU" (%s) data done\n", stream_id, sess->remote_path ? sess->remote_path : sess->orig_url));
-		sess->hmux_data_done = 1;
-		sess->hmux_is_eos = 0;
-		sess->hmux_send_data = NULL;
-		sess->hmux_send_data_len = 0;
-	}
-	return 0;
+    GF_DownloadSession *sess = (GF_DownloadSession *)stream_user_data;
+    if (!sess) return 0;
+
+    sess->hmux_headers_seen = 1;
+
+    /* Set TTFB at first response headers */
+    if (!sess->server_mode && !sess->reply_time) {
+        H3Metrics *m = (H3Metrics *)sess->metrics_priv;
+        if (m && m->t_submit_us) {
+            u64 now = h3_now_us();
+            sess->reply_time = (u32)(now - m->t_submit_us);
+        }
+    }
+
+    if (sess->server_mode) {
+        GF_LOG(GF_LOG_DEBUG, GF_LOG_HTTP, ("[HTTP/3] All headers received for stream ID "LLD"\n", sess->hmux_stream_id));
+    } else {
+        GF_LOG(GF_LOG_DEBUG, GF_LOG_HTTP, ("[HTTP/3] All headers received for stream ID "LLD"\n", sess->hmux_stream_id));
+    }
+
+    if (fin && !sess->server_mode) {
+        GF_LOG(GF_LOG_DEBUG, GF_LOG_HTTP, ("[HTTP/3] stream_id "LLU" (%s) data done\n",
+            stream_id, sess->remote_path ? sess->remote_path : sess->orig_url));
+        sess->hmux_data_done = 1;
+        sess->hmux_is_eos = 0;
+        sess->hmux_send_data = NULL;
+        sess->hmux_send_data_len = 0;
+    }
+    return 0;
 }
+
 
 static int ngh3_begin_trailers(nghttp3_conn *conn, int64_t stream_id, void *conn_user_data, void *stream_user_data) {
 	return 0;
@@ -563,6 +666,20 @@ static int ngh3_stream_close(nghttp3_conn *conn, int64_t stream_id, uint64_t app
 			sess->last_error = GF_OK;
 		}
 	}
+	/*  Metrics: finalize & emit  */
+	H3Metrics *m = (H3Metrics*)sess->metrics_priv;
+	if (m) {
+		if (!m->t_end_us) m->t_end_us = h3_now_us();
+		h3_metrics_capture_rusage(m);
+		
+		// If download completed (bytes_done matches expected), treat as close
+		const char *phase = "error";
+		if (app_error_code == NGHTTP3_H3_NO_ERROR || sess->bytes_done == m->bytes) {
+			phase = "close";
+		}
+		h3_metrics_emit(sess, m, phase);
+	}
+
 
 	//stream closed
 	sess->hmux_stream_id = -1;
@@ -761,6 +878,19 @@ static GF_Err h3_submit_request(GF_DownloadSession *sess, char *req_name, const 
 	sess->hmux_data_done = 0;
 	sess->hmux_headers_seen = 0;
 	sess->hmux_ready_to_send = 0;
+	/*  Metrics: mark request submit time  */
+	H3Metrics *m = (H3Metrics*)sess->metrics_priv;
+	if (m) {
+		m->t_submit_us = h3_now_us();
+		m->t_first_us  = 0;
+		m->t_end_us    = 0;
+		m->bytes       = 0;
+		m->ru_maxrss_kb = 0;
+		m->user_ms = m->sys_ms = 0;
+	}
+	// reset TTFB used by generic summary
+	sess->reply_time = 0;
+
 	GF_Err e = GF_OK;
     int rv = ngtcp2_conn_open_bidi_stream(qc->conn, &sess->hmux_stream_id, sess);
     if (rv != 0) {
@@ -1486,38 +1616,73 @@ static GF_Err h3_initialize(GF_DownloadSession *sess, char *server, u32 server_p
 		nghttp3_set_debug_vprintf_callback(ngq_debug_trace_noop);
 	}
 
-	settings.initial_ts = ngtcp2_timestamp();
-	settings.cc_algo = NGTCP2_CC_ALGO_CUBIC;
-	settings.initial_rtt = NGTCP2_DEFAULT_INITIAL_RTT;
-	settings.max_window = 0;
-	settings.max_stream_window = 0;
-	settings.handshake_timeout = sess->conn_timeout*1000000;
-	settings.handshake_timeout = UINT64_MAX;
-	settings.no_pmtud = 0;
-	settings.ack_thresh = 2;
-	settings.initial_pkt_num = 1;
+	// After ngtcp2_settings_default(&settings) and initial fields
+settings.initial_ts = ngtcp2_timestamp();
+settings.cc_algo = NGTCP2_CC_ALGO_CUBIC;
+settings.initial_rtt = NGTCP2_DEFAULT_INITIAL_RTT;
+settings.max_window = 0;
+settings.max_stream_window = 0;
+settings.handshake_timeout = sess->conn_timeout*1000000;
+settings.handshake_timeout = UINT64_MAX;
+settings.no_pmtud = 0;
+settings.ack_thresh = 2;
+settings.initial_pkt_num = 1;
 
-	//server config
-	if (sess->server_mode) {
-		settings.token = srv_hd->token;
-		settings.tokenlen = srv_hd->tokenlen;
-		settings.token_type = token_type;
-		settings.max_window = 6000000;
-		settings.max_stream_window = 6000000;
-	}
+/* NEW: read tunables once, apply to BOTH sides */
+int wnd_kb    = gf_opts_get_int("core", "h3-maxwnd");
+int ack_thr   = gf_opts_get_int("core", "h3-ack-thresh");
+const char *algo = gf_opts_get_key("core", "h3-algo");
+if (wnd_kb   <= 0) wnd_kb   = 16000;   // 16 MB
+if (ack_thr  <= 0) ack_thr  = 2;
+if (!algo)         algo     = "cubic";
+
+/* apply on both client & server (receive windows matter on receiver) */
+settings.max_window        = 1000 * wnd_kb;
+settings.max_stream_window = 1000 * wnd_kb;
+settings.ack_thresh        = ack_thr;
+
+/* keep server-only extras + logging */
+if (sess->server_mode) {
+    settings.token      = srv_hd ? srv_hd->token : NULL;
+    settings.tokenlen   = srv_hd ? srv_hd->tokenlen : 0;
+    settings.token_type = token_type;
+
+    if (!strcmp(algo, "bbr"))
+        settings.cc_algo = NGTCP2_CC_ALGO_BBR;
+
+    static int tuning_logged = 0;
+    if (!tuning_logged) {
+        fprintf(stderr, "[H3-TUNING] Server config: max_window=%d, ack_thresh=%d, cc_algo=%s\n",
+                1000*wnd_kb, ack_thr, algo);
+        tuning_logged = 1;
+    }
+}
+
+
+
+
+
+
 
 	ngtcp2_transport_params_default(&params);
 
-	params.initial_max_data = 1024 * 1024;
-	params.initial_max_stream_data_bidi_local = sess->server_mode ? 0 : 16777216;
-	params.initial_max_stream_data_bidi_remote = sess->server_mode ? 16777216 : 0;
-	params.initial_max_stream_data_uni = 16777216;
-	params.initial_max_streams_bidi = sess->server_mode ? 100 : 0;
-	params.initial_max_streams_uni = 3;
-	params.max_idle_timeout = 30 * NGTCP2_SECONDS;
-	params.active_connection_id_limit = 7;
-	params.grease_quic_bit = 1;
-
+	/* NEW: larger flow-control budgets */
+	const uint32_t imd  = 64u * 1024u * 1024u;  // 64 MB connection window
+	const uint32_t imsd = 32u * 1024u * 1024u;  // 32 MB per-stream window
+	params.initial_max_data = imd;
+	/* HTTP/3 uses client-initiated bidi streams for response data:
+   - client must set bidi_local high (lets the *peer* send on our locally-initiated streams)
+   - server must set bidi_remote high (lets the *peer* send on its remotely-initiated streams) */
+   params.initial_max_stream_data_bidi_local  = sess->server_mode ? 0 : imsd;
+   params.initial_max_stream_data_bidi_remote = sess->server_mode ? imsd : 0;
+   params.initial_max_stream_data_uni = imsd;
+   params.initial_max_streams_bidi = sess->server_mode ? 100 : 0;
+   params.initial_max_streams_uni = 3;
+   params.max_idle_timeout = 30 * NGTCP2_SECONDS;
+   params.active_connection_id_limit = 7;
+   params.grease_quic_bit = 1;
+	
+		
 	if (sess->server_mode) {
 		params.stateless_reset_token_present = 1;
 		if (srv_ocid) {

--- a/src/utils/downloader_ngtcp2.c
+++ b/src/utils/downloader_ngtcp2.c
@@ -1617,7 +1617,7 @@ static GF_Err h3_initialize(GF_DownloadSession *sess, char *server, u32 server_p
 }
 
 
-	// After ngtcp2_settings_default(&settings) and initial fields
+       // After ngtcp2_settings_default(&settings) and initial fields
 settings.initial_ts = ngtcp2_timestamp();
 settings.cc_algo = NGTCP2_CC_ALGO_CUBIC;
 settings.initial_rtt = NGTCP2_DEFAULT_INITIAL_RTT;
@@ -1630,20 +1630,34 @@ settings.ack_thresh = 2;
 settings.initial_pkt_num = 1;
 
 /* NEW: read tunables once, apply to BOTH sides */
-int wnd_kb    = gf_opts_get_int("temp", "h3-maxwnd");
-int ack_thr   = gf_opts_get_int("temp", "h3-ack-thresh");
+int wnd_kb = gf_opts_get_int("temp", "h3-maxwnd");
+int ack_thr = gf_opts_get_int("temp", "h3-ack-thresh");
 const char *algo = gf_opts_get_key("temp", "h3-algo");
 
-/* Fallbacks if no CLI override */
-if (wnd_kb   <= 0) wnd_kb   = 16000;   // 16 MB
-if (ack_thr  <= 0) ack_thr  = 2;
-if (!algo)         algo     = "cubic";
+/* Detect explicit user overrides */
+int user_set_wnd  = (wnd_kb > 0);
+int user_set_ack  = (ack_thr > 0);
+int user_set_algo = (algo && algo[0]);
 
 
-/* apply on both client & server (receive windows matter on receiver) */
-settings.max_window        = 1000 * wnd_kb;
-settings.max_stream_window = 1000 * wnd_kb;
-settings.ack_thresh        = ack_thr;
+/* Apply only the options that were explicitly provided */
+if (user_set_wnd) {
+    /* you were using KB * 1000 previously; keep same semantics */
+    settings.max_window = (uint64_t)1000 * (uint64_t)wnd_kb;
+	settings.max_stream_window = (uint64_t)1000 * (uint64_t)wnd_kb;
+}
+
+if (user_set_ack) {
+    settings.ack_thresh = (uint32_t)ack_thr;
+}
+
+if (user_set_algo) {
+    if (!strcmp(algo, "bbr")) {
+        settings.cc_algo = NGTCP2_CC_ALGO_BBR;
+    } else if (!strcmp(algo, "cubic")) {
+        settings.cc_algo = NGTCP2_CC_ALGO_CUBIC;
+    }
+}
 
 /* keep server-only extras + logging */
 if (sess->server_mode) {
@@ -1651,17 +1665,15 @@ if (sess->server_mode) {
     settings.tokenlen   = srv_hd ? srv_hd->tokenlen : 0;
     settings.token_type = token_type;
 
-    if (!strcmp(algo, "bbr"))
-        settings.cc_algo = NGTCP2_CC_ALGO_BBR;
-
-    static int tuning_logged = 0;
-    if (!tuning_logged) {
-        fprintf(stderr, "[H3-TUNING] Server config: max_window=%d, ack_thresh=%d, cc_algo=%s\n",
-                1000*wnd_kb, ack_thr, algo);
-        tuning_logged = 1;
+    if (user_set_wnd || user_set_ack || user_set_algo) {
+        fprintf(stderr,
+        "[H3-TUNING] Server override: max_window=%" PRIu64
+        ", ack_thresh=%u, cc_algo=%s\n",
+        (uint64_t)settings.max_window,
+        (unsigned)settings.ack_thresh,
+        user_set_algo ? algo : "(default)");
     }
 }
-
 
 
 
@@ -1764,7 +1776,7 @@ if (sess->server_mode) {
 		sess->hmux_sess->mx = sess->mx;
 	}
 	sess->chunked = GF_FALSE;
-	//don't flush packets now in server mode
+	//not flush packets now in server mode
 	if (qsc) return GF_OK;
 
 	return h3_session_write(sess);

--- a/src/utils/downloader_ngtcp2.c
+++ b/src/utils/downloader_ngtcp2.c
@@ -349,7 +349,7 @@ static nghttp3_ssize ngh3_data_source_read_callback(
 static GF_Err h3_setup_session(GF_DownloadSession *sess, Bool is_destroy)
 {
     if (is_destroy) {
-        // destroy path 
+        // destroy path
         if (sess->metrics_priv) {
             gf_free(sess->metrics_priv);
             sess->metrics_priv = NULL;
@@ -365,7 +365,7 @@ static GF_Err h3_setup_session(GF_DownloadSession *sess, Bool is_destroy)
         return GF_OK;
     }
 
-    // init path 
+    // init path
     if (!sess->metrics_priv) {
         sess->metrics_priv = gf_malloc(sizeof(H3Metrics));
         if (!sess->metrics_priv) return GF_OUT_OF_MEM;
@@ -418,7 +418,7 @@ static int ngh3_recv_data(nghttp3_conn *conn, int64_t stream_id, const uint8_t *
 		m->bytes += datalen;
 	}
 
-	
+
 	GF_LOG(GF_LOG_DEBUG, GF_LOG_HTTP, ("[HTTP/3] stream_id "LLD" received %d bytes (%d/%d total)\n", sess->hmux_stream_id, (u32) datalen, sess->hmux_buf.size, sess->total_size));
 	return 0;
 }
@@ -671,8 +671,7 @@ static int ngh3_stream_close(nghttp3_conn *conn, int64_t stream_id, uint64_t app
 	if (m) {
 		if (!m->t_end_us) m->t_end_us = h3_now_us();
 		h3_metrics_capture_rusage(m);
-		
-		// If download completed (bytes_done matches expected), treat as close
+		// If download completed, treat as close
 		const char *phase = "error";
 		if (app_error_code == NGHTTP3_H3_NO_ERROR || sess->bytes_done == m->bytes) {
 			phase = "close";
@@ -1629,7 +1628,7 @@ settings.no_pmtud = 0;
 settings.ack_thresh = 2;
 settings.initial_pkt_num = 1;
 
-/* NEW: read tunables once, apply to BOTH sides */
+/* Read user-provided QUIC tuning parameters and apply overrides */
 int wnd_kb = gf_opts_get_int("temp", "h3-maxwnd");
 int ack_thr = gf_opts_get_int("temp", "h3-ack-thresh");
 const char *algo = gf_opts_get_key("temp", "h3-algo");
@@ -1682,13 +1681,13 @@ if (sess->server_mode) {
 
 	ngtcp2_transport_params_default(&params);
 
-	/* NEW: larger flow-control budgets */
-	const uint32_t imd  = 64u * 1024u * 1024u;  // 64 MB connection window
-	const uint32_t imsd = 32u * 1024u * 1024u;  // 32 MB per-stream window
+	/* larger flow-control budgets */
+	const uint32_t imd  = 64u * 1024u * 1024u;  // 64 MB connection
+	const uint32_t imsd = 32u * 1024u * 1024u;  // 32 MB per-stream
 	params.initial_max_data = imd;
 	/* HTTP/3 uses client-initiated bidi streams for response data:
-   - client must set bidi_local high (lets the *peer* send on our locally-initiated streams)
-   - server must set bidi_remote high (lets the *peer* send on its remotely-initiated streams) */
+   - client must set bidi_local high
+   - server must set bidi_remote high*/
    params.initial_max_stream_data_bidi_local  = sess->server_mode ? 0 : imsd;
    params.initial_max_stream_data_bidi_remote = sess->server_mode ? imsd : 0;
    params.initial_max_stream_data_uni = imsd;
@@ -1697,8 +1696,6 @@ if (sess->server_mode) {
    params.max_idle_timeout = 30 * NGTCP2_SECONDS;
    params.active_connection_id_limit = 7;
    params.grease_quic_bit = 1;
-	
-		
 	if (sess->server_mode) {
 		params.stateless_reset_token_present = 1;
 		if (srv_ocid) {

--- a/src/utils/downloader_ngtcp2.c
+++ b/src/utils/downloader_ngtcp2.c
@@ -1609,12 +1609,13 @@ static GF_Err h3_initialize(GF_DownloadSession *sess, char *server, u32 server_p
 
 	ngtcp2_settings_default(&settings);
 
-	if (gf_opts_get_bool("core", "h3-trace")) {
-		settings.log_printf = ngq_printf;
-		nghttp3_set_debug_vprintf_callback(ngq_debug_trace);
-	} else {
-		nghttp3_set_debug_vprintf_callback(ngq_debug_trace_noop);
-	}
+	if (gf_opts_get_bool("temp", "h3-trace")) {
+    settings.log_printf = ngq_printf;
+    nghttp3_set_debug_vprintf_callback(ngq_debug_trace);
+} else {
+    nghttp3_set_debug_vprintf_callback(ngq_debug_trace_noop);
+}
+
 
 	// After ngtcp2_settings_default(&settings) and initial fields
 settings.initial_ts = ngtcp2_timestamp();
@@ -1629,12 +1630,15 @@ settings.ack_thresh = 2;
 settings.initial_pkt_num = 1;
 
 /* NEW: read tunables once, apply to BOTH sides */
-int wnd_kb    = gf_opts_get_int("core", "h3-maxwnd");
-int ack_thr   = gf_opts_get_int("core", "h3-ack-thresh");
-const char *algo = gf_opts_get_key("core", "h3-algo");
+int wnd_kb    = gf_opts_get_int("temp", "h3-maxwnd");
+int ack_thr   = gf_opts_get_int("temp", "h3-ack-thresh");
+const char *algo = gf_opts_get_key("temp", "h3-algo");
+
+/* Fallbacks if no CLI override */
 if (wnd_kb   <= 0) wnd_kb   = 16000;   // 16 MB
 if (ack_thr  <= 0) ack_thr  = 2;
 if (!algo)         algo     = "cubic";
+
 
 /* apply on both client & server (receive windows matter on receiver) */
 settings.max_window        = 1000 * wnd_kb;

--- a/src/utils/downloader_ngtcp2.c
+++ b/src/utils/downloader_ngtcp2.c
@@ -60,7 +60,7 @@
 //amount of bytes we store internally
 #define SOCK_BUF_SIZE	200000
 
-// METRCIS TEST
+/* Metrics collection for HTTP/3 */
 typedef struct {
 	u64 t_submit_us;    /* request submit time */
 	u64 t_first_us;     /* first byte time (0 until set) */
@@ -1622,7 +1622,6 @@ settings.cc_algo = NGTCP2_CC_ALGO_CUBIC;
 settings.initial_rtt = NGTCP2_DEFAULT_INITIAL_RTT;
 settings.max_window = 0;
 settings.max_stream_window = 0;
-settings.handshake_timeout = sess->conn_timeout*1000000;
 settings.handshake_timeout = UINT64_MAX;
 settings.no_pmtud = 0;
 settings.ack_thresh = 2;
@@ -1641,8 +1640,8 @@ int user_set_algo = (algo && algo[0]);
 
 /* Apply only the options that were explicitly provided */
 if (user_set_wnd) {
-    /* you were using KB * 1000 previously; keep same semantics */
-    settings.max_window = (uint64_t)1000 * (uint64_t)wnd_kb;
+    /*using KB * 1000 previously; keep same semantics */
+    settings.max_window = (uint64_t)wnd_kb * 1000;
 	settings.max_stream_window = (uint64_t)1000 * (uint64_t)wnd_kb;
 }
 

--- a/src/utils/os_config_init.c
+++ b/src/utils/os_config_init.c
@@ -1575,8 +1575,13 @@ GF_GPACArg GPAC_Args[] = {
 #endif
 
 #ifdef GPAC_HAS_NGTCP2
- GF_DEF_ARG("h3-trace", NULL, "trace QUIC and HTTP3", NULL, NULL, GF_ARG_BOOL, GF_ARG_HINT_EXPERT|GF_ARG_SUBSYS_HTTP),
+GF_DEF_ARG("h3-trace", NULL, "trace QUIC and HTTP3", NULL, NULL, GF_ARG_BOOL, GF_ARG_HINT_EXPERT|GF_ARG_SUBSYS_HTTP),
+GF_DEF_ARG("h3-algo", NULL, "algo to use for QUIC, one of\n"
+"- cubic: bla\n"
+"- bbr: foo", "cubic", "cubic|bbr", GF_ARG_INT, GF_ARG_HINT_EXPERT|GF_ARG_SUBSYS_HTTP),
+GF_DEF_ARG("h3-maxwnd", NULL, "max window size in kilo bytes", "16000", NULL, GF_ARG_INT, GF_ARG_HINT_EXPERT|GF_ARG_SUBSYS_HTTP),
 #endif
+
 
 
  GF_DEF_ARG("dbg-edges", NULL, "log edges status in filter graph before dijkstra resolution (for debug). Edges are logged as edge_source(status(disable_depth), weight, src_cap_idx -> dst_cap_idx)", NULL, NULL, GF_ARG_BOOL, GF_ARG_HINT_EXPERT|GF_ARG_SUBSYS_FILTERS),

--- a/src/utils/os_config_init.c
+++ b/src/utils/os_config_init.c
@@ -1579,8 +1579,13 @@ GF_DEF_ARG("h3-trace", NULL, "trace QUIC and HTTP3", NULL, NULL, GF_ARG_BOOL, GF
 GF_DEF_ARG("h3-algo", NULL, "algo to use for QUIC, one of\n"
 "- cubic: bla\n"
 "- bbr: foo", "cubic", "cubic|bbr", GF_ARG_INT, GF_ARG_HINT_EXPERT|GF_ARG_SUBSYS_HTTP),
+GF_DEF_ARG("h3-ack-thresh", NULL,
+    "ACK threshold for QUIC (ngtcp2_settings.ack_thresh)",
+    "2", NULL,
+    GF_ARG_INT, GF_ARG_HINT_EXPERT|GF_ARG_SUBSYS_HTTP),
 GF_DEF_ARG("h3-maxwnd", NULL, "max window size in kilo bytes", "16000", NULL, GF_ARG_INT, GF_ARG_HINT_EXPERT|GF_ARG_SUBSYS_HTTP),
 #endif
+
 
 
 

--- a/src/utils/os_config_init.c
+++ b/src/utils/os_config_init.c
@@ -1577,8 +1577,9 @@ GF_GPACArg GPAC_Args[] = {
 #ifdef GPAC_HAS_NGTCP2
 GF_DEF_ARG("h3-trace", NULL, "trace QUIC and HTTP3", NULL, NULL, GF_ARG_BOOL, GF_ARG_HINT_EXPERT|GF_ARG_SUBSYS_HTTP),
 GF_DEF_ARG("h3-algo", NULL, "algo to use for QUIC, one of\n"
-"- cubic: bla\n"
-"- bbr: foo", "cubic", "cubic|bbr", GF_ARG_INT, GF_ARG_HINT_EXPERT|GF_ARG_SUBSYS_HTTP),
+"- cubic: default congestion control\n"
+"- bbr: bottleneck bandwidth and RTT",
+"cubic", "cubic|bbr", GF_ARG_STRING, GF_ARG_HINT_EXPERT|GF_ARG_SUBSYS_HTTP),
 GF_DEF_ARG("h3-ack-thresh", NULL,
     "ACK threshold for QUIC (ngtcp2_settings.ack_thresh)",
     "2", NULL,


### PR DESCRIPTION
This PR introduces performance instrumentation and QUIC tuning capabilities for HTTP/2 and HTTP/3 in GPAC.

### Main Features

- Added per-transfer metrics for:
  - HTTP/1.1 (H1)
  - HTTP/2 (H2 - nghttp2)
  - HTTP/3 (H3 - ngtcp2 + nghttp3)

Metrics added includes:
- bytes transferred
- time to first byte (TTFB)
- total duration
- throughput (Mb/s)
- CPU usage (user/sys)
- memory usage (RSS)

### HTTP/2 improvements
- Inline metrics collection integrated in nghttp2 callbacks
- Increased flow control windows to improve throughput:
  - 32MB stream window
  - 64MB connection window

### HTTP/3 improvements
- Metrics collection via dedicated structure (metrics_priv)
- QUIC tuning parameters exposed via CLI:
  - `-h3-algo` (cubic | bbr)
  - `-h3-ack-thresh`
  - `-h3-maxwnd`

### Notes
- Metrics are designed for benchmarking and performance analysis use cases for HTTP/1.1 and HTTP/2 in different real scenarios (e.g., video delivery)
