### PR TITLE
GPAC_QUIC_METRICS: Add unified metrics for HTTP/1.1, HTTP/2, HTTP/3

### DIFF
--- a/src/utils/downloader.c
+++ b/src/utils/downloader.c
@@ -22,9 +22,9 @@
  *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
  *
  */
-
+#include <inttypes.h>
 #include "downloader.h"
-
+#include <gpac/tools.h>
 #ifndef GPAC_DISABLE_NETWORK
 
 static void gf_dm_connect(GF_DownloadSession *sess);
@@ -2387,7 +2387,38 @@ void gf_dm_data_received(GF_DownloadSession *sess, u8 *payload, u32 payload_size
 
 		GF_LOG(GF_LOG_INFO, GF_LOG_HTTP, ("[%s] %s (%d bytes) downloaded in "LLU" us (%d kbps) (%d us since request - got response in %d us)\n", sess->log_name, gf_file_basename(gf_cache_get_url(sess->cache_entry)), sess->bytes_done,
 		                                     run_time, 8*sess->bytes_per_sec/1000, sess->total_time_since_req, sess->reply_time));
+/*  H1-METRICS (only for true H1)  */
+{
+    Bool is_h1 = GF_TRUE;
+    /* If HTTP/2 mux is present 1 */
+#if defined(GPAC_HTTPMUX)
+    if (sess->hmux_sess) is_h1 = GF_FALSE;
+#endif
+    /* If QUIC/H3 flag is set */
+    if (sess->flags & GF_NETIO_SESSION_USE_QUIC) is_h1 = GF_FALSE;
 
+    if (is_h1) {
+        GF_SystemRTInfo rti;
+		gf_sys_get_rti(0, &rti, 0);
+
+        double dur_s = (double)sess->total_time_since_req / 1e6;
+        double thr   = (dur_s > 0) ? (8.0 * (double)sess->bytes_done / dur_s / 1e6) : 0.0;
+
+        GF_LOG(GF_LOG_INFO, GF_LOG_HTTP,
+           ("[H1-METRICS] mode=%s url=%s bytes=%" PRIu64 " ttfb_us=%u dur_us=%u thr=%.3fMb/s "
+            "cpu_total_ms=%llu mem_kb=%llu phase=%s\n",
+            sess->server_mode ? "server" : "client",
+            sess->orig_url ? sess->orig_url : "",
+            sess->bytes_done,
+            sess->reply_time,
+            sess->total_time_since_req,
+            thr,
+            (unsigned long long) rti.process_cpu_time,
+			(unsigned long long)(rti.physical_memory / 1024),
+            sess->last_error ? "error" : "close"));
+    }
+}
+/* end H1-METRICS  */
 		if (sess->chunked && (payload_size==2))
 			payload_size=0;
 		sess->last_error = GF_OK;

--- a/src/utils/downloader.h
+++ b/src/utils/downloader.h
@@ -40,14 +40,14 @@
 #include <gpac/crypt.h>
 
 #ifdef GPAC_HAS_SSL
-#ifdef GPAC_HAS_NGTCP2
-#include <openssl/types.h>
-#endif
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
+#ifdef GPAC_HAS_NGTCP2
+//#include <openssl/types.h>
+#endif
 #endif
 
 #ifdef GPAC_HAS_CURL
@@ -360,6 +360,9 @@ struct __gf_download_session
 	u8 *local_buf;
 	u32 local_buf_len, local_buf_alloc;
 #endif
+    /* Custom metrics storage for H3 (and H2) */
+    void *metrics_priv;
+
 
 };
 

--- a/src/utils/downloader_nghttp2.c
+++ b/src/utils/downloader_nghttp2.c
@@ -35,7 +35,82 @@
 #if !defined(__GNUC__) && ( defined(_WIN32_WCE) || defined (WIN32) )
 #pragma comment(lib, "nghttp2")
 #endif
