### PR TITLE
load source filters within playlist

### DIFF
--- a/include/gpac/filters.h
+++ b/include/gpac/filters.h
@@ -2959,6 +2959,14 @@ The resulting filter will not be clonable unless the `:clone` argument is passed
 */
 Bool gf_filter_is_supported_source(GF_Filter *filter, const char *url, const char *parent_url);
 
+/*! Checks if name represents a source filter. The source filter is not loaded.
+
+\param filter the caller filter
+\param name the filter name to look for
+\return GF_TRUE if name is a source filter
+*/
+Bool gf_filter_url_is_source(GF_Filter *filter, const char *name);
+
 /*! Checks if a URL describes a filter
 
 \param filter the target filter

--- a/src/filter_core/filter.c
+++ b/src/filter_core/filter.c
@@ -4185,7 +4185,7 @@ Bool gf_filter_swap_source_register(GF_Filter *filter)
 		filter->orig_args = NULL;
 	}
 
-	gf_fs_load_source_dest_internal(filter->session, src_url, src_args, NULL, &e, filter, filter->target_filter ? filter->target_filter : filter->dst_filter, GF_TRUE, filter->no_dst_arg_inherit, NULL, NULL);
+	gf_fs_load_source_dest_internal(filter->session, src_url, src_args, NULL, &e, filter, filter->target_filter ? filter->target_filter : filter->dst_filter, GF_TRUE, filter->no_dst_arg_inherit, NULL, NULL, NULL);
 	if (src_args) gf_free(src_args);
 
 	//we manage to reassign an input registry
@@ -4275,15 +4275,35 @@ Bool gf_filter_is_supported_source(GF_Filter *filter, const char *url, const cha
 {
 	GF_Err e;
 	Bool is_supported = GF_FALSE;
-	gf_fs_load_source_dest_internal(filter->session, url, NULL, parent_url, &e, NULL, filter, GF_TRUE, GF_TRUE, &is_supported, NULL);
+	gf_fs_load_source_dest_internal(filter->session, url, NULL, parent_url, &e, NULL, filter, GF_TRUE, GF_TRUE, &is_supported, NULL, NULL);
 	return is_supported;
+}
+
+GF_EXPORT
+Bool gf_filter_url_is_source(GF_Filter *filter, const char *name)
+{
+	GF_Err e;
+	Bool is_supported = GF_FALSE;
+	char *candidate = NULL;
+	gf_fs_load_source_dest_internal(filter->session, name, NULL, NULL, &e, NULL, NULL, GF_TRUE, GF_TRUE, &is_supported, NULL, &candidate);
+	if (is_supported && candidate) {
+		const char *sep = strchr(name, filter->session->sep_args);
+		u32 len = (u32) (sep ? (sep - name) : strlen(name));
+		Bool match = GF_FALSE;
+		if ((strlen(candidate)==len) && !strncmp(candidate, name, len)) {
+			match = GF_TRUE;
+		}
+		gf_free(candidate);
+		return match;
+	}
+	return GF_FALSE;
 }
 
 GF_EXPORT
 Bool gf_filter_url_is_filter(GF_Filter *filter, const char *url, Bool *act_as_source)
 {
 	char *sep = strchr(url, filter->session->sep_args);
-	u32 len = (u32) ( sep ? (sep - url - 1) : strlen(url) );
+	u32 len = (u32) ( sep ? (sep - url) : strlen(url) );
 	u32 i, count = gf_list_count(filter->session->registry);
 	for (i=0; i<count; i++) {
 		const GF_FilterRegister *freg = gf_list_get(filter->session->registry, i);
@@ -4383,7 +4403,7 @@ GF_Filter *gf_filter_connect_source_internal(GF_Filter *filter, const char *url,
 	if (gf_filter_url_is_filter(filter, url, NULL)) {
 		filter_src = gf_fs_load_filter(filter->session, url, err);
 	} else {
-		filter_src = gf_fs_load_source_dest_internal(filter->session, url, NULL, parent_url, err, NULL, is_src_add ? NULL : filter, GF_TRUE, is_src_add ? GF_FALSE : GF_TRUE, NULL, NULL);
+		filter_src = gf_fs_load_source_dest_internal(filter->session, url, NULL, parent_url, err, NULL, is_src_add ? NULL : filter, GF_TRUE, is_src_add ? GF_FALSE : GF_TRUE, NULL, NULL, NULL);
 	}
 	if (full_args) gf_free(full_args);
 
@@ -4421,7 +4441,7 @@ GF_EXPORT
 GF_Filter *gf_filter_connect_destination(GF_Filter *filter, const char *url, GF_Err *err)
 {
 	if (!filter) return NULL;
-	return gf_fs_load_source_dest_internal(filter->session, url, NULL, NULL, err, NULL, filter, GF_FALSE, GF_FALSE, NULL, NULL);
+	return gf_fs_load_source_dest_internal(filter->session, url, NULL, NULL, err, NULL, filter, GF_FALSE, GF_FALSE, NULL, NULL, NULL);
 }
 
 

--- a/src/filter_core/filter_session.c
+++ b/src/filter_core/filter_session.c
@@ -3630,7 +3630,7 @@ static GF_Filter *locate_alias_sink(GF_Filter *filter, const char *url, const ch
 	return NULL;
 }
 
-GF_Filter *gf_fs_load_source_dest_internal(GF_FilterSession *fsess, const char *url, const char *user_args, const char *parent_url, GF_Err *err, GF_Filter *filter, GF_Filter *dst_filter, Bool for_source, Bool no_args_inherit, Bool *probe_only, const GF_FilterRegister **probe_reg)
+GF_Filter *gf_fs_load_source_dest_internal(GF_FilterSession *fsess, const char *url, const char *user_args, const char *parent_url, GF_Err *err, GF_Filter *filter, GF_Filter *dst_filter, Bool for_source, Bool no_args_inherit, Bool *probe_only, const GF_FilterRegister **probe_reg, char **probe_fname)
 {
 	GF_FilterProbeScore score = GF_FPROBE_NOT_SUPPORTED;
 	GF_FilterRegister *candidate_freg=NULL;
@@ -3745,7 +3745,22 @@ GF_Filter *gf_fs_load_source_dest_internal(GF_FilterSession *fsess, const char *
 				if (try_js) {
 					if (!strncmp(url, "gpac://", 7)) url += 7;
 					filter = gf_fs_load_filter_internal(fsess, url, err, probe_only);
-					if (probe_only) return NULL;
+					if (probe_only) {
+						if (probe_fname && *probe_only) {
+							char *sname = strchr(url, fsess->sep_args);
+							if (sname) {
+								u32 len = (u32) (sname - url);
+								*probe_fname = (char *) gf_malloc(len + 1);
+								memcpy(*probe_fname, url, len);
+								(*probe_fname)[len] = 0;
+							}
+						} else if (probe_fname) {
+							*probe_fname = gf_strdup(url);
+							char *sep = strchr(*probe_fname, fsess->sep_args);
+							if (sep) sep[0] = 0;
+						}
+						return NULL;
+					}
 
 					if (filter) {
 						//for link resolution
@@ -3840,6 +3855,9 @@ restart:
 	if (probe_only) {
 		*probe_only = candidate_freg ? GF_TRUE : GF_FALSE;
 		if (probe_reg) *probe_reg = candidate_freg;
+		if (probe_fname && candidate_freg) {
+			*probe_fname = gf_strdup(candidate_freg->name);
+		}
 
 		if (free_url)
 			gf_free(sURL);
@@ -3956,13 +3974,13 @@ restart:
 GF_EXPORT
 GF_Filter *gf_fs_load_source(GF_FilterSession *fsess, const char *url, const char *args, const char *parent_url, GF_Err *err)
 {
-	return gf_fs_load_source_dest_internal(fsess, url, args, parent_url, err, NULL, NULL, GF_TRUE, GF_FALSE, NULL, NULL);
+	return gf_fs_load_source_dest_internal(fsess, url, args, parent_url, err, NULL, NULL, GF_TRUE, GF_FALSE, NULL, NULL, NULL);
 }
 
 GF_EXPORT
 GF_Filter *gf_fs_load_destination(GF_FilterSession *fsess, const char *url, const char *args, const char *parent_url, GF_Err *err)
 {
-	return gf_fs_load_source_dest_internal(fsess, url, args, parent_url, err, NULL, NULL, GF_FALSE, GF_FALSE, NULL, NULL);
+	return gf_fs_load_source_dest_internal(fsess, url, args, parent_url, err, NULL, NULL, GF_FALSE, GF_FALSE, NULL, NULL, NULL);
 }
 
 
@@ -4939,7 +4957,7 @@ Bool gf_fs_is_supported_source(GF_FilterSession *session, const char *url, const
 {
 	GF_Err e;
 	Bool is_supported = GF_FALSE;
-	gf_fs_load_source_dest_internal(session, url, NULL, parent_url, &e, NULL, NULL, GF_TRUE, GF_TRUE, &is_supported, NULL);
+	gf_fs_load_source_dest_internal(session, url, NULL, parent_url, &e, NULL, NULL, GF_TRUE, GF_TRUE, &is_supported, NULL, NULL);
 	return is_supported;
 }
 

--- a/src/filter_core/filter_session.h
+++ b/src/filter_core/filter_session.h
@@ -911,7 +911,7 @@ Bool gf_filter_swap_source_register(GF_Filter *filter);
 
 GF_Err gf_filter_new_finalize(GF_Filter *filter, const char *args, GF_FilterArgType arg_type);
 
-GF_Filter *gf_fs_load_source_dest_internal(GF_FilterSession *fsess, const char *url, const char *args, const char *parent_url, GF_Err *err, GF_Filter *filter, GF_Filter *dst_filter, Bool for_source, Bool no_args_inherit, Bool *probe_only, const GF_FilterRegister **probe_reg);
+GF_Filter *gf_fs_load_source_dest_internal(GF_FilterSession *fsess, const char *url, const char *args, const char *parent_url, GF_Err *err, GF_Filter *filter, GF_Filter *dst_filter, Bool for_source, Bool no_args_inherit, Bool *probe_only, const GF_FilterRegister **probe_reg, char **probe_fname);
 
 void gf_fs_post_pid_instance_delete_task(GF_FilterSession *session, GF_Filter *filter, GF_FilterPid *pid, GF_FilterPidInst *pidinst);
 

--- a/src/filter_core/filter_session_js.c
+++ b/src/filter_core/filter_session_js.c
@@ -1069,9 +1069,9 @@ static Bool jsfs_get_filter_args(JSContext *ctx, GF_FilterSession *fs, GF_Filter
 		GF_Err e;
 		Bool probe;
 		if (!strncmp(regname, "src=", 4)) {
-			gf_fs_load_source_dest_internal(fs, regname+4, NULL, NULL, &e, NULL, NULL, GF_TRUE, GF_FALSE, &probe, &freg);
+			gf_fs_load_source_dest_internal(fs, regname+4, NULL, NULL, &e, NULL, NULL, GF_TRUE, GF_FALSE, &probe, &freg, NULL);
 		} else if (!strncmp(regname, "dst=", 4)) {
-			gf_fs_load_source_dest_internal(fs, regname+4, NULL, NULL, &e, NULL, NULL, GF_FALSE, GF_FALSE, &probe, &freg);
+			gf_fs_load_source_dest_internal(fs, regname+4, NULL, NULL, &e, NULL, NULL, GF_FALSE, GF_FALSE, &probe, &freg, NULL);
 		}
 	}
 

--- a/src/filters/filelist.c
+++ b/src/filters/filelist.c
@@ -1460,8 +1460,13 @@ static GF_Err filelist_load_next(GF_Filter *filter, GF_FileListCtx *ctx)
 				f = gf_filter_load_filter(filter, url, &e);
 				if (f) gf_filter_require_source_id(f);
 			} else {
-				//no parent path if gfio
-				fsrc = gf_filter_connect_source(filter, url, ctx->is_gfio ? NULL : ctx->file_path, GF_FALSE, &e);
+				Bool is_src_filter = gf_filter_is_supported_source(filter, url, NULL);
+				if (is_src_filter) {
+					fsrc = gf_filter_load_filter(filter, url, &e);
+				} else {
+					//no parent path if gfio
+					fsrc = gf_filter_connect_source(filter, url, ctx->is_gfio ? NULL : ctx->file_path, GF_FALSE, &e);
+				}
 
 				if (fsrc) {
 					gf_filter_set_setup_failure_callback(filter, fsrc, filelist_on_filter_setup_error, filter);

--- a/src/filters/filelist.c
+++ b/src/filters/filelist.c
@@ -1460,7 +1460,7 @@ static GF_Err filelist_load_next(GF_Filter *filter, GF_FileListCtx *ctx)
 				f = gf_filter_load_filter(filter, url, &e);
 				if (f) gf_filter_require_source_id(f);
 			} else {
-				Bool is_src_filter = gf_filter_is_supported_source(filter, url, NULL);
+				Bool is_src_filter = gf_filter_url_is_source(filter, url);
 				if (is_src_filter) {
 					fsrc = gf_filter_load_filter(filter, url, &e);
 				} else {


### PR DESCRIPTION
Adds the ability to load source filters from within playlist.

Example playlist

```
##begin basic.pl
avgen:dur=4 && txtgen:dur=4:!rt
##end playlist
```

Example command-line:

```
gpac -i basic.pl:RSID c=avc c=aac @@ tx3g2vtt -o out.mp4:frag
```

> [!WARNING]
> The `RSID` and `@@` was needed for graph to connect properly. Maybe there's something missing with sources that need other intermediate filters.