### PR TITLE
Harden MP4Box dump filename construction

### DIFF
--- a/applications/mp4box/filedump.c
+++ b/applications/mp4box/filedump.c
@@ -375,6 +375,7 @@ void dump_isom_scene_stats(char *file, char *inName, Bool is_final_name, u32 sta
 	dump = NULL;
 	sm = NULL;
 	sample_list = NULL;
+	e = GF_OK;
 
 	close = 0;
 
@@ -400,12 +401,12 @@ void dump_isom_scene_stats(char *file, char *inName, Bool is_final_name, u32 sta
 	if (e<0) goto exit;
 
 	if (inName) {
-		gf_strcpy(szBuf, inName);
-		if (!is_final_name) gf_strcat(szBuf, "_stat.xml");
+		gf_strlcpy(szBuf, inName, sizeof(szBuf));
+		if (!is_final_name) gf_strlcat(szBuf, "_stat.xml", sizeof(szBuf));
 		dump = gf_fopen(szBuf, "wt");
 		if (!dump) {
 			M4_LOG(GF_LOG_ERROR, ("Failed to open %s for dumping\n", szBuf));
-			return;
+			goto exit;
 		}
 		close = 1;
 	} else {
@@ -1427,7 +1428,7 @@ GF_Err dump_isom_nal(GF_ISOFile *file, GF_ISOTrackID trackID, char *inName, Bool
 		if (is_final_name) {
 			gf_strcpy(szFileName, inName);
 		} else {
-			sprintf(szFileName, "%s_%d_%s.xml", inName, trackID, is_av1 ? "obu" : "nalu");
+			snprintf(szFileName, sizeof(szFileName), "%s_%d_%s.xml", inName, trackID, is_av1 ? "obu" : "nalu");
 		}
 		dump = gf_fopen(szFileName, "wt");
 		if (!dump) {
@@ -1709,7 +1710,7 @@ void dump_isom_saps(GF_ISOFile *file, GF_ISOTrackID trackID, u32 dump_saps_mode,
 		char szBuf[GF_MAX_PATH];
 		gf_strcpy(szBuf, inName);
 
-		if (!is_final_name) sprintf(szBuf, "%s_%d_cues.xml", inName, trackID);
+		if (!is_final_name) snprintf(szBuf, sizeof(szBuf), "%s_%d_cues.xml", inName, trackID);
 		dump = gf_fopen(szBuf, "wt");
 		if (!dump) {
 			M4_LOG(GF_LOG_ERROR, ("Failed to open %s for dumping\n", szBuf));
@@ -2024,9 +2025,9 @@ void dump_isom_timed_text(GF_ISOFile *file, GF_ISOTrackID trackID, char *inName,
 		if (is_final_name) {
 			gf_strcpy(szBuf, inName) ;
 		} else if (is_convert)
-			sprintf(szBuf, "%s.%s", inName, ext) ;
+			snprintf(szBuf, sizeof(szBuf), "%s.%s", inName, ext) ;
 		else
-			sprintf(szBuf, "%s_%d_text.%s", inName, trackID, ext);
+			snprintf(szBuf, sizeof(szBuf), "%s_%d_text.%s", inName, trackID, ext);
 
 		dump = gf_fopen(szBuf, "wt");
 		if (!dump) {

--- a/applications/mp4box/filedump.c
+++ b/applications/mp4box/filedump.c
@@ -401,8 +401,8 @@ void dump_isom_scene_stats(char *file, char *inName, Bool is_final_name, u32 sta
 	if (e<0) goto exit;
 
 	if (inName) {
-		gf_strlcpy(szBuf, inName, sizeof(szBuf));
-		if (!is_final_name) gf_strlcat(szBuf, "_stat.xml", sizeof(szBuf));
+		gf_strcpy(szBuf, inName);
+		if (!is_final_name) gf_strcat(szBuf, "_stat.xml");
 		dump = gf_fopen(szBuf, "wt");
 		if (!dump) {
 			M4_LOG(GF_LOG_ERROR, ("Failed to open %s for dumping\n", szBuf));


### PR DESCRIPTION
While reviewing the MP4Box dump routines in applications/mp4box/filedump.c, I noticed several places where output filenames were assembled with unbounded formatting calls. Those paths were building scene-stat, cue, AV1/NAL, and timed-text file names directly from the user-provided base name.

That pattern could grow past the fixed stack buffers used in those functions and create a memory-safety risk. I patched the file to use bounded string construction instead, following GPAC’s existing safe string helper style and [snprintf](vscode-file://vscode-app/c:/Users/Kartik%20K/AppData/Local/Programs/Microsoft%20VS%20Code/4fe60c8b1c/resources/app/out/vs/code/electron-browser/workbench/workbench.html) where formatting was needed.

The change keeps the same behavior for normal filenames, but removes the overflow-prone path when long names are used. It is a small hardening fix with low maintenance cost and no functional redesign.

