### PR TITLE
mp4box: fix -set-vexu not saving the file

### DIFF
--- a/applications/mp4box/mp4box.c
+++ b/applications/mp4box/mp4box.c
@@ -6826,6 +6826,7 @@ int mp4box_main(int argc, char **argv)
 
 	if (set_vexu | hero_eye) {
 		gf_isom_set_vexu(file, hero_eye);
+		do_save = GF_TRUE;
 	}
 
 	if (!encode) {


### PR DESCRIPTION
`gf_isom_set_vexu()` adds the `vexu`/`StereoView`/hero-eye boxes to the in-memory file, but the `-set-vexu` handling in `mp4box.c` never sets `do_save`, unlike every other option that mutates the file in this same function (`-timescale`, `-rem-hint`, etc). The command prints "VEXU box is added" and exits successfully, but the file on disk is never rewritten - running `-set-vexu -hero-eye 1` on a file and re-inspecting it with `MP4Box -info` shows no vexu box at all.

Fix: set `do_save` when `set_vexu`/`hero_eye` is used, matching the surrounding options.

Verified: before the fix, `-set-vexu -hero-eye 1` left the input file byte-for-byte unchanged. After the fix, `MP4Box -diso` on the output shows the full `vexu > eyes (StereoViewBox) > hero (HeroStereoEyeDescriptionBox, hero_eye_indicator=1)` hierarchy correctly written into the `hvc1` sample entry. `-unit-tests` passes.
