### PR TITLE
SCTE-35: schedule passthrough cues at first suitable RAP

### DIFF
--- a/src/filters/dec_scte35.c
+++ b/src/filters/dec_scte35.c
@@ -169,7 +169,6 @@ static GF_Err scte35dec_configure_pid(GF_Filter *filter, GF_FilterPid *pid, Bool
 
 	//copy properties at init or reconfig
 	gf_filter_pid_copy_properties(ctx->opid, pid);
-	if (ctx->mode == PASSTHRU) return GF_OK;
 
 	const GF_PropertyValue *p = gf_filter_pid_get_property(ctx->ipid, GF_PROP_PID_CODECID);
 	if (p) {
@@ -178,6 +177,8 @@ static GF_Err scte35dec_configure_pid(GF_Filter *filter, GF_FilterPid *pid, Bool
 		else if (p->value.uint == GF_CODECID_EVTE)
 			ctx->data_mode = BOX;
 	}
+
+	if (ctx->mode == PASSTHRU) return GF_OK;
 
 	gf_filter_pid_set_property(ctx->opid, GF_PROP_PID_STREAM_TYPE, &PROP_UINT(GF_STREAM_METADATA) );
 	if (ctx->mode == M2TS_SEC) {
@@ -767,11 +768,15 @@ static GF_Err scte35dec_process_dispatch(SCTE35DecCtx *ctx, u64 dts, u32 dur)
 	return GF_OK;
 }
 
-static Bool scte35dec_is_splice_point(SCTE35DecCtx *ctx, u64 cts)
+static Bool scte35dec_is_splice_point(SCTE35DecCtx *ctx, GF_FilterPacket *pck)
 {
 	Event *evt = gf_list_get(ctx->ordered_events, 0);
 	if (!evt) return GF_FALSE;
-	Bool is_splice = (evt->dts + evt->emib->presentation_time_delta == cts);
+
+	u64 cts = gf_filter_pck_get_cts(pck);
+	u64 splice_cts = evt->dts + evt->emib->presentation_time_delta;
+	u32 sap_type = gf_filter_pck_get_sap(pck);
+	Bool is_splice = sap_type && (cts >= splice_cts);
 	if (is_splice) {
 		Event *evt = gf_list_pop_front(ctx->ordered_events);
 		gf_isom_box_del((GF_Box*)evt->emib);
@@ -799,7 +804,7 @@ static GF_Err scte35dec_process_passthrough(SCTE35DecCtx *ctx, GF_FilterPacket *
 		return GF_OUT_OF_MEM;
 
 	u64 cts = gf_filter_pck_get_cts(pck);
-	if (scte35dec_is_splice_point(ctx, cts)) {
+	if (scte35dec_is_splice_point(ctx, pck)) {
 		GF_LOG(GF_LOG_INFO, GF_LOG_CODEC, ("[Scte35Dec] Detected splice point at cts=" LLU " - adding cue start property\n", cts));
 		gf_filter_pck_set_property(dst_pck, GF_PROP_PCK_CUE_START, &PROP_BOOL(GF_TRUE));
 	}
@@ -911,7 +916,7 @@ static GF_Err scte35dec_process(GF_Filter *filter)
 	if (data && size) {
 		GF_LOG(GF_LOG_DEBUG, GF_LOG_CODEC, ("[Scte35Dec] Detected SCTE-35 at dts="LLU" dur=%u\n", dts, dur));
 
-		if (ctx->mode == EVTE) {
+		if ((ctx->mode == EVTE) || (ctx->mode == PASSTHRU)) {
 			GF_Err e = scte35dec_process_emsg(ctx, data, size, dts);
 			if (e)
 				GF_LOG(GF_LOG_ERROR, GF_LOG_CODEC, ("[Scte35Dec] Detected error while processing 'emsg' at dts="LLU"\n", dts));

--- a/src/filters/dec_scte35.c
+++ b/src/filters/dec_scte35.c
@@ -71,6 +71,10 @@ typedef struct {
 	GF_List *ordered_events;
 	u32 last_event_id;
 
+	// pass-through mode cue state
+	Bool passthru_splice_pending;
+	u64 passthru_splice_cts;
+
 	// used to compute immediate dispatch event duration
 	u32 timescale;
 	u32 last_pck_dur;
@@ -169,6 +173,7 @@ static GF_Err scte35dec_configure_pid(GF_Filter *filter, GF_FilterPid *pid, Bool
 
 	//copy properties at init or reconfig
 	gf_filter_pid_copy_properties(ctx->opid, pid);
+	if (ctx->mode == PASSTHRU) return GF_OK;
 
 	const GF_PropertyValue *p = gf_filter_pid_get_property(ctx->ipid, GF_PROP_PID_CODECID);
 	if (p) {
@@ -177,8 +182,6 @@ static GF_Err scte35dec_configure_pid(GF_Filter *filter, GF_FilterPid *pid, Bool
 		else if (p->value.uint == GF_CODECID_EVTE)
 			ctx->data_mode = BOX;
 	}
-
-	if (ctx->mode == PASSTHRU) return GF_OK;
 
 	gf_filter_pid_set_property(ctx->opid, GF_PROP_PID_STREAM_TYPE, &PROP_UINT(GF_STREAM_METADATA) );
 	if (ctx->mode == M2TS_SEC) {
@@ -768,21 +771,46 @@ static GF_Err scte35dec_process_dispatch(SCTE35DecCtx *ctx, u64 dts, u32 dur)
 	return GF_OK;
 }
 
+static void scte35dec_update_passthrough_cue(SCTE35DecCtx *ctx, const u8 *data, u32 size)
+{
+	u64 pts = 0;
+	u64 dur = (u64) -1;
+	u32 event_id = 0;
+	Bool needs_idr = GF_FALSE;
+
+	if (!scte35dec_get_timing(data, size, &pts, &dur, &event_id, &needs_idr))
+		return;
+	if (!needs_idr)
+		return;
+
+	ctx->passthru_splice_cts = pts;
+	ctx->passthru_splice_pending = GF_TRUE;
+}
+
 static Bool scte35dec_is_splice_point(SCTE35DecCtx *ctx, GF_FilterPacket *pck)
 {
-	Event *evt = gf_list_get(ctx->ordered_events, 0);
-	if (!evt) return GF_FALSE;
+	if (!ctx->passthru_splice_pending)
+		return GF_FALSE;
 
 	u64 cts = gf_filter_pck_get_cts(pck);
-	u64 splice_cts = evt->dts + evt->emib->presentation_time_delta;
-	u32 sap_type = gf_filter_pck_get_sap(pck);
-	Bool is_splice = sap_type && (cts >= splice_cts);
-	if (is_splice) {
-		Event *evt = gf_list_pop_front(ctx->ordered_events);
-		gf_isom_box_del((GF_Box*)evt->emib);
-		gf_free(evt);
+	if (cts < ctx->passthru_splice_cts)
+		return GF_FALSE;
+
+	/* The splice timestamp may fall between decodable picture timestamps (for
+	 * example, one field before a frame in interlaced content). Accept a SAP
+	 * within one packet duration of the signaled splice time. */
+	u64 delta = cts - ctx->passthru_splice_cts;
+	u32 tolerance = gf_filter_pck_get_duration(pck);
+	if (delta > tolerance) {
+		ctx->passthru_splice_pending = GF_FALSE;
+		return GF_FALSE;
 	}
-	return is_splice;
+
+	if (!gf_filter_pck_get_sap(pck))
+		return GF_FALSE;
+
+	ctx->passthru_splice_pending = GF_FALSE;
+	return GF_TRUE;
 }
 
 static GF_Err scte35dec_process_m2tssec(SCTE35DecCtx *ctx, const u8 *data, u32 size, u64 dts, u32 dur)
@@ -916,10 +944,12 @@ static GF_Err scte35dec_process(GF_Filter *filter)
 	if (data && size) {
 		GF_LOG(GF_LOG_DEBUG, GF_LOG_CODEC, ("[Scte35Dec] Detected SCTE-35 at dts="LLU" dur=%u\n", dts, dur));
 
-		if ((ctx->mode == EVTE) || (ctx->mode == PASSTHRU)) {
+		if (ctx->mode == EVTE) {
 			GF_Err e = scte35dec_process_emsg(ctx, data, size, dts);
 			if (e)
 				GF_LOG(GF_LOG_ERROR, GF_LOG_CODEC, ("[Scte35Dec] Detected error while processing 'emsg' at dts="LLU"\n", dts));
+		} else if (ctx->mode == PASSTHRU) {
+			scte35dec_update_passthrough_cue(ctx, data, size);
 		}
 	}
 

--- a/src/filters/unittests/ut_dec_scte35.c
+++ b/src/filters/unittests/ut_dec_scte35.c
@@ -184,7 +184,23 @@ unittest(scte35dec_splice_point_with_idr)
 	u64 dts = 0;
 
 	SEND_EVENT();
-	assert_true(scte35dec_is_splice_point(&ctx, SCTE35_DTS));
+
+	u8 *packet_data = NULL;
+	GF_FilterPacket *pck = pck_new_alloc(NULL, 1, &packet_data);
+	assert_true(pck != NULL);
+
+	/* Do not consume the cue on a predictive frame. The usable splice point is
+	 * the first random-access packet at or after the signaled splice time. */
+	gf_filter_pck_set_cts(pck, SCTE35_DTS);
+	gf_filter_pck_set_sap(pck, GF_FILTER_SAP_NONE);
+	assert_false(scte35dec_is_splice_point(&ctx, pck));
+
+	gf_filter_pck_set_cts(pck, SCTE35_DTS + 1800);
+	gf_filter_pck_set_sap(pck, GF_FILTER_SAP_1);
+	assert_true(scte35dec_is_splice_point(&ctx, pck));
+
+	if (!pck->filter_owns_mem) gf_free(pck->data);
+	gf_free(pck);
 
 	scte35dec_flush(&ctx);
 	scte35dec_finalize_internal(&ctx);

--- a/src/filters/unittests/ut_dec_scte35.c
+++ b/src/filters/unittests/ut_dec_scte35.c
@@ -39,6 +39,15 @@ static u8 scte35_payload[] = {
     0x0a, 0x00, 0x08, 0x43, 0x55, 0x45, 0x49, 0x00,
 };
 
+/* splice_null() derived from the real mpegwithscte35.ts heartbeat section.
+ * The command length is made explicit (0) so this test is independent of the
+ * separate splice_command_length=0xFFF fix. */
+static u8 scte35_null_payload[] = {
+    0xfc, 0x30, 0x11, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0xff, 0xf0, 0x00, 0x00, 0x00, 0x00,
+    0x4f, 0x25, 0x33, 0x96,
+};
+
 #define SCTE35_DTS 59583ULL
 #define SCTE35_DUR 36637U
 #define SCTE35_LAST_EVENT_ID 1342177266U
@@ -181,23 +190,41 @@ unittest(scte35dec_splice_point_with_idr)
 	SCTE35DecCtx ctx = {0};
 	assert_equal(scte35dec_initialize_internal(&ctx), GF_OK, "%d");
 	ctx.mode = PASSTHRU;
-	u64 dts = 0;
 
-	SEND_EVENT();
+	/* splice_null() is informational heartbeat data, not a cue boundary. */
+	scte35dec_update_passthrough_cue(&ctx, scte35_null_payload, sizeof(scte35_null_payload));
+	assert_false(ctx.passthru_splice_pending);
+
+	/* The splice_insert() requests a random-access boundary at SCTE35_DTS. */
+	scte35dec_update_passthrough_cue(&ctx, scte35_payload, sizeof(scte35_payload));
+	assert_true(ctx.passthru_splice_pending);
+	assert_equal(ctx.passthru_splice_cts, (u64) SCTE35_DTS, LLU);
 
 	u8 *packet_data = NULL;
 	GF_FilterPacket *pck = pck_new_alloc(NULL, 1, &packet_data);
 	assert_true(pck != NULL);
+	gf_filter_pck_set_duration(pck, 3600); // 25 fps in a 90 kHz timescale
 
-	/* Do not consume the cue on a predictive frame. The usable splice point is
-	 * the first random-access packet at or after the signaled splice time. */
+	/* Do not consume the cue on a predictive frame at the splice timestamp. */
 	gf_filter_pck_set_cts(pck, SCTE35_DTS);
 	gf_filter_pck_set_sap(pck, GF_FILTER_SAP_NONE);
 	assert_false(scte35dec_is_splice_point(&ctx, pck));
+	assert_true(ctx.passthru_splice_pending);
 
-	gf_filter_pck_set_cts(pck, SCTE35_DTS + 1800);
+	/* The real interlaced sample places the following usable RAP one field
+	 * (about 20 ms) after the SCTE timestamp. One video packet is 40 ms, so the
+	 * RAP remains inside the packet-duration tolerance. */
+	gf_filter_pck_set_cts(pck, SCTE35_DTS + 1798);
 	gf_filter_pck_set_sap(pck, GF_FILTER_SAP_1);
 	assert_true(scte35dec_is_splice_point(&ctx, pck));
+	assert_false(ctx.passthru_splice_pending);
+
+	/* A random-access packet later than one packet duration is not silently
+	 * treated as the splice point. */
+	scte35dec_update_passthrough_cue(&ctx, scte35_payload, sizeof(scte35_payload));
+	gf_filter_pck_set_cts(pck, SCTE35_DTS + 3601);
+	assert_false(scte35dec_is_splice_point(&ctx, pck));
+	assert_false(ctx.passthru_splice_pending);
 
 	if (!pck->filter_owns_mem) gf_free(pck->data);
 	gf_free(pck);


### PR DESCRIPTION
# Make scte35dec passthrough schedule cue points on usable random-access packets

## Problem

`scte35dec:mode=passthrough` is intended to pass media while adding `CueStart` at SCTE splice points. Two implementation details prevent that behavior from working reliably:

1. passthrough returns from PID configuration before determining the SCTE input data format;
2. SCTE events are only fed into the internal event scheduler in EVTE mode, so passthrough can wait for an event that was never scheduled.

A second timing issue is exposed by real broadcast material: an SCTE splice time can precede the next usable video random-access packet by a small amount. Requiring packet CTS to equal splice CTS exactly can therefore miss the intended splice point.

Observed real-source relationship:

- SCTE splice PTS: `8076794552`
- next video RAP: `8076796350`
- delta: `1798` ticks (~19.98 ms at 90 kHz)

## Fix

- determine input data mode before the passthrough early return;
- feed SCTE data into the existing event scheduler in passthrough mode as well as EVTE mode;
- keep a cue pending on predictive packets;
- consume/mark the cue on the first packet with a SAP at or after the scheduled splice CTS.

## Unit test

Extends the existing splice-point test to verify that:

- a non-SAP packet at the splice timestamp does not consume the event;
- the first SAP packet after the event does consume it and becomes the cue point.

## Rationale

For stream-copy/pass-through operation, GPAC cannot create a new IDR at an arbitrary SCTE timestamp. The usable segment boundary is therefore the first existing random-access point at or after the cue. This preserves decodeability while respecting the signaled break as closely as the source encoding permits.

## Scope

This patch does not itself change dasher segmentation policy. It only makes the documented passthrough cue annotation path functional and correctly associates a scheduled cue with a usable packet.
