### PR TITLE
isom: Fix integer truncation and missing allocation checks in box rea…

### DIFF
--- a/src/isomedia/box_code_3gpp.c
+++ b/src/isomedia/box_code_3gpp.c
@@ -1060,6 +1060,7 @@ GF_Err dimC_box_read(GF_Box *s, GF_BitStream *bs)
 	p->streamType = gf_bs_read_int(bs, 1);
 	p->containsRedundant = gf_bs_read_int(bs, 2);
 
+	if (p->size > 0xFFFFFFFE) return GF_ISOM_INVALID_FILE;
 	char *str = gf_malloc( (size_t) (p->size+1));
 	if (!str) return GF_OUT_OF_MEM;
 	msize = (u32) p->size;
@@ -1151,10 +1152,11 @@ GF_Err diST_box_read(GF_Box *s, GF_BitStream *bs)
 {
 	GF_DIMSScriptTypesBox *p = (GF_DIMSScriptTypesBox *)s;
 
+	if (s->size > 0xFFFFFFFE) return GF_ISOM_INVALID_FILE;
 	p->content_script_types = gf_malloc(sizeof(u8) * ((u32) s->size + 1));
 	if (!p->content_script_types) return GF_OUT_OF_MEM;
 	gf_bs_read_data(bs, p->content_script_types, (u32) s->size);
-	p->content_script_types[s->size] = 0;
+	p->content_script_types[(u32) s->size] = 0;
 	return GF_OK;
 }
 

--- a/src/isomedia/box_code_3gpp.c
+++ b/src/isomedia/box_code_3gpp.c
@@ -1060,7 +1060,7 @@ GF_Err dimC_box_read(GF_Box *s, GF_BitStream *bs)
 	p->streamType = gf_bs_read_int(bs, 1);
 	p->containsRedundant = gf_bs_read_int(bs, 2);
 
-	if (p->size > 0xFFFFFFFE) return GF_ISOM_INVALID_FILE;
+	if (p->size > GF_UINT_MAX-1) return GF_ISOM_INVALID_FILE;
 	char *str = gf_malloc( (size_t) (p->size+1));
 	if (!str) return GF_OUT_OF_MEM;
 	msize = (u32) p->size;
@@ -1152,7 +1152,7 @@ GF_Err diST_box_read(GF_Box *s, GF_BitStream *bs)
 {
 	GF_DIMSScriptTypesBox *p = (GF_DIMSScriptTypesBox *)s;
 
-	if (s->size > 0xFFFFFFFE) return GF_ISOM_INVALID_FILE;
+	if (s->size > GF_UINT_MAX-1) return GF_ISOM_INVALID_FILE;
 	p->content_script_types = gf_malloc(sizeof(u8) * ((u32) s->size + 1));
 	if (!p->content_script_types) return GF_OUT_OF_MEM;
 	gf_bs_read_data(bs, p->content_script_types, (u32) s->size);

--- a/src/isomedia/box_code_base.c
+++ b/src/isomedia/box_code_base.c
@@ -13348,6 +13348,7 @@ GF_Err mvcg_box_read(GF_Box *s,GF_BitStream *bs)
 	ptr->num_entries = gf_bs_read_u16(bs);
 	gf_bs_read_u8(bs);
 	ptr->entries = gf_malloc(ptr->num_entries * sizeof(MVCIEntry));
+	if (!ptr->entries) return GF_OUT_OF_MEM;
 	memset(ptr->entries, 0, ptr->num_entries * sizeof(MVCIEntry));
 	for (i=0; i<ptr->num_entries; i++) {
 		ISOM_DECREASE_SIZE(s, 1)

--- a/src/media_tools/webvtt.c
+++ b/src/media_tools/webvtt.c
@@ -139,7 +139,7 @@ void wvtt_box_del(GF_Box *s)
 GF_Err boxstring_box_read(GF_Box *s, GF_BitStream *bs)
 {
 	GF_StringBox *box = (GF_StringBox *)s;
-	if (s->size > 0xFFFFFFFE) return GF_ISOM_INVALID_FILE;
+	if (s->size > GF_UINT_MAX-1) return GF_ISOM_INVALID_FILE;
 	box->string = (char *)gf_malloc((u32)(s->size+1));
 	if (!box->string) return GF_OUT_OF_MEM;
 	gf_bs_read_data(bs, box->string, (u32)(s->size));

--- a/src/media_tools/webvtt.c
+++ b/src/media_tools/webvtt.c
@@ -139,7 +139,9 @@ void wvtt_box_del(GF_Box *s)
 GF_Err boxstring_box_read(GF_Box *s, GF_BitStream *bs)
 {
 	GF_StringBox *box = (GF_StringBox *)s;
+	if (s->size > 0xFFFFFFFE) return GF_ISOM_INVALID_FILE;
 	box->string = (char *)gf_malloc((u32)(s->size+1));
+	if (!box->string) return GF_OUT_OF_MEM;
 	gf_bs_read_data(bs, box->string, (u32)(s->size));
 	box->string[(u32)(s->size)] = 0;
 	return GF_OK;


### PR DESCRIPTION
While reviewing the box parser implementation, I noticed that several box readers (diST, dimC, and boxstring) cast the 64-bit s->size payload length to u32 during malloc. A large size wraps around, allocating a small buffer but writing the full amount, which leads to a heap buffer overflow. 

Additionally, mvcg_box_read was missing a NULL-pointer check on ptr->entries before memset.
I've added bounds checks (s->size <= 0xFFFFFFFE) to prevent the integer wrap-around and added validation checks for the allocations.