### PR TITLE
filter: Defer PID teardown until process returns

### DIFF
--- a/src/filter_core/filter.c
+++ b/src/filter_core/filter.c
@@ -3648,8 +3648,17 @@ static void gf_filter_setup_failure_task(GF_FSTask *task)
 	//detach all input pids
 	while (gf_list_count(f->input_pids)) {
 		GF_FilterPidInst *pidinst = gf_list_pop_back(f->input_pids);
+		GF_FilterPid *pid = pidinst->pid;
+		GF_Filter *src_filter = pid ? pid->filter : NULL;
 		gf_filter_instance_detach_pid(pidinst);
+		if (src_filter) {
+			gf_fs_post_pid_instance_delete_task(f->session, src_filter, pid, pidinst);
+		} else {
+			gf_filter_pid_inst_check_delete(pidinst);
+		}
 	}
+	f->num_input_pids = 0;
+	f->single_source = NULL;
 	//detach all output pids
 	while (gf_list_count(f->output_pids)) {
 		u32 j;
@@ -3737,7 +3746,10 @@ void gf_filter_setup_failure(GF_Filter *filter, GF_Err reason)
 		notif_filter = sfilter;
 	}
 	//filter was already connected, trigger removal of all pid instances
-	else if (filter->num_input_pids) {
+	else if (filter->num_input_pids
+		&& !filter->in_process_callback
+		&& (filter->scheduled_for_next_task != GF_FILTER_DIRECT_SCHEDULED)
+	) {
 		gf_filter_reset_pending_packets(filter);
 		filter->removed = 1;
 		gf_mx_p(filter->tasks_mx);


### PR DESCRIPTION
## Summary

- defer input PID-instance cleanup when setup failure is raised from an active process or direct-call callback
- retire deferred input instances from the serialized setup-failure task through the existing PID deletion path
- preserve immediate PID cleanup when no callback is active

## Root cause

`gf_filter_setup_failure()` removed and scheduled deletion of input PID instances synchronously, even when a filter called it from inside `process()`. The later filter-destruction task already waits for the callback to return, but the earlier PID deletion did not.

With the public #3874 AV1 input, `av1dmx_process_buffer()` reports setup failure while `av1dmx_process()` still owns the current input packet. A source-filter deletion task can then free that PID instance on another scheduler thread before `av1dmx_process()` reaches `gf_filter_pid_drop_packet()`, producing the reported heap-use-after-free.

Active callbacks now leave their input instances attached until the already-serialized setup-failure task runs. That task detaches each remaining instance and schedules its normal source-filter deletion before destroying the failed filter.

## Testing

- clean full build with AddressSanitizer, UndefinedBehaviorSanitizer, float-cast-overflow, and bounds sanitizers
- exact public #3874 input (`f595eb3696914afe279f83e874b76db82ceccd662cc92e6a89a337f0594e22c7`): current master fails on the first invocation with an ASAN heap-use-after-free in `gf_filter_pid_drop_packet`; 1,200 eight-thread runs after this change completed without a sanitizer finding
- malformed-input direct-scheduler smoke test: clean rejection as `BitStream Not Compliant`
- generated valid two-frame AV1/IVF input: imported successfully with eight scheduler threads

Closes #3874
