### PR TITLE
zlib: avoid zip bombs with ZLIB_INFLATE_MAX_MULTIPLIER 

### DIFF
--- a/include/gpac/setup.h
+++ b/include/gpac/setup.h
@@ -916,6 +916,12 @@ size_t gf_strlcat(char *dst, const char *src, size_t dsize);
 #endif
 //! @endcond
 
+#ifndef GPAC_DISABLE_ZLIB
+#define ZLIB_INFLATE_MAX_MULTIPLIER 32
+#define ZLIB_COMPRESS_SAFE 4
+#endif
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/filters/dmx_nhml.c
+++ b/src/filters/dmx_nhml.c
@@ -539,8 +539,6 @@ exit:
 /*since 0.2.2, we use zlib for xmt/x3d reading to handle gz files*/
 #include <zlib.h>
 
-#define ZLIB_COMPRESS_SAFE	4
-
 static GF_Err compress_sample_data(GF_NHMLDmxCtx *ctx, u32 compress_type, char **dict, u32 offset)
 {
 	z_stream stream;

--- a/src/filters/load_svg.c
+++ b/src/filters/load_svg.c
@@ -85,6 +85,12 @@ GF_Err svgin_deflate(SVGIn *svgin, const char *buffer, u32 buffer_len, Bool is_d
 				e = GF_NON_COMPLIANT_BITSTREAM;
 				break;
 			}
+			if (d_stream.total_out / ZLIB_INFLATE_MAX_MULTIPLIER > buffer_len) {
+				GF_LOG(GF_LOG_ERROR, GF_LOG_CORE, ("[zlib] uncompressed data size is larger than %u times input data size (%u)\n", (u32) ZLIB_INFLATE_MAX_MULTIPLIER, (u32) buffer_len ));
+				e = GF_NON_COMPLIANT_BITSTREAM;
+				break;
+			}
+
 			svg_data[d_stream.total_out - done] = 0;
 			e = gf_sm_load_string(&svgin->loader, svg_data, GF_FALSE);
 			if (e || (err== Z_STREAM_END)) break;

--- a/src/filters/write_nhml.c
+++ b/src/filters/write_nhml.c
@@ -608,7 +608,7 @@ static GF_Err nhmldump_send_dims(GF_NHMLDumpCtx *ctx, char *data, u32 data_size,
 			if (err == Z_OK) {
 				while ((s32) d_stream.total_in < size-1) {
 					err = inflate(&d_stream, Z_NO_FLUSH);
-					if (err < Z_OK) break;
+					if (err < Z_OK || d_stream.total_out / ZLIB_INFLATE_MAX_MULTIPLIER > size) break;
 					svg_data[d_stream.total_out - done] = 0;
 					gf_bs_write_data(ctx->bs_w, svg_data, (u32) strlen(svg_data));
 

--- a/src/utils/base_encoding.c
+++ b/src/utils/base_encoding.c
@@ -182,8 +182,6 @@ u32 gf_base16_decode(u8 *in, u32 inSize, u8 *out, u32 outSize)
 
 #include <zlib.h>
 
-#define ZLIB_COMPRESS_SAFE	4
-
 GF_EXPORT
 GF_Err gf_gz_compress_payload_ex(u8 **data, u32 data_len, u32 *max_size, u8 data_offset, Bool skip_if_larger, u8 **out_comp_data, Bool use_gz)
 {
@@ -288,10 +286,17 @@ GF_Err gf_gz_decompress_payload_ex(u8 *data, u32 data_len, u8 **uncompressed_dat
 			}
 			if (err==Z_STREAM_END) break;
 
+			if (d_stream.total_out / ZLIB_INFLATE_MAX_MULTIPLIER > data_len) {
+				e = GF_NON_COMPLIANT_BITSTREAM;
+				GF_LOG(GF_LOG_ERROR, GF_LOG_CORE, ("[zlib] uncompressed data size is larger than %u times input data size (%u)\n", (u32) ZLIB_INFLATE_MAX_MULTIPLIER, (u32) data_len ));
+				break;
+			}
+
 			if (size >= GF_UINT_MAX/2 - 1)
 				size = GF_UINT_MAX - 1;
 			else
 				size *= 2;
+
 			*uncompressed_data = (char*)gf_realloc(*uncompressed_data, sizeof(char)*(size+1));
 			if (!*uncompressed_data) return GF_OUT_OF_MEM;
 			d_stream.avail_out = (u32) (size - d_stream.total_out);


### PR DESCRIPTION
Hi all, 

see #3588

our inflate() loops are vulnerable to zip bombs (which are more an annoyance than an actual threat but still)

since we can't know in advance the decompressed output buffer size, the easiest solution is either to have a hard size limit or a multiplier limit

I implemented the multiplier limit in this branch, with a (kinda randomly picked) value of 32 (allowing I think all legitimate uses and preventing really aggressive malicious inputs). 

I'm doing this as a PR in case anyone has comments on the solution or the value of ZLIB_INFLATE_MAX_MULTIPLIER 

In case of no comments I'll merge this (on monday probably).


cheers