### PR TITLE
Scope XMT peeked nodes to their scene graph

### DIFF
--- a/src/scene_manager/loader_xmt.c
+++ b/src/scene_manager/loader_xmt.c
@@ -743,7 +743,8 @@ static GF_Node *xmt_find_node(GF_XMTParser *parser, char *ID)
 	count = gf_list_count(parser->peeked_nodes);
 	for (i=0; i<count; i++) {
 		n = (GF_Node*)gf_list_get(parser->peeked_nodes, i);
-		if (!strcmp(gf_node_get_name(n), ID)) return n;
+		if ((n->sgprivate->scenegraph == parser->load->scene_graph)
+		    && !strcmp(gf_node_get_name(n), ID)) return n;
 	}
 	node_class = gf_xml_sax_peek_node(parser->sax_parser, "DEF", ID, "ProtoInstance", "name", "<par", &is_proto);
 	if (!node_class) return NULL;


### PR DESCRIPTION
Fixes #3865.

`xmt_find_node` scans a parser-wide list of nodes created while looking ahead for forward `USE` references. During PROTO parsing, that list can contain nodes owned by sibling PROTO scene graphs. Reusing one as another PROTO's default field crosses the scene-graph ownership boundary; deleting the owning subgraph force-destroys the node and leaves the sibling interface with a dangling pointer.

Only reuse a peeked node when it belongs to the parser's current scene graph. A same-named forward reference in another PROTO is then created in that PROTO's own graph.

Testing:
- Built GPAC with `./configure --enable-sanitizer --disable-opt --disable-x11` and `make -j4`.
- Replayed the public #3865 input with `MP4Box -info`; the unpatched build reports the documented heap-use-after-free and the patched build completes without ASAN/UBSAN findings.
- Parsed the checked-in `share/deprecated/mpegu-wm.xmt` sample under the same sanitizer build without sanitizer findings.
- `git diff --check` passes.