### PR TITLE
HLS: normalize SCTE-35 time against presentation time offset

### DIFF
--- a/src/media_tools/mpd.c
+++ b/src/media_tools/mpd.c
@@ -4325,17 +4325,38 @@ static void hls_insert_crypt_info(FILE *out, GF_MPD_Representation *rep, GF_DASH
 	}
 }
 
-static void hls_insert_scte35_info(FILE *out, u64 ast, const GF_MPD_Period *period, GF_DASH_SegmentContext *sctx)
+static void hls_insert_scte35_info(FILE *out, u64 ast, GF_MPD_Period *period, GF_MPD_AdaptationSet *adaptation_set, GF_MPD_Representation *representation, GF_DASH_SegmentContext *sctx)
 {
+	u64 segment_duration = 0;
+	u64 presentation_time_offset = 0;
+	u32 segment_timescale = 1;
 	GF_MPD_EventStream *es = NULL;
+
+	/* Segment contexts are presentation-relative, while SCTE-35 splice_time is
+	 * carried on the source timeline. Resolve the inherited PTO once so both
+	 * values are compared in the same clock domain. */
+	gf_mpd_resolve_segment_duration(representation, adaptation_set, period,
+		&segment_duration, &segment_timescale, &presentation_time_offset, NULL);
+	if (!segment_timescale) segment_timescale = 1;
 	u32 i = 0;
 	while ( (es = gf_list_enum(period->event_streams, &i)) ) {
 		GF_MPD_EventStreamEntry *ese = NULL;
 		u32 j = 0;
 		while ( (ese = gf_list_enum(es->entries, &j)) ) {
-			if (ese->state == 0 && sctx->time <= ese->presentation_time && ese->presentation_time < sctx->time+sctx->dur) {
+			u64 event_time = ese->presentation_time;
+			u64 event_time_in_representation_timescale;
+			u64 event_duration_in_representation_timescale;
+			u64 presentation_time_offset_in_event_timescale = gf_timestamp_rescale(presentation_time_offset, segment_timescale, es->timescale);
+
+			if (event_time >= presentation_time_offset_in_event_timescale)
+				event_time -= presentation_time_offset_in_event_timescale;
+
+			event_time_in_representation_timescale = gf_timestamp_rescale(event_time, es->timescale, representation->timescale);
+			event_duration_in_representation_timescale = gf_timestamp_rescale(ese->duration, es->timescale, representation->timescale);
+
+			if (ese->state == 0 && sctx->time <= event_time_in_representation_timescale && event_time_in_representation_timescale < sctx->time+sctx->dur) {
 				gf_fprintf(out, "#EXT-X-DATERANGE:ID=\"%d-%04d\",", ese->id, ese->state);
-				gf_mpd_print_date(out, "START-DATE", ast + (ese->presentation_time * 1000) / es->timescale);
+				gf_mpd_print_date(out, "START-DATE", ast + (event_time * 1000) / es->timescale);
 				gf_fprintf(out, ",PLANNED-DURATION=%g", ese->duration/(Double)es->timescale);
 				if (ese->message) {
 					gf_fprintf(out, ",SCTE35-OUT=0x");
@@ -4348,7 +4369,7 @@ static void hls_insert_scte35_info(FILE *out, u64 ast, const GF_MPD_Period *peri
 				ese->state = 1;
 			}
 
-			if (ese->state == 1 && ese->presentation_time+ese->duration <= sctx->time+sctx->dur) {
+			if (ese->state == 1 && event_time_in_representation_timescale+event_duration_in_representation_timescale <= sctx->time+sctx->dur) {
 				gf_fprintf(out, "#EXT-X-CUE-IN\n");
 				ese->state = 0;
 			}
@@ -4575,7 +4596,7 @@ static GF_Err gf_mpd_write_m3u8_playlist(const GF_MPD *mpd, const GF_MPD_Period 
 			// 0-duration may be encountered in non-LL modes when the duration is not known yet, but players may not like (cf issue 3462)
 			if (!sctx->dur) continue;
 
-			hls_insert_scte35_info(out, mpd->availabilityStartTime, period, sctx);
+			hls_insert_scte35_info(out, mpd->availabilityStartTime, period, as, rep, sctx);
 
 			//signal discontinuity if needed
 			if (sctx && sctx->is_discontinuity)

--- a/src/media_tools/unittests/ut_mpd.c
+++ b/src/media_tools/unittests/ut_mpd.c
@@ -54,3 +54,54 @@ unittest(mpd_event_streams)
 	gf_xml_dom_del(dom);
 	gf_mpd_del(mpd);
 }
+
+/*************************************/
+
+unittest(mpd_hls_scte35_nonzero_presentation_time_offset)
+{
+	GF_MPD_Period period = {0};
+	GF_MPD_AdaptationSet adaptation_set = {0};
+	GF_MPD_Representation representation = {0};
+	GF_MPD_SegmentTemplate segment_template = {0};
+	GF_DASH_SegmentContext segment = {0};
+	GF_MPD_EventStream event_stream = {0};
+	GF_MPD_EventStreamEntry event = {0};
+
+	period.event_streams = gf_list_new();
+	event_stream.entries = gf_list_new();
+	assert_true(period.event_streams != NULL);
+	assert_true(event_stream.entries != NULL);
+
+	segment_template.timescale = 90000;
+	segment_template.presentation_time_offset = 8070463950ULL;
+	adaptation_set.segment_template = &segment_template;
+	representation.timescale = 90000;
+
+	event_stream.timescale = 90000;
+	event.presentation_time = 8076794552ULL;
+	event.duration = 21780000U;
+	event.id = 662;
+	gf_list_add(event_stream.entries, &event);
+	gf_list_add(period.event_streams, &event_stream);
+
+	/* PTO-normalized event time is 6330602 and falls inside this segment. */
+	segment.time = 6105600ULL;
+	segment.dur = 417600U;
+
+	FILE *output = tmpfile();
+	assert_true(output != NULL);
+	hls_insert_scte35_info(output, 0, &period, &adaptation_set, &representation, &segment);
+	fflush(output);
+	rewind(output);
+
+	char text[1024] = {0};
+	size_t bytes_read = fread(text, 1, sizeof(text)-1, output);
+	text[bytes_read] = 0;
+	assert_true(strstr(text, "#EXT-X-DATERANGE:ID=\"662-0000\"") != NULL);
+	assert_true(strstr(text, "#EXT-X-CUE-OUT:242") != NULL);
+	assert_equal(event.state, 1, "%u");
+
+	fclose(output);
+	gf_list_del(event_stream.entries);
+	gf_list_del(period.event_streams);
+}


### PR DESCRIPTION
# Normalize SCTE-35 time for HLS when presentationTimeOffset is non-zero

## Problem

GPAC can parse SCTE-35 from MPEG-TS and expose it as an MPD event stream, but HLS SCTE manifest generation compares two different clock domains when the source has a non-zero MPEG-TS timeline:

- SCTE `splice_time()` remains on the source media clock;
- HLS segment contexts are presentation-relative after DASH `presentationTimeOffset` (PTO) is applied.

As a result, valid events are not associated with any HLS segment and no `EXT-X-DATERANGE` / `EXT-X-CUE-OUT` marker is emitted.

Observed real-source values:

- SCTE event PTS: `8076794552`
- PTO: `8070463950`
- normalized event time: `6330602` ticks (`70.340022 s`)

DASH EventStream output already demonstrated that the cue itself was parsed correctly; the failure was limited to HLS segment/event matching.

## Fix

Resolve the representation's inherited segment timescale and PTO, then:

- subtract PTO from source-clock SCTE event time when appropriate;
- rescale event time and duration to the representation timescale for segment matching;
- use the normalized presentation time for HLS `START-DATE` calculation.

## Unit test

Adds `mpd_hls_scte35_nonzero_presentation_time_offset` using the real timing values. It verifies that the event is matched to the expected presentation-relative segment and that the HLS writer emits:

- `#EXT-X-DATERANGE:ID="662-0000"`
- `#EXT-X-CUE-OUT:242`

## Validation

In the integration test, the same real SCTE source generated DATERANGE, CUE-OUT, and CUE-IN after the fix. The generated CMAF media fragments were byte-for-byte identical before and after the change; only manifest SCTE timing/signaling changed.

## Rationale

HLS event matching should occur in one clock domain. Normalizing source-clock SCTE timing by the inherited PTO is consistent with the presentation-relative segment state already used by the HLS writer.
