### PR TITLE
SCTE-35: handle unspecified splice command length sentinel

### DIFF
--- a/src/filters/dec_scte35.c
+++ b/src/filters/dec_scte35.c
@@ -478,7 +478,9 @@ Bool scte35dec_get_timing(const u8 *data, u32 size, u64 *pts, u64 *dur, u32 *spl
 	/*u32 tier = */gf_bs_read_int(bs, 12);
 
 	u32 splice_command_length = gf_bs_read_int(bs, 12);
-	if (splice_command_length > gf_bs_available(bs)) {
+	/* 0xFFF indicates that splice_command_length is unspecified. */
+	Bool splice_command_length_unspecified = (splice_command_length == 0xFFF);
+	if (!splice_command_length_unspecified && (splice_command_length > gf_bs_available(bs))) {
 		GF_LOG(GF_LOG_ERROR, GF_LOG_CODEC, ("[Scte35Dec] Bitstream too short (" LLU " bytes) while parsing splice command (%u bytes)\n",
 			gf_bs_available(bs), splice_command_length));
 		goto exit;
@@ -546,7 +548,8 @@ Bool scte35dec_get_timing(const u8 *data, u32 size, u64 *pts, u64 *dur, u32 *spl
 		break;
 	case 0x00: //splice_null()
 		GF_LOG(GF_LOG_INFO, GF_LOG_CODEC, ("[Scte35Dec] Found splice_null()\n"));
-		gf_bs_skip_bytes(bs, splice_command_length);
+		if (!splice_command_length_unspecified)
+			gf_bs_skip_bytes(bs, splice_command_length);
 		gf_bs_align(bs);
 		break;
 	default:

--- a/src/filters/unittests/ut_dec_scte35.c
+++ b/src/filters/unittests/ut_dec_scte35.c
@@ -194,7 +194,19 @@ unittest(scte35dec_splice_point_with_idr)
 
 unittest(scte35dec_unspecified_splice_command_length)
 {
-	/* Broadcast splice_insert using splice_command_length=0xFFF. */
+	/*
+	 * Real broadcast SCTE-35 splice_info_section captured from mpegwithscte35.ts.
+	 * Relevant decoded fields:
+	 *   tier                  = 0xFFF
+	 *   splice_command_length = 0xFFF (unspecified)
+	 *   splice_command_type   = 0x05  (splice_insert)
+	 *   splice_event_id       = 662
+	 *   splice_time           = 8076794552 (90 kHz)
+	 *   break_duration        = 21780000 (242 s at 90 kHz)
+	 *
+	 * The regression verifies that 0xFFF is treated as an unspecified command
+	 * length rather than a literal 4095-byte payload length.
+	 */
 	static u8 payload[] = {
 		0xfc, 0x30, 0x2f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0xff, 0xff, 0xff, 0x05, 0x00, 0x00, 0x02, 0x96, 0x7f, 0xef,

--- a/src/filters/unittests/ut_dec_scte35.c
+++ b/src/filters/unittests/ut_dec_scte35.c
@@ -192,6 +192,31 @@ unittest(scte35dec_splice_point_with_idr)
 
 /*************************************/
 
+unittest(scte35dec_unspecified_splice_command_length)
+{
+	/* Broadcast splice_insert using splice_command_length=0xFFF. */
+	static u8 payload[] = {
+		0xfc, 0x30, 0x2f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0xff, 0xff, 0xff, 0x05, 0x00, 0x00, 0x02, 0x96, 0x7f, 0xef,
+		0xff, 0xe1, 0x6a, 0x1a, 0xb8, 0x7e, 0x01, 0x4c, 0x56, 0x20,
+		0x00, 0x01, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x08, 0x43, 0x55,
+		0x45, 0x49, 0x00, 0x00, 0x00, 0x00, 0x10, 0xfa, 0x4d, 0x9e
+	};
+
+	u64 pts = 0, duration = 0;
+	u32 splice_event_id = 0;
+	Bool needs_idr = GF_FALSE;
+
+	Bool parsed = scte35dec_get_timing(payload, sizeof(payload), &pts, &duration, &splice_event_id, &needs_idr);
+	assert_true(parsed);
+	assert_equal(pts, (u64)8076794552ULL, LLU);
+	assert_equal(duration, (u64)21780000ULL, LLU);
+	assert_equal(splice_event_id, (u32)662, "%u");
+	assert_equal(needs_idr, (Bool)GF_TRUE, "%d");
+}
+
+/*************************************/
+
 static GF_Err pck_send_simple(GF_FilterPacket *pck)
 {
 	#define expected_calls 3


### PR DESCRIPTION
# Fix SCTE-35 unspecified splice_command_length (0xFFF)

## Problem

`splice_command_length` is a 12-bit field. A value of `0xFFF` indicates that the command length is unspecified rather than that 4095 command bytes follow. The current decoder treats `0xFFF` literally, rejects otherwise valid broadcast SCTE-35 sections as truncated, and for `splice_null()` attempts to skip 4095 bytes.

The issue was reproduced with a real MPEG-TS SCTE-35 `splice_insert()` section that uses `splice_command_length=0xFFF`.

## Fix

Treat `0xFFF` as the unspecified-length sentinel:

- skip the literal available-bytes validation for that sentinel;
- do not skip 4095 bytes for `splice_null()` when the length is unspecified;
- leave all explicitly sized command behavior unchanged.

## Unit test

Adds `scte35dec_unspecified_splice_command_length` using the real 50-byte broadcast section. The test verifies that parsing succeeds and yields:

- splice event ID: `662`
- PTS: `8076794552`
- break duration: `21780000` ticks (`242` seconds at 90 kHz)
- IDR requirement: true

## Rationale

This is a parser correctness fix. It does not alter SCTE-35 timing, event conversion, HLS/DASH output.

## Review notes

The patch is deliberately small so it can be reviewed independently from the other SCTE/HLS findings.
