### PR TITLE
av_parsers: fix missing pps->weighted_bipred_idc assignment in PPS parsing

### DIFF
--- a/src/media_tools/av_parsers.c
+++ b/src/media_tools/av_parsers.c
@@ -6293,7 +6293,7 @@ static s32 gf_avc_read_pps_bs_internal(GF_BitStream *bs, AVCState *avc, u32 nal_
 	*/
 
 	pps->weighted_pred_flag = gf_bs_read_int_log(bs, 1, "weighted_pred_flag");
-	gf_bs_read_int_log(bs, 2, "weighted_bipred_idc");
+	pps->weighted_bipred_idc = gf_bs_read_int_log(bs, 2, "weighted_bipred_idc");
 	gf_bs_read_se_log(bs, "init_qp_minus26");
 	gf_bs_read_se_log(bs, "init_qs_minus26");
 	gf_bs_read_se_log(bs, "chroma_qp_index_offset");

--- a/src/media_tools/unittests/ut_av_parsers.c
+++ b/src/media_tools/unittests/ut_av_parsers.c
@@ -1,0 +1,28 @@
+#include "tests.h"
+#include <string.h>
+#include <gpac/bitstream.h>
+#include <gpac/internal/media_dev.h>
+
+unittest(avc_pps_weighted_bipred_idc)
+{
+	AVCState avc;
+	s32 pps_id;
+	/* Minimal AVC PPS NAL, byte-aligned:
+	 * - byte 0 (0x68): NAL header (nal_ref_idc=3, nal_unit_type=8/PPS)
+	 * - byte 1 (0xCE) + byte 2 (0x78): PPS RBSP with all ue(v)/se(v) fields set
+	 *   to 0 except weighted_bipred_idc, encoded as 1 (binary "01").
+	 */
+	u8 pps_nal[] = { 0x68, 0xCE, 0x78 };
+	GF_BitStream *bs;
+
+	memset(&avc, 0, sizeof(avc));
+	/* fake a registered SPS so the PPS sps_id lookup doesn't reject the PPS */
+	avc.sps[0].state = 1;
+
+	bs = gf_bs_new(pps_nal, sizeof(pps_nal), GF_BITSTREAM_READ);
+	pps_id = gf_avc_read_pps_bs(bs, &avc);
+	gf_bs_del(bs);
+
+	assert_true(pps_id == 0);
+	assert_equal(avc.pps[0].weighted_bipred_idc, 1, "%u");
+}


### PR DESCRIPTION
## Summary

`gf_avc_read_pps_bs_internal()` reads the 2-bit `weighted_bipred_idc` field from the PPS bitstream but never stores it into the PPS struct, so it always stays `0` in `AVCState`.

`avc_parse_slice()` relies on `si->pps->weighted_bipred_idc == 1` to decide whether a B-slice's header contains a `pred_weight_table()`. With the field stuck at `0`, that table is silently skipped whenever the stream actually signals explicit weighted bi-prediction, desynchronizing the bit reader for the rest of the slice header. This makes any subsequent "clear header size" computation for that slice 1 byte short.

Streams that rely on this size (e.g. CENC/CBCS subsample encryption, which needs the exact clear-header/encrypted-payload boundary) end up with the byte boundary off by one, encrypting a byte that belongs to the clear slice header. Strict decoders then choke on the corrupted NAL unit, while more tolerant ones mask the error.

## Fix

Store the parsed value in `pps->weighted_bipred_idc` as intended (one-line fix, no other behavior change).

## Testing

Added `src/media_tools/unittests/ut_av_parsers.c`: builds a minimal PPS NAL with `weighted_bipred_idc` set to 1 and asserts `gf_avc_read_pps_bs()` stores that value correctly. Runs as part of `make UNIT_TESTS=yes unit_tests`.