### PR TITLE
fix #3904 : reject nodes from PROTO declaration sub-graphs

### DIFF
--- a/src/scene_manager/loader_xmt.c
+++ b/src/scene_manager/loader_xmt.c
@@ -3330,10 +3330,14 @@ attach_node:
 					if (parser->command->in_scene && node->sgprivate->scenegraph
 					    && node->sgprivate->scenegraph != parser->command->in_scene) {
 						Bool is_subscene = GF_FALSE;
-						GF_SceneGraph *par = node->sgprivate->scenegraph->parent_scene;
-						while (par) {
-							if (par == parser->command->in_scene) { is_subscene = GF_TRUE; break; }
+						GF_SceneGraph *par = node->sgprivate->scenegraph;
+						/*only proto instance namespaces (pOwningProto set) live as long as their node; a PROTO declaration
+						  sub-graph (e.g. from an unclosed ProtoDeclare) is destroyed with its proto by a later SceneReplace,
+						  leaving the command node with a dangling scenegraph*/
+						while (par->pOwningProto) {
 							par = par->parent_scene;
+							if (!par) break;
+							if (par == parser->command->in_scene) { is_subscene = GF_TRUE; break; }
 						}
 						if (!is_subscene) {
 							xmt_report(parser, GF_OK, "Warning: node %s is from an unrelated scene - skipping in command", name);


### PR DESCRIPTION
The unrelated-scene check in loader_xmt.c:3330 is meant to discard nodes that do not belong to the command's scene. It accepted any node whose scene graph is a descendant of the command's graph. A PROTO declaration sub-graph is also such a descendant, so with an unclosed ProtoDeclare a node created in the proto's sub-graph (InputSensor in the PoC) was attached to a top-level INDEXED_REPLACE command. Only walk up through proto instance namespaces (graphs with pOwningProto set, which live as long as their ProtoNode). A PROTO declaration sub-graph is now rejected and the node is discarded with the existing unrelated-scene warning.