+/*
+ * Inline metrics collection
+ *
+ * Emits one CSV line per transfer if GPAC_METRICS is set, otherwise emits a single log line.
+ * Collected:
+ *  - bytes
+ *  - ttfb_us (submit -> first data)
+ *  - duration_us (submit -> end)
+ *  - throughput_mbps (computed)
+ *  - cpu_total_ms, mem_kb (via gf_sys_get_rti)
+ */
 
+#include <gpac/tools.h>
+#include <stdio.h>
+
+typedef struct {
+	u64 t_submit_us;    /* request submit time */
+	u64 t_first_us;     /* first byte time (0 until set) */
+	u64 t_end_us;       /* end time */
+	u64 bytes;          /* payload bytes received/sent */
+} H2Metrics;
+
+static inline u64 h2_now_us(void) { return gf_sys_clock_high_res(); }
+
+static inline const char *h2_mode_str(const GF_DownloadSession *sess) {
+    return (sess && sess->server_mode) ? "server" : "client";
+}
+static void h2_metrics_emit(const GF_DownloadSession *sess, const H2Metrics *m, const char *phase)
+{
+	if (!m) return;
+	double dur_s  = (m->t_end_us > m->t_submit_us) ? (m->t_end_us - m->t_submit_us)/1e6 : 0.0;
+	double mbps   = (dur_s>0) ? ((double)m->bytes * 8.0 / dur_s / 1e6) : 0.0;
+
+	const char *csv = getenv("GPAC_METRICS");
+
+	const char *url  = (sess && sess->orig_url) ? sess->orig_url : "";
+	const char *mode = h2_mode_str(sess);
+	const char *ph   = phase ? phase : "";
+	GF_SystemRTInfo rti;
+	gf_sys_get_rti(0, &rti, 0);
+
+	if (csv && csv[0]) {
+		FILE *f = fopen(csv, "a");
+		if (f) {
+			/* proto,mode,url,bytes,ttfb_us,duration_us,throughput_mbps,cpu_total_ms,mem_kb,phase */
+			fprintf(f, "h2,%s,%s,%llu,%llu,%llu,%.3f,%llu,%llu,%s\n",
+				mode, url,
+				(unsigned long long)m->bytes,
+				(unsigned long long)(m->t_first_us ? (m->t_first_us - m->t_submit_us) : 0),
+				(unsigned long long)(m->t_end_us - m->t_submit_us),
+				mbps,
+				(unsigned long long) rti.process_cpu_time,
+				(unsigned long long)(rti.physical_memory / 1024),
+				ph);
+			fclose(f);
+		}
+	} else {
+		GF_LOG(GF_LOG_INFO, GF_LOG_HTTP,
+			("[H2-METRICS] mode=%s url=%s bytes=%llu ttfb_us=%llu dur_us=%llu thr=%.3fMb/s cpu_total_ms=%llu mem_kb=%llu phase=%s\n",
+			 mode, url,
+			 (unsigned long long)m->bytes,
+			 (unsigned long long)(m->t_first_us ? (m->t_first_us - m->t_submit_us) : 0),
+			 (unsigned long long)(m->t_end_us - m->t_submit_us),
+			 mbps,
+			 (unsigned long long) rti.process_cpu_time,
+			 (unsigned long long)(rti.physical_memory / 1024),
+			 ph));
+	}
+}
+
+/* Pack metrics right after nghttp2_data_provider in hmux_priv */
+static inline H2Metrics *h2_metrics_ptr(GF_DownloadSession *sess)
+{
+    if (!sess || !sess->hmux_priv) return NULL;
+    return (H2Metrics *)((u8*)sess->hmux_priv + sizeof(nghttp2_data_provider));
+}
 
 static void h2_flush_send_ex(GF_DownloadSession *sess, Bool flush_local_buf);
 
