### PR TITLE
utils: Avoid mutex access after release

### DIFF
--- a/src/utils/os_thread.c
+++ b/src/utils/os_thread.c
@@ -622,6 +622,10 @@ GF_EXPORT
 void gf_mx_v(GF_Mutex *mx)
 {
 	u32 caller;
+#ifndef GPAC_DISABLE_LOG
+	char released_name[256];
+	Bool log_release = GF_FALSE;
+#endif
 	if (!mx) return;
 	caller = gf_th_id();
 
@@ -636,6 +640,14 @@ void gf_mx_v(GF_Mutex *mx)
 	if (mx->HolderCount == 0) {
 		mx->Holder = 0;
 		gf_fatal_assert(mx->HolderCount == 0);
+
+#ifndef GPAC_DISABLE_LOG
+		if (mx->log_name && !mx->nolog) {
+			gf_strlcpy(released_name, mx->log_name, sizeof(released_name));
+			log_release = GF_TRUE;
+		}
+#endif
+
 #ifdef WIN32
 		{
 			BOOL ret = ReleaseMutex(mx->hMutex);
@@ -663,9 +675,9 @@ void gf_mx_v(GF_Mutex *mx)
 #endif
 
 #ifndef GPAC_DISABLE_LOG
-		if (mx->log_name && !mx->nolog) {
+		if (log_release) {
 			char szName[100];
-			GF_LOG(GF_LOG_DEBUG, GF_LOG_MUTEX, ("[Mutex %s] Released by thread %s (hcount %u)\n", mx->log_name, log_th_name(mx->Holder, szName), mx->HolderCount ));
+			GF_LOG(GF_LOG_DEBUG, GF_LOG_MUTEX, ("[Mutex %s] Released by thread %s (hcount 0)\n", released_name, log_th_name(caller, szName) ));
 		}
 #endif
 	}


### PR DESCRIPTION
## Summary

- snapshot the mutex name before releasing the native mutex
- emit the release trace from the snapshot instead of reading the mutex wrapper after unlock
- report the actual releasing thread rather than the cleared holder field

## Root cause

`gf_mx_v` unlocked the native mutex and then read `mx->log_name`, `mx->nolog`, `mx->Holder`, and `mx->HolderCount` for debug logging. Once the native unlock completed, a waiting teardown thread could destroy and free the mutex wrapper before those reads. This produced the `gf_mx_v` heap-use-after-free reported in #3867.

The release trace now uses values captured while the wrapper is still protected. No wrapper field is accessed after a successful native unlock.

## Testing

- full debug build with AddressSanitizer and UndefinedBehaviorSanitizer
- exact public #3867 input and 16-worker/8-thread reproducer: ASAN UAF on current master, no sanitizer finding in 800 deadline-bounded runs after this change
- focused mutex release/destroy harness: 10,000 synchronized cycles under ASAN and UBSAN
- mutex debug-log smoke test
- `GPAC_DISABLE_LOG` compile check

Closes #3867
