### PR TITLE
fix: bounds-check brcode in gf_ac3_get_bitrate

### DIFF
--- a/src/media_tools/av_parsers.c
+++ b/src/media_tools/av_parsers.c
@@ -10578,6 +10578,8 @@ u32 gf_ac3_get_surround_channels(u32 acmod)
 GF_EXPORT
 u32 gf_ac3_get_bitrate(u32 brcode)
 {
+	if (brcode >= sizeof(ac3_sizecod_to_bitrate) / sizeof(u32))
+		return 0;
 	return ac3_sizecod_to_bitrate[brcode];
 }
 


### PR DESCRIPTION
`gf_ac3_get_bitrate()` indexes `ac3_sizecod_to_bitrate[]` (19 entries) directly with `brcode`, but the AC-3 `dac3` box stores that value in a 5-bit field, so a crafted file can set it up to 31. `DumpStsdInfo` reads it straight from the box and passes it in unchecked, which is the OOB reported in #3635 (UBSan: index 24 out of bounds). The other callers (mpeg2_ps.c, inspect.c) feed it parser/box values the same way.

Added the same range guard already used in `gf_ac3_parser_bs` so the lookup returns 0 for an invalid code instead of reading past the array.

fixes #3635
