### PR TITLE
Reject duplicate fields in XMT PROTO declarations

### DIFF
--- a/src/scene_manager/loader_xmt.c
+++ b/src/scene_manager/loader_xmt.c
@@ -1779,9 +1779,13 @@ static GF_Node *xmt_parse_element(GF_XMTParser *parser, char *name, const char *
 				else if (strstr(att->name, "value") || strstr(att->name, "Value")) value = att->value;
 			}
 			parser->proto_field = gf_sg_proto_field_new(parser->parsing_proto, fType, eType, fieldName);
+			if (!parser->proto_field) {
+				xmt_report(parser, GF_BAD_PARAM, "Cannot create proto field - please check syntax");
+				return NULL;
+			}
 			if (value && strlen(value)) {
 				gf_sg_proto_field_get_field(parser->proto_field, &info);
-				if (gf_sg_vrml_is_sf_field(fType)) {
+				if (gf_sg_vrml_is_sf_field(info.fieldType)) {
 					xmt_parse_sf_field(parser, &info, NULL, value);
 				} else {
 					xmt_parse_mf_field(parser, &info, NULL, value);


### PR DESCRIPTION
## Summary

- reject an XMT PROTO field when its interface cannot be created
- select scalar or multi-value parsing from the created field metadata

## Root cause

Duplicate PROTO field names make `gf_sg_proto_field_new` return null. The XMT
loader ignored that result, so `gf_sg_proto_field_get_field` left the previous
`GF_FieldInfo` on the stack. A duplicate field declared with a multi-value type
could then send that stale scalar pointer to `gf_sg_vrml_mf_reset`, causing an
out-of-bounds read.

The loader now rejects the invalid field before reading its metadata. This
matches the existing script-field handling and prevents stale field state from
driving the parser.

Fixes #3765.

## Testing

- full debug ASAN/UBSAN build
- minimal duplicate PROTO-field reproducer: baseline heap-buffer-overflow,
  patched clean rejection
- exact public #3765 artifact: baseline heap-buffer-overflow, patched malformed
  input rejection without sanitizer findings
- checked-in `share/deprecated/mpegu-wm.xmt`: successful import without
  sanitizer findings
- `git diff --check`
