### PR TITLE
IPMPX: fix out-of-bounds read in GF_IPMPX_ParseBin128

### DIFF
--- a/src/odf/ipmpx_parse.c
+++ b/src/odf/ipmpx_parse.c
@@ -185,9 +185,10 @@ void GF_IPMPX_ParseBin128(char *val, bin128 *data)
 		gf_bs_del(bs);
 	} else {
 		u32 i, b;
+		u32 len = (u32) strlen(val);
 		char szB[3];
 		szB[2] = 0;
-		for (i=0; i<16; i++) {
+		for (i=0; i<16 && 2*i+1 < len; i++) {
 			szB[0] = val[2*i];
 			szB[1] = val[2*i+1];
 			sscanf(szB, "%x", &b);


### PR DESCRIPTION
### What

`GF_IPMPX_ParseBin128()` in `src/odf/ipmpx_parse.c` reads 32 characters from
`val` whenever `strlen(val) >= 16`, but only checks that the string is at least
16 characters long. A `bin128` is 16 bytes and is expected as 32 hex digits.
When the value is 16–31 characters long, the loop reads past the terminating
NUL — up to 15 bytes out of bounds (`val[17]`..`val[31]` for a 16-char input).
The write side is fine (`i < 16` into a 16-byte `bin128`); only the read
overflows.

The sibling parsers `GF_IPMPX_ParseBinData` and `OD_ParseBinData` bound their
loops by the actual string length (`len = strlen/3`); `GF_IPMPX_ParseBin128` is
the only one that assumes a fixed 32-character input.

### How it is reached

`val` is an untrusted token from a text scene file. In
`src/scene_manager/loader_bt.c`, `gf_bt_parse_ipmpx()` reads a token via
`gf_bt_get_next(parser, 0)` and passes it to `gf_ipmpx_set_field()`, which calls
`GF_IPMPX_ParseBin128(str, ...)` for the `toolID` and `cipher_Id` fields with no
length check anywhere along the way.

### Repro

A `.bt` scene with an IPMPX descriptor whose `toolID` is 16–31 characters (a
leading `0x` is not required) triggers the over-read, e.g. `MP4Box -mp4
crafted.bt`. Built with AddressSanitizer this reports a buffer-overflow (READ)
inside `GF_IPMPX_ParseBin128`.

### Fix

Bound the loop by the actual string length so it never reads past the NUL. This
keeps existing behaviour for a well-formed 32-hex-digit value and stops early
for a short one. If you'd prefer to reject short values outright (a 128-bit id
needs 32 digits), I can change the `else` guard to `strlen(val) >= 32` instead —
let me know which you prefer.
