### PR TITLE
ghidmx: fix handling for differing number of segments (#3457) for binary index as well

### DIFF
--- a/src/filters/dmx_ghi.c
+++ b/src/filters/dmx_ghi.c
@@ -839,8 +839,12 @@ GF_Err ghi_dmx_init_bin(GF_Filter *filter, GHIDmxCtx *ctx, GF_BitStream *bs)
 
 		//locate segment
 		if (ctx->sn > st->nb_segs) {
-			GF_LOG(GF_LOG_ERROR, GF_LOG_DASH, ("[GHIX] Invalid segment index %d - only %d segments available\n", ctx->sn, st->nb_segs));
-			return GF_BAD_PARAM;
+			if (!st->inactive) {
+				GF_LOG(GF_LOG_ERROR, GF_LOG_DASH, ("[GHIX] Invalid segment index %d - only %d segments available\n", ctx->sn, st->nb_segs));
+				return GF_BAD_PARAM;
+			}
+			//not active, use last entry for init below
+			st->seg_num = st->nb_segs;
 		//todo: locate by other criteria ? (time)
 		} else {
 			st->seg_num = ctx->sn;


### PR DESCRIPTION
https://github.com/sysfce2/gpac/commit/1a1103b3befce382bed2303f7249804171d0c0a1 fixes #3457 for XML index files but doesn't do it for binary `.ghi` files.

The change is exactly the same and now binary and XML index files behave the same in my testing.