### PR TITLE
fix(scenegraph): guard PROTO field copy when instance is partial

### DIFF
--- a/src/scenegraph/vrml_proto.c
+++ b/src/scenegraph/vrml_proto.c
@@ -816,8 +816,11 @@ GF_Node *gf_sg_proto_create_node(GF_SceneGraph *scene, GF_Proto *proto, GF_Proto
 		/*regular field, duplicate from default value or instantiated one if specified (since
 		a proto may be partially instantiated when used in another proto)*/
 		if (gf_sg_vrml_get_sf_type(inst->FieldType) != GF_SG_VRML_SFNODE) {
-			if (from_inst) {
-				from_field = (GF_ProtoField *)gf_list_get(from_inst->fields, i-1);
+			from_field = from_inst ? (GF_ProtoField *)gf_list_get(from_inst->fields, i-1) : NULL;
+			/*a partially-instantiated PROTO (from_inst supplies fewer fields than this PROTO
+			interface declares) yields a NULL entry here - fall back to the declared default,
+			matching the from_inst==NULL path*/
+			if (from_field) {
 				gf_sg_vrml_field_copy(inst->field_pointer, from_field->field_pointer, inst->FieldType);
 				inst->has_been_accessed = from_field->has_been_accessed;
 			} else {


### PR DESCRIPTION
Fixes #3885.

Small one. `gf_sg_proto_create_node` walks the outer PROTO's declared interface fields and copies each from a source instance, but it never checked that the source actually had all of them. If the source is partial — fewer fields than the interface declares — `gf_list_get(from_inst->fields, i-1)` returns NULL and the next line reads `from_field->field_pointer` at offset 8. That's what @sigdevel's PoC hits from the XMT loader.

The fix is a null-check. When `from_field` is NULL, fall back to `field->def_value` — the same path the code already takes when `from_inst` is NULL. That matches what a partially-instantiated PROTO field is supposed to look like. +5/−2, one function.

**Verified on the ASan+UBSan build**
- Base: master `a765354888d`
- Fix commit: `f5dcb1f`
- Before: sigdevel's PoC halts on `runtime error: member access within null pointer of type 'struct GF_ProtoField'` at `vrml_proto.c:821`.
- After: same PoC is rejected cleanly by the upstream parser (`[CtxLoad] Failed to load context: BitStream Not Compliant`), MP4Box exits non-zero — safe rejection, no crash.
- Regression sanity: a valid inline XMT (Group → Shape → Rectangle) still imports to a 308 KB `.mp4`, sanitizer silent.

Ran the diff past three models as a second-opinion pass — deepseek-r1 and glm-4.6 came back clean with correct invariant walkthroughs; deepseek-chat flagged two things that were both misreads of the diff (the fallback IS in the else branch, the `has_been_accessed` write IS inside the guarded block). Full paper trail is banked at `AetherAI3/AETHER-ATLAS@7d0b6ca` if you want it.

Credit to @sigdevel for the report and the reproducible sample. AI-assisted (Claude); I wrote the fix intent and read every line before commit.

**Human-authored disclosure**

- [x] I wrote this PR description in my own words and reviewed the fix diff line-by-line before commit.