### PR TITLE
outhttp: prevent root escaping by checking the realpath() of resources

### DIFF
--- a/include/gpac/tools.h
+++ b/include/gpac/tools.h
@@ -1905,6 +1905,14 @@ char* gf_file_basename(const char* filename);
 */
 char* gf_file_ext_start(const char* filename);
 
+/*! return the canonicalized absolute pathname
+* portable version of POSIX realpath()
+\param path Path to resolve
+\param resolved_path A buffer to store the result, if NULL a buffer will be allocated and returned
+\return pointer to resolved_path or to a new buffer or NULL if error
+*/
+char* gf_realpath(const char* path, char* resolved_path);
+
 /*!\brief FileEnum info object
 
 The FileEnumInfo object is used to get file attributes upon enumeration of a directory.
@@ -2006,6 +2014,9 @@ Checks if file with given name exists, for regular files or File IO wrapper
 \param par_name  name of the parent file
 \return GF_TRUE if file exists */
 Bool gf_file_exists_ex(const char *file_name, const char *par_name);
+
+
+
 
 /*!
 \brief Open file descriptor

--- a/src/export.cpp
+++ b/src/export.cpp
@@ -186,6 +186,7 @@
 #pragma comment (linker, EXPORT_SYMBOL(gf_file_basename) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_file_ext_start) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_url_colon_suffix) )
+#pragma comment (linker, EXPORT_SYMBOL(gf_realpath) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_prompt_has_input) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_prompt_get_char) )
 #pragma comment (linker, EXPORT_SYMBOL(gf_prompt_set_echo_off) )

--- a/src/filters/out_http.c
+++ b/src/filters/out_http.c
@@ -346,6 +346,7 @@ static u32 httpio_read(GF_FileIO *fileio, u8 *buffer, u32 bytes)
 }
 static u32 httpio_write(GF_FileIO *fileio, u8 *buffer, u32 bytes)
 {
+	if (!buffer || !bytes) return 0;
 	GF_HTTPFileIO *ioctx = gf_fileio_get_udta(fileio);
 	if (!ioctx || ioctx->parent) return 0;
 
@@ -1836,21 +1837,62 @@ static void httpout_sess_io(void *usr_cbk, GF_NETIO_Parameter *parameter)
 			gf_free(full_path);
 			full_path = NULL;
 		}
-		//browse for permissions
+
+		// check that the resolved absolute path is a child of a root and allowed to be accessed
 		if (full_path) {
 			HTTP_DIRInfo *di = NULL;
 			u32 di_len = 0;
-			for (i=0; i<count; i++) {
-				HTTP_DIRInfo *adi = gf_list_get(sess->ctx->directories, i);
-				u32 adi_len = (u32) strlen(adi->path);
-				if (strncmp(adi->path, full_path, adi_len)) continue;
-				if (!di || (di_len < adi_len)) {
-					di_len = adi_len;
-					di = adi;
+
+			char* full_path_res = gf_realpath(full_path, NULL); // allocates its results without gf_malloc
+
+			if (full_path_res) {
+				u32 full_path_len = (u32)strlen(full_path_res);
+
+				for (i=0; i<count; i++) {
+					Bool is_child = GF_TRUE;
+					HTTP_DIRInfo *adi = gf_list_get(sess->ctx->directories, i);
+					u32 adi_len = (u32) strlen(adi->path);
+
+					char* adi_res = gf_realpath(adi->path, NULL); // we'll check the absolute file against the absolute root
+					if (!adi_res) continue;
+
+					u32 adi_res_len = (u32) strlen(adi_res);
+
+					// if the root isn't a prefix of the file => denied
+					if (strncmp(adi_res, full_path_res, adi_res_len)) {
+						is_child = GF_FALSE;
+					}
+
+					// check for cases like root=/webroot file=/webroot_secret/file
+					else if (full_path_len > adi_res_len) {
+
+						char next_char = full_path_res[adi_res_len];
+						if (next_char != '/' && next_char != '\\') {
+							if (adi_res_len && adi->path[adi_res_len-1] != '/' && adi->path[adi_res_len-1] != '\\')
+								is_child = GF_FALSE;
+						}
+					}
+
+					// allowed
+					if (is_child) {
+						if (!di || (di_len < adi_len)) {
+							di_len = adi_len;
+							di = adi;
+						}
+					}
+					free(adi_res);
 				}
 			}
-			sess->dir_desc = di;
+			if (di)
+				sess->dir_desc = di;
+			else {
+				// if di hasn't been set => denied
+				gf_free(full_path);
+				full_path=NULL;
+			}
+			free(full_path_res);
 		}
+
 		if (!full_path && !strcmp(url+1, "favicon.ico")) {
 			char path[GF_MAX_PATH];
 			if (gf_opts_default_shared_directory(path)) {

--- a/src/utils/os_file.c
+++ b/src/utils/os_file.c
@@ -2163,3 +2163,13 @@ char* gf_url_colon_suffix(const char *path, char assign_sep)
 	}
 	return sep;
 }
+
+
+GF_EXPORT
+char* gf_realpath(const char* path, char* resolved_path) {
+#ifdef _WIN32
+    return _fullpath(resolved_path, path, GF_MAX_PATH);
+#else
+    return realpath(path, resolved_path);
+#endif
+}


### PR DESCRIPTION
like we talked about, this adds a portable version of the posix realpath() function and uses it to check the paths of file requests to the webserver, insuring the resolved path is a child of the root dir

comments welcomed, will merge soon otherwise 

thanks