### PR TITLE
fix(ctxload): reject non-OD descriptors in ODUpdate to avoid type-confused deref

### DIFF
--- a/src/filters/load_bt_xmt.c
+++ b/src/filters/load_bt_xmt.c
@@ -669,6 +669,14 @@ static GF_Err ctxload_process(GF_Filter *filter)
 							GF_MuxInfo *mux = NULL;
 							GF_ObjectDescriptor *od = (GF_ObjectDescriptor *)gf_list_get(odU->objectDescriptors, 0);
 							gf_list_rem(odU->objectDescriptors, 0);
+							/*only the OD family carries ESDescriptors; a type-confused entry
+							  from malformed XMT reads a garbage pointer at od->ESDescriptors
+							  and faults in gf_list_get*/
+							if (!od || (od->tag != GF_ODF_OD_TAG && od->tag != GF_ODF_IOD_TAG
+							            && od->tag != GF_ODF_ISOM_OD_TAG && od->tag != GF_ODF_ISOM_IOD_TAG)) {
+								if (od) gf_odf_desc_del((GF_Descriptor *) od);
+								continue;
+							}
 							/*we can only work with single-stream ods*/
 							esd = (GF_ESD*)gf_list_get(od->ESDescriptors, 0);
 							if (!esd) {


### PR DESCRIPTION
Inside the `GF_ODUpdate` handler at
`filters/load_bt_xmt.c:670`, the code pulls an entry from
`odU->objectDescriptors` and casts it blind to
`GF_ObjectDescriptor`, then reads `od->ESDescriptors` on
the next line. If the entry is actually a different
descriptor kind — anything not `OD` / `IOD` / `ISOM_OD` /
`ISOM_IOD` — the offset that lands in `od->ESDescriptors`
is whatever byte pattern lives at that offset in the other
struct. Non-`NULL` but not a real `GF_List`, so
`gf_list_get`'s `ptr->entryCount` read faults on a wild
pointer.

The switch a few lines down at line 677 already treats
those four OD-family tags as the only expected kinds — the
pre-check that would keep everything else out was just
missing. Fix adds one tag check right after the entry is
pulled: not an OD → `gf_odf_desc_del` and `continue`,
`NULL`-guarded first so `od->tag` can't fault. No behaviour
change for well-formed input.

**Repro** (reporter's PoC 212):
`./MP4Box -add 212_gf_list_get_utils_list_c_670 /dev/null`
- Master `a765354888d3` — UBSAN: `runtime error: member
  access within misaligned address 0xf0014000000001 for
  type 'struct GF_List'` at `utils/list.c:670`.
- Patched (`a448d241f`) — the type-confused entries are
  freed and skipped ("Cannot match OD ID 1 to any PID"), no
  sanitizer error, MP4Box exits clean.
- Regression: XMT with `InitialObjectDescriptor` +
  `ES_Descriptor` + scene still imports to a 308,160-byte
  MP4.

Reported by @sigdevel in #3884. AI-assisted 2-model review
over the diff (deepseek-chat + glm-4.6) came back clean;
the fix itself is eight lines I've read end to end and it
mirrors the OD-family switch four lines below. Happy to
adjust.

Fixes #3884.