### PR TITLE
Support extracting standalone IAMF from MP4.

### DIFF
--- a/include/gpac/mpeg4_odf.h
+++ b/include/gpac/mpeg4_odf.h
@@ -1970,7 +1970,7 @@ typedef struct
 */
 GF_IAConfig *gf_odf_iamf_cfg_new();
 
-/*! writes IAMF config to buffer
+/*! writes IAMF config (IACB) to buffer
 \param cfg the IAMF config to write
 \param outData set to an allocated encoded buffer - it is the caller responsibility to free this
 \param outSize set to the encoded dsi buffer size
@@ -1978,12 +1978,19 @@ GF_IAConfig *gf_odf_iamf_cfg_new();
 */
 GF_Err gf_odf_iamf_cfg_write(GF_IAConfig *cfg, u8 **outData, u32 *outSize);
 
-/*! Writes the IAMF config to bitstream
+/*! Writes the IAMF config (IACB) to bitstream
 \param cfg the IAMF config to write
 \param bs the bitstream object
 \return error code if any
 */
 GF_Err gf_odf_iamf_cfg_write_bs(GF_IAConfig *cfg, GF_BitStream *bs);
+
+/*! Writes the IAMF config payload (OBUs only) to bitstream
+\param cfg the IAMF config to write
+\param bs the bitstream object
+\return error code if any
+*/
+GF_Err gf_odf_iamf_cfg_write_obus(GF_IAConfig *cfg, GF_BitStream *bs);
 
 /*! IAMF config destructor
 \param cfg the IAMF config to destroy

--- a/src/filters/isoffin_load.c
+++ b/src/filters/isoffin_load.c
@@ -968,10 +968,7 @@ static void isor_declare_track(ISOMReader *read, ISOMChannel *ch, u32 track, u32
 			codec_id = GF_CODECID_IAMF;
 			GF_IAConfig *iamf = gf_isom_iamf_config_get(read->mov, track, stsd_idx);
 			if (iamf) {
-				GF_BitStream *bs = gf_bs_new(NULL, 0, GF_BITSTREAM_WRITE);
-				gf_odf_iamf_cfg_write_obus(iamf, bs);
-				gf_bs_get_content(bs, &dsi, &dsi_size);
-				gf_bs_del(bs);
+				gf_odf_iamf_cfg_write(iamf, &dsi, &dsi_size);
 				gf_odf_iamf_cfg_del(iamf);
 			}
 		}

--- a/src/filters/isoffin_load.c
+++ b/src/filters/isoffin_load.c
@@ -963,6 +963,19 @@ static void isor_declare_track(ISOMReader *read, ISOMChannel *ch, u32 track, u32
 			codec_id = GF_CODECID_OPUS;
 			gf_isom_opus_config_get(read->mov, track, stsd_idx, &dsi, &dsi_size);
 			break;
+		case GF_ISOM_SUBTYPE_IAMF:
+		{
+			codec_id = GF_CODECID_IAMF;
+			GF_IAConfig *iamf = gf_isom_iamf_config_get(read->mov, track, stsd_idx);
+			if (iamf) {
+				GF_BitStream *bs = gf_bs_new(NULL, 0, GF_BITSTREAM_WRITE);
+				gf_odf_iamf_cfg_write_obus(iamf, bs);
+				gf_bs_get_content(bs, &dsi, &dsi_size);
+				gf_bs_del(bs);
+				gf_odf_iamf_cfg_del(iamf);
+			}
+		}
+			break;
 
 		case GF_QT_SUBTYPE_FL32:
 		case GF_QT_SUBTYPE_FL64:

--- a/src/filters/write_generic.c
+++ b/src/filters/write_generic.c
@@ -1402,6 +1402,32 @@ GF_Err writegen_process(GF_Filter *filter)
 			dsi_out[2] = 'a';
 			dsi_out[3] = 'C';
 			memcpy(dsi_out+4, ctx->dcfg, ctx->dcfg_size);
+		} else if (ctx->is_iamf) {
+			GF_IAConfig *iacb = gf_odf_iamf_cfg_read((u8 *)ctx->dcfg, ctx->dcfg_size);
+			if (iacb) {
+				GF_BitStream *bs = gf_bs_new(NULL, 0, GF_BITSTREAM_WRITE);
+				gf_odf_iamf_cfg_write_obus(iacb, bs);
+				u8 *obus_data = NULL;
+				u32 obus_size = 0;
+				gf_bs_get_content(bs, &obus_data, &obus_size);
+				gf_bs_del(bs);
+				gf_odf_iamf_cfg_del(iacb);
+				if (obus_data && obus_size) {
+					u8 *pck_data;
+					dst_pck = gf_filter_pck_new_alloc(ctx->opid, obus_size, &pck_data);
+					if (!dst_pck) {
+						gf_free(obus_data);
+						return GF_OUT_OF_MEM;
+					}
+					memcpy(pck_data, obus_data, obus_size);
+					gf_free(obus_data);
+				}
+			}
+			if (!dst_pck) {
+				dst_pck = gf_filter_pck_new_shared(ctx->opid, ctx->dcfg, ctx->dcfg_size, NULL);
+				if (!dst_pck) return GF_OUT_OF_MEM;
+				gf_filter_pck_set_readonly(dst_pck);
+			}
 		} else {
 			dst_pck = gf_filter_pck_new_shared(ctx->opid, ctx->dcfg, ctx->dcfg_size, NULL);
 			if (!dst_pck) return GF_OUT_OF_MEM;

--- a/src/filters/write_generic.c
+++ b/src/filters/write_generic.c
@@ -63,6 +63,7 @@ typedef struct
 
 	u32 codecid;
 	Bool is_mj2k;
+	Bool is_iamf;
 	u32 sample_num;
 
 	const char *dcfg;
@@ -136,6 +137,7 @@ GF_Err writegen_configure_pid(GF_Filter *filter, GF_FilterPid *pid, Bool is_remo
 	cid = p->value.uint;
 
 	ctx->codecid = cid;
+	ctx->is_iamf = GF_FALSE;
 	if (!ctx->opid) {
 		ctx->opid = gf_filter_pid_new(filter);
 		if (!ctx->opid)
@@ -242,6 +244,11 @@ GF_Err writegen_configure_pid(GF_Filter *filter, GF_FilterPid *pid, Bool is_remo
 	case GF_CODECID_J2K:
 		ctx->split = GF_TRUE;
 		ctx->is_mj2k = GF_TRUE;
+		break;
+	case GF_CODECID_IAMF:
+		ctx->is_iamf = GF_TRUE;
+		if (ctx->decinfo == DECINFO_AUTO)
+			ctx->decinfo = DECINFO_FIRST;
 		break;
 	case GF_CODECID_AMR:
 		gf_filter_pid_set_property(ctx->opid, GF_PROP_PID_MIME, &PROP_STRING(mimetype) );
@@ -1385,7 +1392,7 @@ GF_Err writegen_process(GF_Filter *filter)
 
 	if (ctx->frame) {
 		split = GF_TRUE;
-	} else if (ctx->dcfg_size && gf_filter_pck_get_sap(pck) && !ctx->is_mj2k && !ctx->webvtt && (ctx->decinfo!=DECINFO_NO) && !ctx->cfg_sent) {
+	} else if (ctx->dcfg_size && (gf_filter_pck_get_sap(pck) || ctx->is_iamf) && !ctx->is_mj2k && !ctx->webvtt && (ctx->decinfo!=DECINFO_NO) && !ctx->cfg_sent) {
 		if (ctx->codecid==GF_CODECID_FLAC) {
 			u8 *dsi_out;
 			dst_pck = gf_filter_pck_new_alloc(ctx->opid, ctx->dcfg_size+4, &dsi_out);
@@ -1857,6 +1864,14 @@ static GF_FilterCapability GenDumpCaps[] =
 	CAP_UINT(GF_CAPS_OUTPUT, GF_PROP_PID_STREAM_TYPE, GF_STREAM_FILE),
 	CAP_STRING(GF_CAPS_OUTPUT, GF_PROP_PID_FILE_EXT, "usac|xheaac|latm"),
 	CAP_STRING(GF_CAPS_OUTPUT, GF_PROP_PID_MIME, "audio/xheaac+latm"),
+	{0},
+
+	//we accept IAMF
+	CAP_UINT(GF_CAPS_INPUT,GF_PROP_PID_STREAM_TYPE, GF_STREAM_AUDIO),
+	CAP_UINT(GF_CAPS_INPUT,GF_PROP_PID_CODECID, GF_CODECID_IAMF),
+	CAP_UINT(GF_CAPS_OUTPUT, GF_PROP_PID_STREAM_TYPE, GF_STREAM_FILE),
+	CAP_STRING(GF_CAPS_OUTPUT, GF_PROP_PID_FILE_EXT, "iamf"),
+	CAP_STRING(GF_CAPS_OUTPUT, GF_PROP_PID_MIME, "audio/iamf"),
 	{0},
 
 	CAP_UINT(GF_CAPS_INPUT,GF_PROP_PID_STREAM_TYPE, GF_STREAM_VISUAL),

--- a/src/isomedia/box_code_base.c
+++ b/src/isomedia/box_code_base.c
@@ -4415,6 +4415,7 @@ GF_Err audio_sample_entry_box_size(GF_Box *s)
 	gf_isom_check_position(s, (GF_Box *)ptr->cfg_ac3, &pos);
 	gf_isom_check_position(s, (GF_Box *)ptr->cfg_flac, &pos);
 	gf_isom_check_position(s, (GF_Box *)ptr->cfg_mlp, &pos);
+	gf_isom_check_position(s, (GF_Box *)ptr->cfg_iamf, &pos);
 
 	if (!ptr->version) {
 		gf_isom_check_position(s, gf_isom_box_find_child(ptr->child_boxes, GF_ISOM_BOX_TYPE_SRAT), &pos);

--- a/src/isomedia/media.c
+++ b/src/isomedia/media.c
@@ -381,10 +381,7 @@ GF_Err Media_GetESD(GF_MediaBox *mdia, u32 sampleDescIndex, GF_ESD **out_esd, Bo
 		(*out_esd)->decoderConfig->streamType = GF_STREAM_AUDIO;
 		(*out_esd)->decoderConfig->objectTypeIndication = GF_CODECID_IAMF;
 		
-		GF_BitStream *bs = gf_bs_new(NULL, 0, GF_BITSTREAM_WRITE);
-		gf_odf_iamf_cfg_write_obus(iamf_c->cfg, bs);
-		gf_bs_get_content(bs, &(*out_esd)->decoderConfig->decoderSpecificInfo->data, &(*out_esd)->decoderConfig->decoderSpecificInfo->dataLength);
-		gf_bs_del(bs);
+		gf_odf_iamf_cfg_write(iamf_c->cfg, & (*out_esd)->decoderConfig->decoderSpecificInfo->data, & (*out_esd)->decoderConfig->decoderSpecificInfo->dataLength);
 		break;
 	}
 	case GF_ISOM_SUBTYPE_3GP_H263:

--- a/src/isomedia/media.c
+++ b/src/isomedia/media.c
@@ -364,7 +364,29 @@ GF_Err Media_GetESD(GF_MediaBox *mdia, u32 sampleDescIndex, GF_ESD **out_esd, Bo
 		gf_odf_opus_cfg_write(&opus_c->opcfg, & (*out_esd)->decoderConfig->decoderSpecificInfo->data, & (*out_esd)->decoderConfig->decoderSpecificInfo->dataLength);
 		break;
 	}
+	case GF_ISOM_SUBTYPE_IAMF:
+		if (entry->internal_type != GF_ISOM_SAMPLE_ENTRY_AUDIO)
+			return GF_ISOM_INVALID_MEDIA;
+	{
+		GF_IAConfigurationBox *iamf_c;
+		if (true_desc_only)
+			return GF_ISOM_INVALID_MEDIA;
 
+		iamf_c = ((GF_MPEGAudioSampleEntryBox*)entry)->cfg_iamf;
+		if (!iamf_c || !iamf_c->cfg) {
+			GF_LOG(GF_LOG_WARNING, GF_LOG_CONTAINER, ("ESD not found for IAMF\n"));
+			break;
+		}
+		*out_esd = gf_odf_desc_esd_new(2);
+		(*out_esd)->decoderConfig->streamType = GF_STREAM_AUDIO;
+		(*out_esd)->decoderConfig->objectTypeIndication = GF_CODECID_IAMF;
+		
+		GF_BitStream *bs = gf_bs_new(NULL, 0, GF_BITSTREAM_WRITE);
+		gf_odf_iamf_cfg_write_obus(iamf_c->cfg, bs);
+		gf_bs_get_content(bs, &(*out_esd)->decoderConfig->decoderSpecificInfo->data, &(*out_esd)->decoderConfig->decoderSpecificInfo->dataLength);
+		gf_bs_del(bs);
+		break;
+	}
 	case GF_ISOM_SUBTYPE_3GP_H263:
 		if (entry->internal_type != GF_ISOM_SAMPLE_ENTRY_VIDEO)
 			return GF_ISOM_INVALID_MEDIA;

--- a/src/odf/descriptors.c
+++ b/src/odf/descriptors.c
@@ -2746,21 +2746,31 @@ void gf_odf_iamf_cfg_del(GF_IAConfig *cfg)
 }
 
 GF_EXPORT
-GF_Err gf_odf_iamf_cfg_write_bs(GF_IAConfig *cfg, GF_BitStream *bs)
+GF_Err gf_odf_iamf_cfg_write_obus(GF_IAConfig *cfg, GF_BitStream *bs)
 {
 	u32 i;
 	if (!cfg || !bs) return GF_BAD_PARAM;
 
 	#ifndef GPAC_DISABLE_AV_PARSERS
-		gf_bs_write_u8(bs, cfg->configurationVersion);
-		gf_av1_leb128_write(bs, cfg->configOBUs_size);
-		for (i = 0; i < gf_list_count(cfg->configOBUs); ++i) {
-				GF_IamfObu *configOBU = gf_list_get(cfg->configOBUs, i);
-				gf_bs_write_data(bs, configOBU->raw_obu_bytes, (u32)configOBU->obu_length);
-		}
+	for (i = 0; i < gf_list_count(cfg->configOBUs); ++i) {
+		GF_IamfObu *configOBU = gf_list_get(cfg->configOBUs, i);
+		gf_bs_write_data(bs, configOBU->raw_obu_bytes, (u32)configOBU->obu_length);
+	}
 	#endif
-
 	return GF_OK;
+}
+
+GF_EXPORT
+GF_Err gf_odf_iamf_cfg_write_bs(GF_IAConfig *cfg, GF_BitStream *bs)
+{
+  if (!cfg || !bs) return GF_BAD_PARAM;
+
+#ifndef GPAC_DISABLE_AV_PARSERS
+  gf_bs_write_u8(bs, cfg->configurationVersion);
+  gf_av1_leb128_write(bs, cfg->configOBUs_size);
+  return gf_odf_iamf_cfg_write_obus(cfg, bs);
+#endif
+  return GF_OK;
 }
 
 GF_EXPORT

--- a/src/utils/constants.c
+++ b/src/utils/constants.c
@@ -158,6 +158,7 @@ CodecIDReg CodecRegistry [] = {
 
 	{GF_CODECID_MPHA, 0, GF_STREAM_AUDIO, "MPEG-H Audio", "mhas", "mha1", "audio/x-mpegh", .unframe=GF_TRUE},
 	{GF_CODECID_MHAS, 0, GF_STREAM_AUDIO, "MPEG-H AudioMux", "mhas", "mhm1", "audio/x-mhas", .unframe=GF_TRUE},
+	{GF_CODECID_IAMF, 0, GF_STREAM_AUDIO, "AOM IAMF (Immersive Audio Model and Formats)", "iamf", "iamf", "audio/iamf", .unframe=GF_TRUE},
 
 	{GF_CODECID_APCH, 0, GF_STREAM_VISUAL, "ProRes Video 422 HQ", "prores|apch", "apch", "video/prores", .unframe=GF_TRUE},
 	{GF_CODECID_APCO, 0, GF_STREAM_VISUAL, "ProRes Video 422 Proxy", "prores|apco", "apco", "video/prores", GF_CODECID_APCH, .unframe=GF_TRUE},
@@ -286,6 +287,8 @@ GF_CodecID gf_codec_id_from_isobmf(u32 isobmftype)
 		return GF_CODECID_VP10;
 	case GF_ISOM_SUBTYPE_AVS3:
 		return GF_CODECID_AVS3_VIDEO;
+	case GF_ISOM_SUBTYPE_IAMF:
+		return GF_CODECID_IAMF;
 
 	case GF_QT_SUBTYPE_APCH:
 		return GF_CODECID_APCH;


### PR DESCRIPTION
Support extracting standalone IAMF from MP4.

  - Enables extracting IAMF tracks for IAMF containers into "standalone" IAMF streams.
  - Works via any standard GPAC pileine commands (e.g. `gpac -i input.mp4 -o otuput.iamf`)
  - `descriptors.c`: Split out a function, standalone IAMF uses a subset of the IACB (`config_OBUs`).
  - `write_generic.c`: IAMF has key frames, so bypass SAP check.