### PR TITLE
mux_isom: accept integer 48 fps for ProRes muxing (follow-up to #3544)

### DIFF
--- a/src/filters/mux_isom.c
+++ b/src/filters/mux_isom.c
@@ -1370,6 +1370,7 @@ static GF_Err mp4_mux_setup_pid(GF_Filter *filter, GF_FilterPid *pid, Bool is_tr
 				else if (inc * 2997 == ts * 125) target_timescale = 2997;
 				else if (inc * 48000 == ts * 1001) target_timescale = 48000;
 				else if (inc * 4800 == ts * 100) target_timescale = 4800;
+				else if (inc * 6000 == ts * 100) target_timescale = 6000;
 				else if (is_prores) {
 					GF_LOG(GF_LOG_ERROR, GF_LOG_MEDIA, ("[ProRes] Unrecognized frame rate %g\n", ((Double)ts)/inc ));
 					return GF_NON_COMPLIANT_BITSTREAM;

--- a/src/filters/mux_isom.c
+++ b/src/filters/mux_isom.c
@@ -1369,6 +1369,7 @@ static GF_Err mp4_mux_setup_pid(GF_Filter *filter, GF_FilterPid *pid, Bool is_tr
 				else if (inc * 5994 == ts * 100) target_timescale = 60000;
 				else if (inc * 2997 == ts * 125) target_timescale = 2997;
 				else if (inc * 48000 == ts * 1001) target_timescale = 48000;
+				else if (inc * 4800 == ts * 100) target_timescale = 4800;
 				else if (is_prores) {
 					GF_LOG(GF_LOG_ERROR, GF_LOG_MEDIA, ("[ProRes] Unrecognized frame rate %g\n", ((Double)ts)/inc ));
 					return GF_NON_COMPLIANT_BITSTREAM;


### PR DESCRIPTION

## Summary

`MP4Box -add prores_48fps.mov out.mov` fails with `[ProRes] Unrecognized frame rate 48` when the input is ProRes at integer 48 fps. The post-mux validator `gf_media_check_qt_prores()` in `src/media_tools/isom_tools.c` already recognizes integer 48 fps (added in #3544), but the pre-mux filter validator in `src/filters/mux_isom.c` does not — so the filter graph fails to connect and the post-mux validator is never reached.

## Version

GPAC: `master` @ `9e6cda84d` (verified 2026-05-18). Patch applies cleanly to current `master` HEAD, but the **PR branch is based on `81f648162` (`Fixed #3569`)** because buildbot build 1172 on `9e6cda84d` is currently red on debian32 (unrelated HEVC test failures). Happy to rebase onto master once that's resolved.

## Symptom

A simple `-add prores_48fps.mov out.mov` succeeds because it goes through the legacy `gf_media_import` path, which finalizes via `gf_media_check_qt_prores()` in `isom_tools.c` (where integer 48 was added by #3544). The failure path is reached when the input is a **playlist** — that routes through the `flist` filter into `mp4mx`, hitting the pre-mux validator in `mux_isom.c`:

```
$ MP4Box -force-cat -noprog -add chunks.playlist out.mov

[FileList] Switching to file prores_xq_48.mov
[ProRes] Unrecognized frame rate 48
Failed to connect filter flist PID prores_xq_48.mov to filter mp4mx: BitStream Not Compliant
Blacklisting mp4mx as output from flist and retrying connections
No filter chain found for PID prores_xq_48.mov in filter flist to any loaded filters - NOT CONNECTED
[Importer] No valid track to import in input file "chunks.playlist"
Failure while importing media: Feature Not Supported
Error importing chunks.playlist: Feature Not Supported

$ echo $?
1
```

## Root cause

`src/filters/mux_isom.c:1357–1376` (master @ `9e6cda84d`):

```c
if (ctx->make_qt && (tkw->stream_type==GF_STREAM_VISUAL)) {
    p = gf_filter_pid_get_property(pid, GF_PROP_PID_FPS);
    if (p) {
        u32 ts=p->value.frac.num, inc=p->value.frac.den;
        if (inc * 24000 == ts * 1001) target_timescale = 24000;
        else if (inc * 2400  == ts * 100)  target_timescale = 2400;
        else if (inc * 2500  == ts * 100)  target_timescale = 2500;
        else if (inc * 30000 == ts * 1001) target_timescale = 30000;
        else if (inc * 2997  == ts * 100)  target_timescale = 30000;
        else if (inc * 3000  == ts * 100)  target_timescale = 3000;
        else if (inc * 5000  == ts * 100)  target_timescale = 5000;
        else if (inc * 60000 == ts * 1001) target_timescale = 60000;
        else if (inc * 5994  == ts * 100)  target_timescale = 60000;
        else if (inc * 2997  == ts * 125)  target_timescale = 2997;
        else if (inc * 48000 == ts * 1001) target_timescale = 48000;   // 47.952, added in #3544
        else if (is_prores) {
            GF_LOG(GF_LOG_ERROR, GF_LOG_MEDIA, ("[ProRes] Unrecognized frame rate %g\n", ((Double)ts)/inc ));
            return GF_NON_COMPLIANT_BITSTREAM;
        }
    }
    ...
}
```

For integer 48 fps (`ts=48, inc=1`, equivalently `ts=48000, inc=1000`), none of the existing `==` checks satisfy, so the `is_prores` branch fires and returns `GF_NON_COMPLIANT_BITSTREAM`.

The post-mux validator in `src/media_tools/isom_tools.c:1259–1270` already handles integer 48 (also added in #3544):

```c
else if (ifps >= 4794 && ifps <= 4796) target_ts = 48000; // 47.952
else if (ifps >= 4799 && ifps <= 4801) target_ts = 4800;  // 48
```

…but `gf_media_check_qt_prores()` is invoked from `applications/mp4box/mp4box.c:6918` *after* muxing completes, which never happens here because `mp4_mux_setup_pid` failed at filter graph connect time.

## Proposed fix

```diff
diff --git a/src/filters/mux_isom.c b/src/filters/mux_isom.c
@@ -1368,6 +1368,7 @@ static GF_Err mp4_mux_setup_pid(GF_Filter *filter, GF_FilterPid *pid, Bool is_tr
                 else if (inc * 60000 == ts * 1001) target_timescale = 60000;
                 else if (inc * 5994 == ts * 100) target_timescale = 60000;
                 else if (inc * 2997 == ts * 125) target_timescale = 2997;
                 else if (inc * 48000 == ts * 1001) target_timescale = 48000;
+                else if (inc * 4800 == ts * 100) target_timescale = 4800;
                 else if (is_prores) {
                     GF_LOG(GF_LOG_ERROR, GF_LOG_MEDIA, ("[ProRes] Unrecognized frame rate %g\n", ((Double)ts)/inc ));
                     return GF_NON_COMPLIANT_BITSTREAM;
```

For `ts=48, inc=1` this evaluates `1 * 4800 == 48 * 100 → 4800 == 4800`, sets `target_timescale = 4800`, and falls through cleanly. For unreduced `ts=48000, inc=1000` the equality still holds.

This restores symmetry with the post-mux validator, which has accepted both 47.952 and integer 48 since #3544.


## Synthetic reproduction

Verified on `master @ 9e6cda84d`, macOS 26.2, Apple clang 21.0.0, configured with `./configure --static-mp4box --use-zlib=no`. ffmpeg 8.1.1.

```sh
# 1. Create a 2s ProRes 4444 clip at integer 48 fps (profile 4 = 4444)
ffmpeg -y -f lavfi -i "testsrc2=duration=2:size=1920x1080:rate=48" \
       -c:v prores_ks -profile:v 4 -pix_fmt yuv444p10le -vendor apl0 \
       prores_xq_48.mov

# 2. Single-entry playlist (the bug is in the playlist/filter path)
echo "prores_xq_48.mov" > chunks.playlist

# 3. Repro on master (without fix)
MP4Box -force-cat -noprog -add chunks.playlist out.mov ; echo "exit=$?"
# → exit=1
# → [ProRes] Unrecognized frame rate 48
# → Failed to connect filter flist PID ... to filter mp4mx: BitStream Not Compliant
# → No filter chain found ... NOT CONNECTED
# → [Importer] No valid track to import in input file "chunks.playlist"

# 4. Same command after applying the one-line patch above
MP4Box -force-cat -noprog -add chunks.playlist out.mov ; echo "exit=$?"
# → exit=0
# → [FileList] Switching to file prores_xq_48.mov
# → Track Importing ProRes Video 4444 - Width 1920 Height 1080 FPS 12288/256
# → [QTFF/ProRes] Adjusting ProRes compliancy

# 5. MP4Box -info confirms the container is valid QT/ProRes
MP4Box -info out.mov
# → Movie Info - 1 track - TimeScale 4800
# → Duration 00:00:02.000
# → ProRes Video 4444 - Resolution 1920 x 1080
# → Max sample duration: 100 / 4800   (= 1/48 s per frame ✓)

# 6. Regression check — the existing 47.952 fps path still works after the patch
ffmpeg -y -f lavfi -i "testsrc2=duration=2:size=1920x1080:rate=48000/1001" \
       -c:v prores_ks -profile:v 4 -pix_fmt yuv444p10le -vendor apl0 \
       prores_xq_47952.mov
echo "prores_xq_47952.mov" > chunks_47952.playlist
MP4Box -force-cat -noprog -add chunks_47952.playlist out_47952.mov ; echo "exit=$?"
# → exit=0  (unchanged behavior — `48000/1001` line is untouched)
```

## Thanks

Thanks to @jeanlf and the GPAC team for the recent merges and quick turnaround on earlier issues — much appreciated.
