### PR TITLE
fix(scenegraph): reject NULL field payload in indexed Replace

### DIFF
--- a/src/scenegraph/commands.c
+++ b/src/scenegraph/commands.c
@@ -598,6 +598,10 @@ GF_Err gf_sg_command_apply(GF_SceneGraph *graph, GF_Command *com, Double time_of
 		}
 		/*indexed replacement*/
 		if (pos>=-1) {
+			/*a well-formed indexed replacement always carries a field payload;
+			  a missing payload (inf->field_ptr NULL) reaches value.far_ptr as
+			  NULL and would fault on the deref below*/
+			if (!value.far_ptr) return GF_NON_COMPLIANT_BITSTREAM;
 			/*if MFNode remove the child and set new node*/
 			if (field.fieldType == GF_SG_VRML_MFNODE) {
 				GF_Node *nn = *(GF_Node**)value.far_ptr;


### PR DESCRIPTION
An indexed `Replace` on an `MFNode` reads
`*(GF_Node**)value.far_ptr` at `scenegraph/commands.c:603`
without first checking `value.far_ptr` — when the incoming
`GF_CommandField` has no payload, `inf->field_ptr` is `NULL`,
`value.far_ptr` is `NULL`, and it faults at `0x0`. The
indexed SFField branch a few lines down at line 622 does the
same read through the same field.

One check right after `if (pos>=-1) {` covers both branches
and matches the guard style already used two spots away
(`if (!value.far_ptr) break;` at line 637 for the
non-indexed MFNode case; `if (!field.far_ptr) return
GF_NON_COMPLIANT_BITSTREAM;` at line 610). No behaviour
change for well-formed input — the legitimate "remove child
at pos" flow passes a `value.far_ptr` pointing at a `NULL`
node, not a `NULL` `value.far_ptr` itself.

**Repro** (reporter's PoC 210):
`./MP4Box -add 210_gf_sg_command_apply_scenegraph_commands_c_603 /dev/null`
- Master `a765354888d3` — ASAN/UBSAN: `runtime error: load of
  null pointer of type 'struct GF_Node *'` at
  `scenegraph/commands.c:603`.
- Patched (`24b13792c`) — no sanitizer error, MP4Box exits
  clean.
- Regression: minimal XMT with Group/Shape/Rectangle still
  imports to a 308,160-byte MP4.

Reported by @sigdevel in #3882. AI-assisted 2-model review
over the diff (deepseek-chat + glm-4.6) came back clean;
the fix itself is four lines I've read end to end. Happy to
adjust wording or return code.

Fixes #3882.