### PR TITLE
compositor: validate Text fontStyle node types

### DIFF
--- a/src/compositor/events.c
+++ b/src/compositor/events.c
@@ -572,7 +572,7 @@ static Bool hit_node_editable(GF_Compositor *compositor, Bool check_focus_node)
 	case TAG_X3D_Text:
 #endif
 	{
-		M_FontStyle *fs = (M_FontStyle *) ((M_Text *)text)->fontStyle;
+		M_FontStyle *fs = compositor_get_font_style(((M_Text *)text)->fontStyle);
 		if (!fs || !fs->style.buffer) return GF_FALSE;
 		if (strstr(fs->style.buffer, "editable") || strstr(fs->style.buffer, "EDITABLE")) {
 			compositor->focus_text_type = 3;
@@ -1401,7 +1401,7 @@ test_grouping:
 			gf_node_set_cyclic_traverse_flag(elt, GF_FALSE);
 
 			if (!current_focus) {
-				M_FontStyle *fs = (M_FontStyle *) ((M_Text *)elt)->fontStyle;
+				M_FontStyle *fs = compositor_get_font_style(((M_Text *)elt)->fontStyle);
 
 				if (!fs || !fs->style.buffer) return NULL;
 

--- a/src/compositor/mpeg4_text.c
+++ b/src/compositor/mpeg4_text.c
@@ -58,6 +58,22 @@ typedef struct
 	GF_Compositor *compositor;
 } TextStack;
 
+GF_NOT_EXPORTED M_FontStyle *compositor_get_font_style(GF_Node *font_style)
+{
+	if (!font_style) return NULL;
+
+	switch (gf_node_get_tag(font_style)) {
+	case TAG_MPEG4_FontStyle:
+		return (M_FontStyle *) font_style;
+#ifndef GPAC_DISABLE_X3D
+	case TAG_X3D_FontStyle:
+		return (M_FontStyle *) font_style;
+#endif
+	default:
+		return NULL;
+	}
+}
+
 void text_clean_paths(GF_Compositor *compositor, TextStack *stack)
 {
 	/*delete all path objects*/
@@ -79,7 +95,7 @@ static void build_text_split(TextStack *st, M_Text *txt, GF_TraverseState *tr_st
 	GF_TextSpan *tspan;
 	GF_FontManager *ft_mgr = tr_state->visual->compositor->font_manager;
 	Fixed fontSize, start_y;
-	M_FontStyle *fs = (M_FontStyle *)txt->fontStyle;
+	M_FontStyle *fs = compositor_get_font_style(txt->fontStyle);
 
 	fontSize = FSSIZE;
 	if (fontSize <= 0) {
@@ -212,7 +228,7 @@ static void build_text(TextStack *st, M_Text *txt, GF_TraverseState *tr_state)
 	Bool horizontal, use_pass = GF_FALSE;
 	GF_TextSpan *trim_tspan = NULL;
 	GF_FontManager *ft_mgr = tr_state->visual->compositor->font_manager;
-	M_FontStyle *fs = (M_FontStyle *)txt->fontStyle;
+	M_FontStyle *fs = compositor_get_font_style(txt->fontStyle);
 
 	fontSize = FSSIZE;
 	if (fontSize <= 0) {
@@ -499,7 +515,7 @@ static void text_get_draw_opt(GF_Node *node, TextStack *st, Bool *force_texture,
 {
 	const char *fs_style;
 	char *hlight;
-	M_FontStyle *fs = (M_FontStyle *) ((M_Text *) node)->fontStyle;
+	M_FontStyle *fs = compositor_get_font_style(((M_Text *) node)->fontStyle);
 
 	*hl_color = 0;
 
@@ -757,4 +773,3 @@ void compositor_extrude_text(GF_Node *node, GF_TraverseState *tr_state, GF_Mesh 
 
 
 #endif //!defined(GPAC_DISABLE_VRML) && !defined(GPAC_DISABLE_COMPOSITOR)
-

--- a/src/compositor/nodes_stacks.h
+++ b/src/compositor/nodes_stacks.h
@@ -201,6 +201,7 @@ Bool compositor_compositetexture_handle_event(GF_Compositor *compositor, GF_Node
 void compositor_compositetexture_sensor_delete(GF_Node *composite_appear, GF_SensorHandler *hdl);
 
 void compositor_init_text(GF_Compositor *compositor, GF_Node *node);
+M_FontStyle *compositor_get_font_style(GF_Node *font_style);
 
 #ifndef GPAC_DISABLE_3D
 
@@ -359,4 +360,3 @@ typedef struct
 
 
 #endif	/*NODES_STACKS_H*/
-

--- a/src/compositor/unittests/ut_mpeg4_text.c
+++ b/src/compositor/unittests/ut_mpeg4_text.c
@@ -1,0 +1,34 @@
+#include "tests.h"
+#include "../nodes_stacks.h"
+
+unittest(compositor_font_style_type_check)
+{
+#ifndef GPAC_DISABLE_VRML
+	GF_SceneGraph *scenegraph = gf_sg_new();
+	GF_Node *mpeg4_font_style = gf_node_new(scenegraph, TAG_MPEG4_FontStyle);
+	GF_Node *face = gf_node_new(scenegraph, TAG_MPEG4_Face);
+#ifndef GPAC_DISABLE_X3D
+	GF_Node *x3d_font_style = gf_node_new(scenegraph, TAG_X3D_FontStyle);
+#endif
+
+	gf_node_register(mpeg4_font_style, NULL);
+	gf_node_register(face, NULL);
+#ifndef GPAC_DISABLE_X3D
+	gf_node_register(x3d_font_style, NULL);
+#endif
+
+	assert_true(compositor_get_font_style(NULL) == NULL);
+	assert_true(compositor_get_font_style(face) == NULL);
+	assert_true(compositor_get_font_style(mpeg4_font_style) == (M_FontStyle *) mpeg4_font_style);
+#ifndef GPAC_DISABLE_X3D
+	assert_true(compositor_get_font_style(x3d_font_style) == (M_FontStyle *) x3d_font_style);
+#endif
+
+	gf_node_unregister(mpeg4_font_style, NULL);
+	gf_node_unregister(face, NULL);
+#ifndef GPAC_DISABLE_X3D
+	gf_node_unregister(x3d_font_style, NULL);
+#endif
+	gf_sg_del(scenegraph);
+#endif
+}


### PR DESCRIPTION
## Summary

- validate `Text.fontStyle` before reading it as a `FontStyle` node
- use the existing default styling for invalid node types
- protect the rendering and keyboard-focus access paths
- add a focused unit regression for MPEG-4 and X3D font styles

This fixes the type confusion reported by @sigdevel in #3883. A crafted XMT-A scene can assign the smaller `Face` node to `Text.fontStyle`; the compositor then reads beyond that allocation while accessing `M_FontStyle` fields.

## Testing

- ASan/UBSan reproduction before the fix: heap-buffer-overflow in `build_text` at `mpeg4_text.c:217`
- minimized malicious XMT-A after the fix: imports successfully with no sanitizer finding
- valid XMT-A `FontStyle` control: imports successfully with no sanitizer finding
- `make unit_tests`: 20 tests and 182 checks passed

Fixes #3883

Assisted-by: OpenAI Codex