### PR TITLE
Associate HLS SCTE-35 cues with segment start boundaries

### DIFF
--- a/src/media_tools/mpd.c
+++ b/src/media_tools/mpd.c
@@ -4354,7 +4354,13 @@ static void hls_insert_scte35_info(FILE *out, u64 ast, GF_MPD_Period *period, GF
 			event_time_in_representation_timescale = gf_timestamp_rescale(event_time, es->timescale, representation->timescale);
 			event_duration_in_representation_timescale = gf_timestamp_rescale(ese->duration, es->timescale, representation->timescale);
 
-			if (ese->state == 0 && sctx->time <= event_time_in_representation_timescale && event_time_in_representation_timescale < sctx->time+sctx->dur) {
+			/* HLS cue tags describe segment boundaries. If an SCTE event falls
+			 * inside a segment, associate CUE-OUT with the first segment that
+			 * starts at or after the splice point rather than with the segment
+			 * that started before it. */
+			if (ese->state == 0
+				&& event_time_in_representation_timescale <= sctx->time
+				&& sctx->time < event_time_in_representation_timescale + event_duration_in_representation_timescale) {
 				gf_fprintf(out, "#EXT-X-DATERANGE:ID=\"%d-%04d\",", ese->id, ese->state);
 				gf_mpd_print_date(out, "START-DATE", ast + (event_time * 1000) / es->timescale);
 				gf_fprintf(out, ",PLANNED-DURATION=%g", ese->duration/(Double)es->timescale);
@@ -4369,7 +4375,11 @@ static void hls_insert_scte35_info(FILE *out, u64 ast, GF_MPD_Period *period, GF
 				ese->state = 1;
 			}
 
-			if (ese->state == 1 && event_time_in_representation_timescale+event_duration_in_representation_timescale <= sctx->time+sctx->dur) {
+			/* Likewise, CUE-IN belongs before the first segment beginning at or
+			 * after the end of the break, not before a segment that still
+			 * contains media preceding the return point. */
+			if (ese->state == 1
+				&& event_time_in_representation_timescale + event_duration_in_representation_timescale <= sctx->time) {
 				gf_fprintf(out, "#EXT-X-CUE-IN\n");
 				ese->state = 0;
 			}

--- a/src/media_tools/unittests/ut_mpd.c
+++ b/src/media_tools/unittests/ut_mpd.c
@@ -105,3 +105,98 @@ unittest(mpd_hls_scte35_nonzero_presentation_time_offset)
 	gf_list_del(event_stream.entries);
 	gf_list_del(period.event_streams);
 }
+
+/*************************************/
+
+unittest(mpd_hls_scte35_cues_follow_segment_boundaries)
+{
+	GF_MPD_Period period = {0};
+	GF_MPD_AdaptationSet adaptation_set = {0};
+	GF_MPD_Representation representation = {0};
+	GF_DASH_SegmentContext segment = {0};
+	GF_MPD_EventStream event_stream = {0};
+	GF_MPD_EventStreamEntry event = {0};
+	char text[1024];
+	size_t bytes_read;
+	FILE *output;
+
+	period.event_streams = gf_list_new();
+	event_stream.entries = gf_list_new();
+	assert_true(period.event_streams != NULL);
+	assert_true(event_stream.entries != NULL);
+
+	representation.timescale = 1000;
+	event_stream.timescale = 1000;
+	event.presentation_time = 10300;
+	event.duration = 5000;
+	event.id = 7;
+	gf_list_add(event_stream.entries, &event);
+	gf_list_add(period.event_streams, &event_stream);
+
+	/* The splice occurs inside this segment. A cue before this segment would
+	 * start replacement 300 ms too early, so no marker belongs here. */
+	segment.time = 10000;
+	segment.dur = 4000;
+	output = tmpfile();
+	assert_true(output != NULL);
+	hls_insert_scte35_info(output, 0, &period, &adaptation_set, &representation, &segment);
+	fflush(output);
+	rewind(output);
+	memset(text, 0, sizeof(text));
+	bytes_read = fread(text, 1, sizeof(text)-1, output);
+	text[bytes_read] = 0;
+	assert_true(strstr(text, "#EXT-X-CUE-OUT") == NULL);
+	assert_equal(event.state, 0, "%u");
+	fclose(output);
+
+	/* CUE-OUT is emitted immediately before the first segment whose start is
+	 * at or after the splice point. */
+	segment.time = 14000;
+	segment.dur = 4000;
+	output = tmpfile();
+	assert_true(output != NULL);
+	hls_insert_scte35_info(output, 0, &period, &adaptation_set, &representation, &segment);
+	fflush(output);
+	rewind(output);
+	memset(text, 0, sizeof(text));
+	bytes_read = fread(text, 1, sizeof(text)-1, output);
+	text[bytes_read] = 0;
+	assert_true(strstr(text, "#EXT-X-DATERANGE:ID=\"7-0000\"") != NULL);
+	assert_true(strstr(text, "#EXT-X-CUE-OUT:5") != NULL);
+	assert_true(strstr(text, "#EXT-X-CUE-IN") == NULL);
+	assert_equal(event.state, 1, "%u");
+	fclose(output);
+
+	/* The break ends at 15.3 s, inside the same 14-18 s segment. Do not put
+	 * CUE-IN before media that still belongs to the break. */
+	output = tmpfile();
+	assert_true(output != NULL);
+	hls_insert_scte35_info(output, 0, &period, &adaptation_set, &representation, &segment);
+	fflush(output);
+	rewind(output);
+	memset(text, 0, sizeof(text));
+	bytes_read = fread(text, 1, sizeof(text)-1, output);
+	text[bytes_read] = 0;
+	assert_true(strstr(text, "#EXT-X-CUE-IN") == NULL);
+	assert_equal(event.state, 1, "%u");
+	fclose(output);
+
+	/* CUE-IN is emitted before the first segment starting at or after the
+	 * return point. */
+	segment.time = 18000;
+	segment.dur = 4000;
+	output = tmpfile();
+	assert_true(output != NULL);
+	hls_insert_scte35_info(output, 0, &period, &adaptation_set, &representation, &segment);
+	fflush(output);
+	rewind(output);
+	memset(text, 0, sizeof(text));
+	bytes_read = fread(text, 1, sizeof(text)-1, output);
+	text[bytes_read] = 0;
+	assert_true(strstr(text, "#EXT-X-CUE-IN") != NULL);
+	assert_equal(event.state, 0, "%u");
+	fclose(output);
+
+	gf_list_del(event_stream.entries);
+	gf_list_del(period.event_streams);
+}


### PR DESCRIPTION

## Problem

The HLS SCTE-35 writer currently associates an event with the segment whose time range contains the event. That can place `EXT-X-CUE-OUT` before a segment that began before the actual splice point, and similarly place `EXT-X-CUE-IN` before a segment that still contains media preceding the return point.

For SSAI, cue tags are segment-boundary signals. Starting replacement at a segment that began before the SCTE splice time replaces valid program media too early.

A simple example is:

- segment: `10.0 -> 14.0 s`
- SCTE break start: `10.3 s`

The current range test emits CUE-OUT before the 10.0 s segment. The first existing HLS boundary at or after the event is 14.0 s, so absent cue-driven media segmentation the marker belongs before that segment instead.

The same issue applies to break end. If the return point is 15.3 s inside the `14.0 -> 18.0 s` segment, CUE-IN belongs before the segment beginning at 18.0 s rather than before the 14.0 s segment.

## Fix

Treat HLS SCTE cue tags as boundary-oriented signaling:

- emit `DATERANGE` / `CUE-OUT` on the first segment whose start is at or after the SCTE event time while the break is active;
- emit `CUE-IN` on the first segment whose start is at or after the event end;
- keep `DATERANGE START-DATE` at the exact SCTE event time.

This patch does **not** create or move media segment boundaries. Cue-driven segmentation is intentionally handled in a separate change.

## Unit test

Adds `mpd_hls_scte35_cues_follow_segment_boundaries`.

The test verifies that:

- no CUE-OUT is emitted on a segment that started before a splice occurring inside it;
- CUE-OUT is emitted on the next segment boundary;
- no CUE-IN is emitted on a segment that contains the return point;
- CUE-IN is emitted on the first segment boundary after the return point.

## Validation

This standalone patch applies cleanly to GPAC base commit `239c20cdfe9dad19580e87f98ca0fd8b55fe560b`.

In the cumulative SCTE fix tree, this behavior is combined with the PTO-normalization fix so source-clock SCTE timestamps are first converted to the presentation timeline and then associated with HLS boundaries.

## Rationale

This change separates two concerns:

1. the HLS writer should never advertise a splice before media that precedes the splice;
2. the segmenter may optionally create a closer boundary at a suitable RAP.

Keeping those responsibilities separate makes the manifest behavior correct even when cue-driven segmentation is not enabled.