@@ -126,6 +201,14 @@ static int h2_frame_recv_callback(nghttp2_session *session, const nghttp2_frame 
 			|| (sess->server_mode && ((frame->headers.cat == NGHTTP2_HCAT_HEADERS) || (frame->headers.cat == NGHTTP2_HCAT_REQUEST)))
 		) {
 			sess->hmux_headers_seen = 1;
+			 /* Set TTFB at first response headers (submit -> headers) */
+            if (!sess->server_mode && !sess->reply_time) {
+                H2Metrics *m = h2_metrics_ptr(sess);
+                if (m && m->t_submit_us) {
+                    u64 now = h2_now_us();
+                    sess->reply_time = (u32)(now - m->t_submit_us);
+                }
+            }
 			if (sess->server_mode) {
 				GF_LOG(GF_LOG_DEBUG, GF_LOG_HTTP, ("[HTTP/2] All headers received for stream ID "LLD"\n", sess->hmux_stream_id));
 			} else {
@@ -176,7 +259,19 @@ static int h2_data_chunk_recv_callback(nghttp2_session *session, uint8_t flags, 
 	GF_DownloadSession *sess = hmux_get_session(user_data, stream_id, GF_FALSE);
 	if (!sess)
 		return NGHTTP2_ERR_CALLBACK_FAILURE;
-
+	/* Metrics: first byte + accumulate bytes */
+	{
+		H2Metrics *m = h2_metrics_ptr(sess);
+		if (m) {
+			if (!m->t_first_us) {
+				m->t_first_us = h2_now_us();
+				/* Fallback TTFB if HEADERS didn’t set it */
+				if (!sess->reply_time && m->t_submit_us)
+				sess->reply_time = (u32)(m->t_first_us - m->t_submit_us);
+			}
+			m->bytes += (u64)len;
+		}
+	}
 	if (sess->hmux_buf.size + len > sess->hmux_buf.alloc) {
 		sess->hmux_buf.alloc = sess->hmux_buf.size + (u32) len;
 		sess->hmux_buf.data = gf_realloc(sess->hmux_buf.data, sizeof(u8) * sess->hmux_buf.alloc);
@@ -184,7 +279,7 @@ static int h2_data_chunk_recv_callback(nghttp2_session *session, uint8_t flags, 
 	}
 	memcpy(sess->hmux_buf.data + sess->hmux_buf.size, data, len);
 	sess->hmux_buf.size += (u32) len;
-	GF_LOG(GF_LOG_DEBUG, GF_LOG_HTTP, ("[HTTP/2] stream_id "LLD" received %d bytes (%d/%d total) - flags %d\n", sess->hmux_stream_id, len, sess->hmux_buf.size, sess->total_size, flags));
+	GF_LOG(GF_LOG_DEBUG, GF_LOG_HTTP, ("[HTTP/2] stream_id "LLD" received %d bytes (%d/%d total) - flags %d\n", sess->hmux_stream_id, (int)len, (int)sess->hmux_buf.size, (int)sess->total_size, (int)flags));
 	return 0;
 }
 
@@ -224,6 +319,14 @@ static int h2_stream_close_callback(nghttp2_session *session, int32_t stream_id,
 			sess->put_state = 0;
 			sess->status = GF_NETIO_DATA_TRANSFERED;
 			sess->last_error = GF_OK;
+		}
+	}
+	/* Metrics: finalize and emit on close (with error or success) */
+	{
+		H2Metrics *m = h2_metrics_ptr(sess);
+		if (m) {
+			if (!m->t_end_us) m->t_end_us = h2_now_us();
+			h2_metrics_emit(sess, m, error_code ? "error" : "close");
 		}
 	}
 
@@ -341,7 +444,7 @@ static int h2_send_data_callback(nghttp2_session *session, nghttp2_frame *frame,
 
 	while (frame->data.padlen > 0) {
 		u32 padlen = (u32) frame->data.padlen - 1;
-		rv = h2_write_data(sess, padding, padlen);
+		rv = h2_write_data(sess, (const uint8_t*)padding, padlen);
 		if (rv<0) {
 			if (rv==NGHTTP2_ERR_WOULDBLOCK) continue;
 			goto err;
@@ -469,6 +572,15 @@ GF_Err h2_submit_request(GF_DownloadSession *sess, char *req_name, const char *u
 		gf_assert(data_io->source.ptr != NULL);
 	}
 #endif
+/* Metrics: mark request submit time and reset counters */
+	{
+		H2Metrics *m = h2_metrics_ptr(sess);
+		if (m) {
+			memset(m, 0, sizeof(*m));
+			m->t_submit_us = h2_now_us();
+			m->bytes = 0;
+		}
+	}
 	sess->hmux_data_done = 0;
 	sess->hmux_headers_seen = 0;
 	sess->hmux_stream_id = nghttp2_submit_request(sess->hmux_sess->hmux_udta, NULL, hdrs, nb_hdrs+4,
@@ -615,12 +727,20 @@ static GF_Err h2_setup_session(GF_DownloadSession *sess, Bool is_destroy)
 		return GF_OK;
 	}
 	if (!sess->hmux_priv) {
-		GF_SAFEALLOC(sess->hmux_priv, nghttp2_data_provider);
-		if (!sess->hmux_priv) return GF_OUT_OF_MEM;
+		/* Allocate a single block for nghttp2_data_provider + inline H2Metrics */
+		void *blk = gf_malloc(sizeof(nghttp2_data_provider) + sizeof(H2Metrics));
+		if (!blk) return GF_OUT_OF_MEM;
+		memset(blk, 0, sizeof(nghttp2_data_provider) + sizeof(H2Metrics));
+		sess->hmux_priv = blk;
 	}
-	nghttp2_data_provider *data_io = sess->hmux_priv;
+	nghttp2_data_provider *data_io = (nghttp2_data_provider*)sess->hmux_priv;
 	data_io->read_callback = h2_data_source_read_callback;
 	data_io->source.ptr = sess;
+	/* Metrics: clear on (re)setup */
+	{
+		H2Metrics *m = h2_metrics_ptr(sess);
+		if (m) memset(m, 0, sizeof(*m));
+	}
 	return GF_OK;
 }
 
@@ -743,6 +863,37 @@ void h2_initialize_session(GF_DownloadSession *sess)
 	} else {
 		nghttp2_session_client_new((nghttp2_session**) &sess->hmux_sess->hmux_udta, callbacks, sess->hmux_sess);
 	}
+	/* H2 THROUGHPUT TUNING */
+{
+    nghttp2_session *h2 = (nghttp2_session*)sess->hmux_sess->hmux_udta;
+
+    /* Big windows to avoid stop-and-go */
+    const uint32_t H2_STREAM_WIN = 32u * 1024u * 1024u;  /* 32 MB per stream */
+    const uint32_t H2_CONN_WIN   = 64u * 1024u * 1024u;  /* 64 MB per connection */
+    const uint32_t H2_MAX_FRAME  = 1u  * 1024u * 1024u;  /* 1 MB frame size */
+
+    /*  peer  use a large INITIAL_WINDOW_SIZE (fixing the bootleneck that we had earlier) */
+    nghttp2_settings_entry iv[] = {
+        { NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE,   H2_STREAM_WIN },
+        { NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, 256 },
+        { NGHTTP2_SETTINGS_MAX_FRAME_SIZE,        H2_MAX_FRAME }, /* optional but helps on localhost */
+    };
+    int rv = nghttp2_submit_settings(h2, NGHTTP2_FLAG_NONE, iv, (size_t)(sizeof(iv)/sizeof(iv[0])));
+    if (rv) {
+        GF_LOG(GF_LOG_WARNING, GF_LOG_HTTP, ("[HTTP/2] submit_settings failed: %d\n", rv));
+    }
+
+    /* Also enlarge OUR local receive window (connection level). Do this early. */
+    rv = nghttp2_session_set_local_window_size(h2, NGHTTP2_FLAG_NONE, 0 /* connection */, (int32_t)H2_CONN_WIN);
+    if (rv) {
+        GF_LOG(GF_LOG_WARNING, GF_LOG_HTTP, ("[HTTP/2] set_local_window_size(conn) failed: %d\n", rv));
+    }
+
+    /* Note: Per-stream local window for streams created later will use the advertised INITIAL_WINDOW_SIZE.
+       If you want to bump window for an already-open inbound stream, also call:
+         nghttp2_session_set_local_window_size(h2, NGHTTP2_FLAG_NONE, stream_id, (int32_t)H2_STREAM_WIN);
+       right after you accept/see its HEADERS. */
+}
 	nghttp2_session_callbacks_del(callbacks);
 	sess->hmux_sess->net_sess = sess;
 	//setup function pointers
@@ -812,6 +963,14 @@ void http2_set_upgrade_headers(GF_DownloadSession *sess)
 		{NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, 100},
 		{NGHTTP2_SETTINGS_ENABLE_PUSH, 0}
 	};
+	/* Disable clear-text HTTP/2 upgrade when GPAC_NO_H2=1 */
+	{
+		const char *env = getenv("GPAC_NO_H2");
+		if (env && !strcmp(env, "1")) {
+			GF_LOG(GF_LOG_INFO, GF_LOG_HTTP, ("[HTTP] HTTP/2 upgrade disabled via env var GPAC_NO_H2=1\n"));
+			return;
+		}
+	}
 
 	PUSH_HDR("Connection", "Upgrade, HTTP2-Settings")
 	PUSH_HDR("Upgrade", "h2c")

--- a/src/utils/downloader_ngtcp2.c
+++ b/src/utils/downloader_ngtcp2.c
@@ -45,12 +45,51 @@
 #include <ngtcp2/ngtcp2_crypto.h>
 #include <ngtcp2/ngtcp2_crypto_quictls.h>
 #include <nghttp3/nghttp3.h>
+#include <stdio.h>
 
 #define NGTCP2_STATELESS_RESET_BURST 100
 #define NGTCP2_SV_SCIDLEN 18
 #define MAX_CONNID_LEN	255
 #define MAX_ADDR_LEN	100
 
+//amount of bytes storing internally
+#define SOCK_BUF_SIZE	200000
+
+/* Metrics collection for HTTP/3 */
+typedef struct {
+	u64 t_submit_us;    /* request submit time */
+	u64 t_first_us;     /* first byte time (0 until set) */
+	u64 t_end_us;       /* end time */
+	u64 bytes;          /* payload bytes received */
+} H3Metrics;
+static inline u64 h3_now_us(void) { return gf_sys_clock_high_res(); }
+static void h3_metrics_emit(const GF_DownloadSession *sess, const H3Metrics *m, const char *phase)
+{
+    if (!m) return;
+
+    double dur_s  = (m->t_end_us > m->t_submit_us) ? (m->t_end_us - m->t_submit_us)/1e6 : 0.0;
+    double mbps   = (dur_s>0) ? ((double)m->bytes * 8.0 / dur_s / 1e6) : 0.0;
+
+    const char *url  = (sess && sess->orig_url) ? sess->orig_url : "";
+    const char *mode = (sess && sess->server_mode) ? "server" : "client";
+    const char *ph   = phase ? phase : "";
+
+	GF_SystemRTInfo rti;
+    gf_sys_get_rti(0, &rti, 0);
+
+    GF_LOG(GF_LOG_INFO, GF_LOG_HTTP,
+        ("[H3-METRICS] mode=%s url=%s bytes=%llu ttfb_us=%llu dur_us=%llu thr=%.3fMb/s "
+         "cpu_total_ms=%llu mem_kb=%llu phase=%s\n",
+         mode, url,
+         (unsigned long long)m->bytes,
+         (unsigned long long)(m->t_first_us ? (m->t_first_us - m->t_submit_us) : 0),
+         (unsigned long long)(m->t_end_us - m->t_submit_us),
+         mbps,
+		 (unsigned long long) rti.process_cpu_time,
+		 /* convert bytes → KB for consistency across platforms */
+         (unsigned long long)(rti.physical_memory / 1024),
+		 ph));
+}
 const u8 *gf_sk_get_address(GF_Socket *sock, u32 *addr_size);
 
 GF_Err gf_sk_bind_ex(GF_Socket *sock, const char *ifce_ip_or_name, u16 port, const char *peer_name, u16 peer_port, u32 options,
@@ -292,6 +331,11 @@ static nghttp3_ssize ngh3_data_source_read_callback(
 static GF_Err h3_setup_session(GF_DownloadSession *sess, Bool is_destroy)
 {
 	if (is_destroy) {
+		// destroy path
+        if (sess->metrics_priv) {
+            gf_free(sess->metrics_priv);
+            sess->metrics_priv = NULL;
+        }
 		if (sess->hmux_priv) {
 			GF_QuicDataRead *qr = sess->hmux_priv;
 			if (qr->second_local_buf) gf_free(qr->second_local_buf);
@@ -299,6 +343,12 @@ static GF_Err h3_setup_session(GF_DownloadSession *sess, Bool is_destroy)
 			sess->hmux_priv = NULL;
 		}
 		return GF_OK;
+	}
+		// init path
+    if (!sess->metrics_priv) {
+		sess->metrics_priv = gf_malloc(sizeof(H3Metrics));
+		if (!sess->metrics_priv) return GF_OUT_OF_MEM;
+        memset(sess->metrics_priv, 0, sizeof(H3Metrics));
 	}
 
 	if (!sess->hmux_priv) {
@@ -331,6 +381,17 @@ static int ngh3_recv_data(nghttp3_conn *conn, int64_t stream_id, const uint8_t *
 	}
 	memcpy(sess->hmux_buf.data + sess->hmux_buf.size, data, datalen);
 	sess->hmux_buf.size += (u32) datalen;
+	/*  Metrics: first byte + accumulate  */
+    H3Metrics *m = (H3Metrics*)sess->metrics_priv;
+	if (m) {
+		if (!m->t_first_us) {
+			m->t_first_us = h3_now_us();
+			/* Also update generic TTFB used by summary logs */
+			if (!sess->reply_time)
+			sess->reply_time = (u32)(m->t_first_us - sess->request_start_time);
+		}
+		m->bytes += datalen;
+	}
 	GF_LOG(GF_LOG_DEBUG, GF_LOG_HTTP, ("[HTTP/3] stream_id "LLD" received %d bytes (%d/%d total)\n", sess->hmux_stream_id, (u32) datalen, sess->hmux_buf.size, sess->total_size));
 	return 0;
 }
@@ -434,8 +495,17 @@ static int ngh3_recv_header(nghttp3_conn *conn, int64_t stream_id, int32_t token
 static int ngh3_end_headers(nghttp3_conn *conn, int64_t stream_id, int fin,
 	void *conn_user_data, void *stream_user_data)
 {
-	GF_DownloadSession *sess = stream_user_data;
+	GF_DownloadSession *sess = (GF_DownloadSession *)stream_user_data;
+	if (!sess) return 0;
 	sess->hmux_headers_seen = 1;
+	 /* Set TTFB at first response headers */
+    if (!sess->server_mode && !sess->reply_time) {
+        H3Metrics *m = (H3Metrics *)sess->metrics_priv;
+        if (m && m->t_submit_us) {
+            u64 now = h3_now_us();
+            sess->reply_time = (u32)(now - m->t_submit_us);
+        }
+    }
 	if (sess->server_mode) {
 		GF_LOG(GF_LOG_DEBUG, GF_LOG_HTTP, ("[HTTP/3] All headers received for stream ID "LLD"\n", sess->hmux_stream_id));
 	} else {
@@ -562,6 +632,17 @@ static int ngh3_stream_close(nghttp3_conn *conn, int64_t stream_id, uint64_t app
 			sess->status = GF_NETIO_DATA_TRANSFERED;
 			sess->last_error = GF_OK;
 		}
+	}
+	/*  Metrics: finalize & emit  */
+	H3Metrics *m = (H3Metrics*)sess->metrics_priv;
+	if (m) {
+		if (!m->t_end_us) m->t_end_us = h3_now_us();
+		// If download completed, treat as close
+		const char *phase = "error";
+		if (app_error_code == NGHTTP3_H3_NO_ERROR || sess->bytes_done == m->bytes) {
+			phase = "close";
+		}
+		h3_metrics_emit(sess, m, phase);
 	}
 
 	//stream closed
@@ -761,6 +842,16 @@ static GF_Err h3_submit_request(GF_DownloadSession *sess, char *req_name, const 
 	sess->hmux_data_done = 0;
 	sess->hmux_headers_seen = 0;
 	sess->hmux_ready_to_send = 0;
+	/*  Metrics: mark request submit time  */
+	H3Metrics *m = (H3Metrics*)sess->metrics_priv;
+	if (m) {
+		m->t_submit_us = h3_now_us();
+		m->t_first_us  = 0;
+		m->t_end_us    = 0;
+		m->bytes       = 0;
+	}
+	// reset TTFB used by generic summary
+	sess->reply_time = 0;
 	GF_Err e = GF_OK;
     int rv = ngtcp2_conn_open_bidi_stream(qc->conn, &sess->hmux_stream_id, sess);
     if (rv != 0) {
@@ -1479,7 +1570,7 @@ static GF_Err h3_initialize(GF_DownloadSession *sess, char *server, u32 server_p
 
 	ngtcp2_settings_default(&settings);
 
-	if (gf_opts_get_bool("core", "h3-trace")) {
+	if (gf_opts_get_bool("temp", "h3-trace")) {
 		settings.log_printf = ngq_printf;
 		nghttp3_set_debug_vprintf_callback(ngq_debug_trace);
 	} else {
@@ -1491,27 +1582,71 @@ static GF_Err h3_initialize(GF_DownloadSession *sess, char *server, u32 server_p
 	settings.initial_rtt = NGTCP2_DEFAULT_INITIAL_RTT;
 	settings.max_window = 0;
 	settings.max_stream_window = 0;
-	settings.handshake_timeout = sess->conn_timeout*1000000;
-	settings.handshake_timeout = UINT64_MAX;
-	settings.no_pmtud = 0;
+	/* Use session timeout (in microseconds) instead of infinite */
+	settings.handshake_timeout = sess->conn_timeout * 1000000;
+	settings.no_pmtud = 0;	
 	settings.ack_thresh = 2;
 	settings.initial_pkt_num = 1;
 
-	//server config
-	if (sess->server_mode) {
-		settings.token = srv_hd->token;
-		settings.tokenlen = srv_hd->tokenlen;
-		settings.token_type = token_type;
-		settings.max_window = 6000000;
-		settings.max_stream_window = 6000000;
-	}
+	/* Read user-provided QUIC tuning parameters and apply overrides */
+int wnd_kb = gf_opts_get_int("temp", "h3-maxwnd");
+int ack_thr = gf_opts_get_int("temp", "h3-ack-thresh");
+const char *algo = gf_opts_get_key("temp", "h3-algo");
+
+/* Detect explicit user overrides */
+int user_set_wnd  = (wnd_kb > 0);
+int user_set_ack  = (ack_thr > 0);
+int user_set_algo = (algo && algo[0]);
+
+
+/* Apply only the options that were explicitly provided */
+if (user_set_wnd) {
+    /*using KB * 1000 previously; keep same semantics */
+    settings.max_window = (uint64_t)wnd_kb * 1000;
+	settings.max_stream_window = (uint64_t)1000 * (uint64_t)wnd_kb;
+}
+
+if (user_set_ack) {
+    settings.ack_thresh = (uint32_t)ack_thr;
+}
+
+if (user_set_algo) {
+    if (!strcmp(algo, "bbr")) {
+        settings.cc_algo = NGTCP2_CC_ALGO_BBR;
+    } else if (!strcmp(algo, "cubic")) {
+        settings.cc_algo = NGTCP2_CC_ALGO_CUBIC;
+    }
+}
+/* keep server-only extras + logging */
+if (sess->server_mode) {
+    settings.token      = srv_hd ? srv_hd->token : NULL;
+    settings.tokenlen   = srv_hd ? srv_hd->tokenlen : 0;
+    settings.token_type = token_type;
+
+    if (user_set_wnd || user_set_ack || user_set_algo) {
+        fprintf(stderr,
+        "[H3-TUNING] Server override: max_window=%" PRIu64
+        ", ack_thresh=%u, cc_algo=%s\n",
+        (uint64_t)settings.max_window,
+        (unsigned)settings.ack_thresh,
+        user_set_algo ? algo : "(default)");
+    }
+}
+
 
 	ngtcp2_transport_params_default(&params);
+	/* larger flow-control budgets */
+	const uint32_t imd  = 64u * 1024u * 1024u;  // 64 MB connection
+	const uint32_t imsd = 32u * 1024u * 1024u;  // 32 MB per-stream
+	params.initial_max_data = imd;
+	/* HTTP/3 uses client-initiated bidi streams for response data:
+   - client must set bidi_local high
+   - server must set bidi_remote high*/
 
 	params.initial_max_data = 1024 * 1024;
-	params.initial_max_stream_data_bidi_local = sess->server_mode ? 0 : 16777216;
-	params.initial_max_stream_data_bidi_remote = sess->server_mode ? 16777216 : 0;
-	params.initial_max_stream_data_uni = 16777216;
+	params.initial_max_stream_data_bidi_local = sess->server_mode ? 0 : imsd;
+	params.initial_max_stream_data_bidi_remote = sess->server_mode ? imsd : 0;
+	params.initial_max_stream_data_uni = imsd;
 	params.initial_max_streams_bidi = sess->server_mode ? 100 : 0;
 	params.initial_max_streams_uni = 3;
 	params.max_idle_timeout = 30 * NGTCP2_SECONDS;

--- a/src/utils/os_config_init.c
+++ b/src/utils/os_config_init.c
@@ -1576,6 +1576,15 @@ GF_GPACArg GPAC_Args[] = {
 
 #ifdef GPAC_HAS_NGTCP2
  GF_DEF_ARG("h3-trace", NULL, "trace QUIC and HTTP3", NULL, NULL, GF_ARG_BOOL, GF_ARG_HINT_EXPERT|GF_ARG_SUBSYS_HTTP),
+ GF_DEF_ARG("h3-algo", NULL, "algo to use for QUIC, one of\n"
+"- cubic: default congestion control\n"
+"- bbr: bottleneck bandwidth and RTT",
+"cubic", "cubic|bbr", GF_ARG_STRING, GF_ARG_HINT_EXPERT|GF_ARG_SUBSYS_HTTP),
+GF_DEF_ARG("h3-ack-thresh", NULL,
+    "ACK threshold for QUIC (ngtcp2_settings.ack_thresh)",
+    "2", NULL,
+    GF_ARG_INT, GF_ARG_HINT_EXPERT|GF_ARG_SUBSYS_HTTP),
+GF_DEF_ARG("h3-maxwnd", NULL, "max window size in kilo bytes", "16000", NULL, GF_ARG_INT, GF_ARG_HINT_EXPERT|GF_ARG_SUBSYS_HTTP),
 #endif
 
 


### PR DESCRIPTION
This PR introduces unified metrics collection across HTTP/1.1, HTTP/2, and HTTP/3. in addition to a tunning option on the server side.. 
These Metrics includes:
- Time to First Byte (TTFB)
- Total transfer duration
- Throughput (Mb/s)
- CPU usage (user/sys)
- Memory usage (RSS)
- 
Implementation is isolated to downloader modules.
Tested locally on H1, H2, and H3.