### PR TITLE
Fix stale XMT OD link on SFNode replacement

### DIFF
--- a/src/scene_manager/loader_xmt.c
+++ b/src/scene_manager/loader_xmt.c
@@ -2154,6 +2154,8 @@ static GF_Node *xmt_parse_element(GF_XMTParser *parser, char *name, const char *
 			GF_Node* old_node = *(GF_Node**)container.far_ptr;
 			if (old_node) {
 				gf_list_del_item(parser->peeked_nodes, old_node);
+				if (old_node->sgprivate->num_instances == 1)
+					xmt_remove_od_links_for_node(parser, old_node);
 				gf_node_unregister(old_node, parent->node);
 			}
 			*((GF_Node**)container.far_ptr) = node;


### PR DESCRIPTION
Fixes #3864.

When an SFNode field is replaced, the old node can be destroyed while `parser->od_links` still retains a pointer to one of its `MFURL` fields. The later OD-link resolution then dereferences freed node storage.

Remove pending OD-link references immediately before dropping the old node's last instance. The instance-count guard preserves links when the node remains alive through another reference.

Testing:
- Built GPAC with `./configure --enable-sanitizer --disable-opt --disable-x11` and `make -j4`.
- Replayed the public #3864 input with `MP4Box -info`; it completes without ASAN/UBSAN findings after the fix (the unpatched build reports the documented heap-use-after-free).
- Parsed the checked-in `share/deprecated/mpegu-wm.xmt` sample under the same sanitizer build without sanitizer findings.
- `git diff --check` passes.