### PR TITLE
fix(scenegraph): drop unknown protos at PROTO_INSERT to avoid heap-UAF

### DIFF
--- a/src/scenegraph/commands.c
+++ b/src/scenegraph/commands.c
@@ -509,11 +509,20 @@ GF_Err gf_sg_command_apply(GF_SceneGraph *graph, GF_Command *com, Double time_of
 		break;
 	}
 	case GF_SG_PROTO_INSERT:
-		/*destroy all proto*/
+		/*promote newly-declared protos from this command into the target graph,
+		  but only those we can still verify are live: xmt_parse_proto/gf_sg_proto_new
+		  file every fresh proto in graph->unregistered_protos alongside the command's
+		  new_proto_list, so a pointer that is NOT in unregistered_protos was either
+		  (a) already promoted by a peer PROTO_INSERT, or (b) freed by an earlier
+		  PROTO_DELETE. Either way, handing it to graph->protos would leave a stale
+		  pointer that a later PROTO_DELETE_ALL walk would deref at
+		  scenegraph/vrml_proto.c:108 (heap-use-after-free). gf_list_del_item only
+		  compares pointer identity, so this check is safe on a dangling p.*/
 		while (gf_list_count(com->new_proto_list)) {
 			GF_Proto *p = (GF_Proto*)gf_list_get(com->new_proto_list, 0);
 			gf_list_rem(com->new_proto_list, 0);
-			gf_list_del_item(graph->unregistered_protos, p);
+			if (gf_list_del_item(graph->unregistered_protos, p) < 0)
+				continue;
 			gf_list_add(graph->protos, p);
 		}
 		return GF_OK;


### PR DESCRIPTION
Closes #3881.

Cross-command heap-UAF in the XMT/BT ctxload path. A malformed input arranges for the same `GF_Proto*` to sit in two scene commands: an earlier `PROTO_DELETE` (by ID) frees it, then a later `PROTO_INSERT` reads the dangling pointer out of its `com->new_proto_list` and hands it back to `graph->protos`. The next `PROTO_DELETE_ALL` walks that list and dereferences `proto->parent_graph` at `scenegraph/vrml_proto.c:108`.

The parser's own bookkeeping is the safe validity gate: every fresh proto goes through `gf_sg_proto_new(..., unregistered=1)`, which files it in `graph->unregistered_protos`. If a pointer is no longer in that list at `PROTO_INSERT` time, it was either already promoted by a peer or freed by an earlier `PROTO_DELETE` — either way it must not reach `graph->protos`. `gf_list_del_item` compares by pointer identity, so the check is safe on a dangling `p`. Well-formed inputs take the same `gf_list_add(graph->protos, p)` branch they always did.

Reproduced on master `4a1eca9ea69a51af2bdd183d8533bc7731ec2105` with the reporter's PoC 209 under `--enable-sanitizer`:

- **Before:** ASan `heap-use-after-free` at `scenegraph/vrml_proto.c:108`, freed via `gf_sg_proto_del` at `scenegraph/commands.c:547`, allocated via `xmt_parse_proto` at `scene_manager/loader_xmt.c:1465`.
- **After (`6d198eda188c0e813ac32a078ddb7546a2dc4368`):** MP4Box exits 0, produces a valid MP4 (`ISO Media, MP4 Base Media v1`, 16374 bytes, `-info` shows 1 track, 320×240 RawVideo, 6 samples, 2.2s). No sanitizer output.

Reported-by: @sigdevel — thanks for the tidy repro.

I hereby agree to the terms of the Contributor License Agreement, version 1.2, as published on http://gpac.io/cla/.

<!-- AI assistance: this fix was drafted with AI help (analysis, instrumented trace, patch, sanity review). I've read the change end to end and I'm on the hook for it through review. -->
- [x] I've read this change end to end and am confident in the wording as my own.