### PR TITLE
compositor: Fix InputSensor media object lifetime

### DIFF
--- a/include/gpac/internal/compositor_dev.h
+++ b/include/gpac/internal/compositor_dev.h
@@ -2523,6 +2523,7 @@ void gf_input_sensor_delete(GF_ObjectManager *odm);
 
 void InitInputSensor(GF_Scene *scene, GF_Node *node);
 void InputSensorModified(GF_Node *n);
+void gf_input_sensor_mo_destroyed(GF_Node *n);
 void InitKeySensor(GF_Scene *scene, GF_Node *node);
 void InitStringSensor(GF_Scene *scene, GF_Node *node);
 

--- a/src/compositor/mpeg4_inputsensor.c
+++ b/src/compositor/mpeg4_inputsensor.c
@@ -457,6 +457,15 @@ static void InputSensorUnregister(GF_Node *node, ISStack *st)
 	}
 }
 
+void gf_input_sensor_mo_destroyed(GF_Node *node)
+{
+	ISStack *st = (ISStack *)gf_node_get_private(node);
+	if (!st) return;
+
+	st->registered = 0;
+	st->mo = NULL;
+}
+
 static void InputSensorRegister(GF_Node *n)
 {
 	GF_ObjectManager *odm;

--- a/src/compositor/scene.c
+++ b/src/compositor/scene.c
@@ -448,9 +448,11 @@ void gf_scene_disconnect(GF_Scene *scene, Bool for_shutdown)
 	if (for_shutdown && scene->root_od->mo) {
 		/*reset private stack of all inline nodes still registered*/
 		while (gf_mo_event_target_count(scene->root_od->mo)) {
-			gf_mo_event_target_remove_by_index(scene->root_od->mo, 0);
 #ifndef GPAC_DISABLE_VRML
 			GF_Node *n = (GF_Node *)gf_event_target_get_node(gf_mo_event_target_get(scene->root_od->mo, 0));
+#endif
+			gf_mo_event_target_remove_by_index(scene->root_od->mo, 0);
+#ifndef GPAC_DISABLE_VRML
 			if (n) {
 				switch (gf_node_get_tag(n)) {
 				case TAG_MPEG4_Inline:
@@ -686,9 +688,11 @@ void gf_scene_remove_object(GF_Scene *scene, GF_ObjectManager *odm, u32 for_shut
 			/*reset private stack of all inline nodes still registered*/
 			if (discard_obj) {
 				while (gf_mo_event_target_count(obj)) {
-					gf_mo_event_target_remove_by_index(obj, 0);
 #ifndef GPAC_DISABLE_VRML
 					GF_Node *n = (GF_Node *)gf_event_target_get_node(gf_mo_event_target_get(obj, 0));
+#endif
+					gf_mo_event_target_remove_by_index(obj, 0);
+#ifndef GPAC_DISABLE_VRML
 					if (n) {
 						switch (gf_node_get_tag(n)) {
 						case TAG_MPEG4_Inline:
@@ -697,6 +701,9 @@ void gf_scene_remove_object(GF_Scene *scene, GF_ObjectManager *odm, u32 for_shut
 #endif
 							if (obj->num_open) gf_mo_stop(&obj);
 							gf_node_set_private(n, NULL);
+							break;
+						case TAG_MPEG4_InputSensor:
+							gf_input_sensor_mo_destroyed(n);
 							break;
 						default:
 							gf_sc_mo_destroyed(n);


### PR DESCRIPTION
## Summary

- read each media-object event target before removing it from the target list
- invalidate an InputSensor's registration and media-object pointer when that object is destroyed
- use the same target-before-removal ordering in the root-scene shutdown path

## Root cause

The cleanup loop removed target index 0 before retrieving its node. For an InputSensor registered as the only target, the node was therefore never notified that its media object had been destroyed. The private InputSensor stack retained a dangling `st->mo` pointer, which `InputSensorRegister` later dereferenced.

## Testing

- full debug build with AddressSanitizer and UndefinedBehaviorSanitizer
- exact public #3866 reproducer: heap-use-after-free on current master, clean parse after this change
- checked-in `modules/demo_is/demo-sensor.bt`: clean parse under sanitizers
- related scene-disconnect artifact from #3846: clean parse under sanitizers

Closes #3866
