### PR TITLE
isom: fix oinf/linf sample groups dropped when fragmenting

### DIFF
--- a/src/filters/mux_isom.c
+++ b/src/filters/mux_isom.c
@@ -8355,7 +8355,10 @@ static void mp4_mux_set_hevc_groups(GF_MP4MuxCtx *ctx, TrackWriter *tkw)
 	}
 	//set linf
 	for (i=0; i<gf_isom_get_track_count(ctx->file); i++) {
-		u32 subtype = gf_isom_get_media_subtype(ctx->file, i+1, 1);
+		u32 subtype;
+		//a track is never its own external base layer
+		if (i+1 == tkw->track_num) continue;
+		subtype = gf_isom_get_media_subtype(ctx->file, i+1, 1);
 		if ( gf_isom_is_media_encrypted(ctx->file, i+1, 1))
 			gf_isom_get_original_format_type(ctx->file, i+1, i+1, &subtype);
 

--- a/src/isomedia/isom_write.c
+++ b/src/isomedia/isom_write.c
@@ -7578,7 +7578,11 @@ GF_Err gf_isom_add_sample_group_info_internal(GF_ISOFile *movie, u32 track, u32 
 
 	if (sampleGroupDescriptionIndex) *sampleGroupDescriptionIndex = 0;
 
-	if (movie->FragmentsFlags & GF_ISOM_FRAG_WRITE_READY) {
+	//oinf and linf describe the track, not a sample - keep them in the sample
+	//table instead of duplicating into each traf
+	Bool force_stbl = (grouping_type==GF_ISOM_SAMPLE_GROUP_OINF) || (grouping_type==GF_ISOM_SAMPLE_GROUP_LINF);
+
+	if (!force_stbl && (movie->FragmentsFlags & GF_ISOM_FRAG_WRITE_READY)) {
 		trak = gf_isom_get_track_box(movie, track);
 		if (!trak) return GF_BAD_PARAM;
 		trafID = trak->Header->trackID;


### PR DESCRIPTION
`gf_isom_add_sample_group_info_internal()` routes every new sample group description to the current traf as soon as fragmented writing is active (`FragmentsFlags & GF_ISOM_FRAG_WRITE_READY`), with no exception for `oinf` (Operating Points Information, used by MV-HEVC/L-HEVC) or `linf` (Layer Information). Both describe the track as a whole, the same as VPS/SPS/PPS, not a per-sample property like rap/roll/sync. Routing them to traf means they get duplicated into every fragment and never written to the init segment's moov/stbl. Any player that reads only the init segment, which is how HLS/CMAF clients are meant to work via EXT-X-MAP, never sees the operating-points declaration and can't recognize the track as valid layered HEVC, even though the underlying bitstream is fine.

Separately, `mp4_mux_set_hevc_groups()`'s scan for an external HEVC base track doesn't exclude the current track. For a single combined base+enhancement track (sample entry hvc1/hev1, both layers muxed together, which is what a number of MV-HEVC encoders produce today), the scan matches the track against itself, sets a self-referential OREF/BASE track reference, and removes the oinf group that had just been attached two lines above. linf isn't touched by that removal, which is why only oinf goes missing in that case.

Fix: oinf and linf are exempted from the fragmented-write routing in `gf_isom_add_sample_group_info_internal()` and always attach to the sample table. The base-track scan in `mp4_mux_set_hevc_groups()` skips the current track.

Verified against a real MV-HEVC asset packaged for HLS (onDemand profile): isolating just the EXT-X-MAP init segment bytes now shows the full Operating Points Information box (scalability_mask Multiview, dependency_layers 2), matching a non-fragmented reference file produced from the same source. `-unit-tests` passes. Also spot-checked a plain non-layered file through the same fragmented pipeline for regressions; no structural issues turned up, though this hasn't been run against the full testsuite corpus.
