### PR TITLE
Complete TrueHD DSI parsing when muxing to MP4

### DIFF
--- a/src/filters/mux_isom.c
+++ b/src/filters/mux_isom.c
@@ -3180,16 +3180,20 @@ sample_entry_setup:
 		}
 	} else if (codec_id==GF_CODECID_TRUEHD) {
 		u32 fmt=0, prate=0;
-		//not ready yet
 		if (!dsi) return GF_OK;
 		if (dsi->value.data.size < 6) return GF_NON_COMPLIANT_BITSTREAM;
 
 		fmt = dsi->value.data.ptr[0];
 		fmt <<= 8;
 		fmt |= dsi->value.data.ptr[1];
-		prate = dsi->value.data.ptr[2];
+		fmt <<= 8;
+		fmt |= dsi->value.data.ptr[2];
+		fmt <<= 8;
+		fmt |= dsi->value.data.ptr[3];
+
+		prate = dsi->value.data.ptr[4];
 		prate <<= 8;
-		prate |= dsi->value.data.ptr[3];
+		prate |= dsi->value.data.ptr[5];
 		prate >>= 1;
 
 		e = gf_isom_truehd_config_new(ctx->file, tkw->track_num, (char *)src_url, NULL, fmt, prate, &tkw->stsd_idx);


### PR DESCRIPTION
Complete TrueHD DSI parsing when creating the MP4 TrueHD sample entry.

The format field is 4 bytes and the peak data rate field is 2 bytes. The previous implementation read these fields from incorrect offsets. This change fixes TrueHD metadata generation during MP4 muxing.

Testsuite PR: https://github.com/gpac/testsuite/pull/72