### PR TITLE
extend c74a306: fix remaining strchr patterns leading to heap overflows

### DIFF
--- a/src/filter_core/filter_session.c
+++ b/src/filter_core/filter_session.c
@@ -5135,7 +5135,7 @@ static Bool fs_check_locales(void *__self, const char *locales_parent_path, cons
 		char *sep_lang = strchr(opt, ';');
 		if (sep_lang) sep_lang[0] = 0;
 
-		while (strchr(" \t", opt[0]))
+		while (opt[0] && strchr(" \t", opt[0]))
 			opt++;
 
 		gf_strcpy(lan, opt);

--- a/src/scene_manager/loader_bt.c
+++ b/src/scene_manager/loader_bt.c
@@ -2375,7 +2375,7 @@ GF_Err gf_bt_parse_bifs_command(GF_BTParser *parser, char *name, GF_List *cmdLis
 
 		/*peek the next word*/
 		j = 0;
-		while (strchr(" \n\t\0", parser->line_buffer[parser->line_pos + j])) j++;
+		while (parser->line_buffer[parser->line_pos + j] && strchr(" \n\t\0", parser->line_buffer[parser->line_pos + j])) j++;
 		str = parser->line_buffer + parser->line_pos + j;
 		j = 0;
 		while (!strchr(" .\0", str[j])) j++;

--- a/src/utils/token.c
+++ b/src/utils/token.c
@@ -70,7 +70,7 @@ s32 gf_token_get_strip(const char *Buffer, s32 Start, const char *Separator, con
 	if (!strip_set || (res<0)) return res;
 	i=k=0;
 	len = (u32) strlen(Container);
-	while (strchr(strip_set, Container[i]) ) i++;
+	while (Container[i] && strchr(strip_set, Container[i]) ) i++;
 	while (len && strchr(strip_set, Container[len]) ) {
 		Container[len]=0;
 		len--;

--- a/src/utils/xml_parser.c
+++ b/src/utils/xml_parser.c
@@ -1573,7 +1573,7 @@ retry:
 		if (!strncmp(sep, att_value, att_len)) {
 			u32 sub_pos;
 			sep = szLine + 1;
-			while (strchr(" \t\r\n", sep[0])) sep++;
+			while (sep[0] && strchr(" \t\r\n", sep[0])) sep++;
 			sub_pos = 0;
 			while (!strchr(" \t\r\n", sep[sub_pos])) sub_pos++;
 			first_c = sep[sub_pos];


### PR DESCRIPTION
Finishes the sweep from [c74a306](https://github.com/gpac/gpac/commit/c74a3065038ede35c1c7b75fa493a69ef6bcdb84) ("fuzz: fix a problematic strchr pattern leading to heap overflows"). That commit guarded seven scan loops. Four of the same shape were still in the tree at 2fd5a06, and two of them are reachable from a file.

`strchr(set, '\0')` returns a non-NULL pointer, it points at the set's own terminator. So `while (strchr(set, p[0])) p++;` never stops at the end of the string and keeps walking. Same one line guard as c74a306.

### token.c:73, stack overflow from a TeXML file

`gf_token_get_strip()` overruns `Container` when the token is nothing but strip characters. `txtin_process_texml()` calls it at load_text.c:3867 with `css_style`, a 1024 byte uninitialized stack array, and with text taken from a `<style>` element.

`txtin_guess_format()` picks TEXML on content, so the input needs no suffix:

```
printf '<text3GTrack><sample duration="100"><description><sharedStyles><style>  :10}</style></sharedStyles></description></sample></text3GTrack>' > poc
```

Built with `./configure --enable-sanitizer && make`, on 2fd5a06:

```
$ gpac -i poc inspect
==1457057==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7b277da92c80 ...
READ of size 1 at 0x7b277da92c80 thread T0
    #0 in gf_token_get_strip utils/token.c:73
    #1 in txtin_process_texml filters/load_text.c:3867
    #2 in txtin_process filters/load_text.c:4299
    #3 in gf_filter_process_task filter_core/filter.c:3257

    [2176, 3200) 'css_style' (line 3855) <== Memory access at offset 3200 overflows this variable
SUMMARY: AddressSanitizer: stack-buffer-overflow utils/token.c:73 in gf_token_get_strip
```

With the patch the same file parses:

```
$ gpac -i poc inspect
PID 1 ID 1 text duration 00:00:00.166 timescale 1000 codec tx3g Subtitle/text 3GPP/Apple Stream
```

### loader_bt.c:2378, heap overflow from a .bt file

The XREPLACE "peek the next word" loop runs off `parser->line_buffer` when `BY` is the last token on its line. The `"\0"` already sitting in the set shows what the loop was meant to do, but strchr cannot match a terminator that way.

poc.bt, with a trailing space after BY:

```
OrderedGroup {
 children [
  DEF N Transform2D {}
 ]
}
AT 1000 {
XREPLACE N.scale BY 
}
```

```
$ MP4Box -mp4 poc.bt -out out.mp4
==1474377==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7dd09c9ec4a0 ...
READ of size 1 at 0x7dd09c9ec4a0 thread T0
    #0 in gf_bt_parse_bifs_command scene_manager/loader_bt.c:2378
    #1 in gf_bt_loader_run_intern scene_manager/loader_bt.c:3502
    #2 in load_bt_run scene_manager/loader_bt.c:3747

0x7dd09c9ec4a0 is located 0 bytes after 4000-byte region [0x7dd09c9eb500,0x7dd09c9ec4a0)
allocated by thread T0 here:
    #1 in gf_sm_load_bt_initialize scene_manager/loader_bt.c:3591
SUMMARY: AddressSanitizer: heap-buffer-overflow scene_manager/loader_bt.c:2378
```

With the patch the parser reports the truncated command normally:

```
[BT/WRL Parsing] scale: Number expected (line 8)
```

### xml_parser.c:1576 and filter_session.c:5138, no reproducer

xml_parser.c:1576 is in `gf_xml_sax_peek_node()`. The two nearest loops, 1568 and 1592, already carry the guard, so this one reads as an oversight. I could not build an input that reaches it. `szLine` always starts at a `<` and still holds the matched attribute past that point, so `szLine + 1` is never all whitespace.

filter_session.c:5138 walks `core:lang`, so it is config driven. A lang value of only spaces or tabs walks `opt` past its terminator, then `gf_strcpy(lan, opt)` copies from there into a 100 byte stack array. Guarded for consistency.

### two sites I left alone

xml_parser.c:448 matches on grep, but I do not think it is this bug. That loop scans backward and decrements `att->name_end`, and `strchr` has already proved the region holds no terminator, since it found the `=` scanning forward from `att_name_start - 1`. Line 415 only sets `att_name_start` from the `default:` case, so `buffer[att_name_start - 1]` is never whitespace and always stops the walk. `x &&` there would be dead code. The loop having no lower bound at all is a separate question, and I have no input for that either. Do you want it in a different patch?

modules/deprecated/old_arch/widgetman/widgetman.c:200 is the same idiom as filter_session.c:5138, in a tree that is not built. Happy to add it if you want the grep to come back empty.

### checks

Linux, gcc 16.2.1, `--enable-sanitizer`, no new warnings on the four files.

- both reproducers abort on 2fd5a06 and run clean with the patch, as above. Reverting the patch and rebuilding brings both aborts back
- `gf_token_get_strip()` before and after, 5490280 cases over the alphabet `` ab{}:\t `` for lengths 0 to 6, crossed with five separator sets, four strip sets and two start offsets: zero differences in return value or output
- read the code after each guarded loop. The trailing strip and the shift in `gf_token_get_strip()` still hold when the leading loop stops at the terminator. The three loops that follow are the negated form, `while (!strchr(...))`, which already stops on a terminator, so they now see an empty token
- valid inputs before and after: a TeXML file with a full sharedStyles block, an SVG with a forward `xlink:href`, an XMT-A scene, share/gui/gui.bt and share/doc/ipmpx_syntax.bt. Identical stdout and stderr on all of them. The muxed mp4 differs in 6 bytes, the same 6 offsets that differ between two runs of one binary, which are the mvhd and mdhd timestamps

I did not run the testsuite repo, no media set here.

Per the issue template, please note this was written with AI assistance (Claude Code). The reproducers, the sanitizer output, the differential and the before and after builds are all things I ran myself.
