### PR TITLE
Add SCTE-35 RAP boundaries without replacing normal segment cadence

### DIFF
--- a/src/filters/dasher.c
+++ b/src/filters/dasher.c
@@ -523,6 +523,13 @@ typedef struct _dash_stream
 	s32 cues_ts_offset;
 	Bool inband_cues;
 
+	/* SCTE-35 splice boundaries are expressed on the MPEG 90 kHz clock.
+	 * Keep the start and optional return boundary while normal duration-based
+	 * segmentation continues. */
+	u64 scte35_splice_start;
+	u64 scte35_splice_end;
+	u8 scte35_boundary_state; /* 0: none, 1: break start, 2: break end */
+
 	Bool clamp_done;
 	u32 dcd_not_ready;
 
@@ -9920,6 +9927,12 @@ static void dasher_set_pto(GF_DashStream *ds, u64 pto_adj)
 	}
 }
 
+GF_STATIC Bool dasher_scte35_boundary_due(u64 packet_cts, u32 packet_timescale, u32 sap_type, u64 boundary_time)
+{
+	if (!sap_type || !packet_timescale) return GF_FALSE;
+	return gf_timestamp_greater_or_equal(packet_cts, packet_timescale, boundary_time, 90000);
+}
+
 static GF_Err dasher_handle_scte35(GF_DasherCtx *ctx, GF_FilterPacket *pck, GF_DashStream *ds)
 {
 	GF_Err ret = GF_OK;
@@ -10004,6 +10017,18 @@ static GF_Err dasher_handle_scte35(GF_DasherCtx *ctx, GF_FilterPacket *pck, GF_D
 			}
 
 			if (!found) {
+				/* A splice that requires a random-access point should also create
+				 * a media segment boundary. Do not switch the representation into
+				 * cue-only segmentation: keep the normal cadence and add the splice
+				 * boundary when the first suitable SAP arrives. */
+				if (needs_idr && (ds->stream_type == GF_STREAM_VISUAL) && !ds->scte35_boundary_state) {
+					ds->scte35_splice_start = evt->presentation_time;
+					ds->scte35_splice_end = 0;
+					if (dur && (dur != (u64)-1) && (evt->presentation_time <= ((u64)-1) - dur))
+						ds->scte35_splice_end = evt->presentation_time + dur;
+					ds->scte35_boundary_state = 1;
+				}
+
 				evt->duration = (u32)dur;
 				es->timescale = gf_filter_pck_get_timescale(pck);
 				evt->message = gf_malloc(size);
@@ -10441,6 +10466,13 @@ static GF_Err dasher_process(GF_Filter *filter)
 			GF_Err e = dasher_handle_scte35(ctx, pck, ds);
 			if (e) return e;
 
+			Bool scte35_splice_boundary = GF_FALSE;
+			if (ds->scte35_boundary_state) {
+				u64 boundary_time = (ds->scte35_boundary_state == 1) ? ds->scte35_splice_start : ds->scte35_splice_end;
+				if (boundary_time)
+					scte35_splice_boundary = dasher_scte35_boundary_due(cts, ds->timescale, sap_type, boundary_time);
+			}
+
 			if (!ds->rep_init) {
 				u32 set_start_with_sap;
 				//for video, resync on sap 1 or 2 if not full profile
@@ -10741,6 +10773,25 @@ static GF_Err dasher_process(GF_Filter *filter)
 			}
 			//flush for entire input, segment is done upon eos
 			else if (ctx->sflush==SFLUSH_SINGLE) {
+			}
+			/* SCTE-35 adds a boundary without replacing normal duration-based
+			 * segmentation. The cue timestamp may fall slightly before an IDR,
+			 * so cut at the first SAP at or after the requested splice time. */
+			else if (scte35_splice_boundary && !ctx->sigfrag && !ds->inband_cues && !ds->cues) {
+				if (ds->scte35_boundary_state == 1 && ds->scte35_splice_end)
+					ds->scte35_boundary_state = 2;
+				else
+					ds->scte35_boundary_state = 0;
+
+				if (ds->segment_started) {
+					seg_over = GF_TRUE;
+					if (ds == base_ds) {
+						/* Re-anchor the regular cadence at the splice boundary. The
+						 * regular segment-duration update will advance from here. */
+						base_ds->next_seg_start = cts;
+						base_ds->adjusted_next_seg_start = cts;
+					}
+				}
 			}
 			//source-driven fragmentation check for segment start
 			else if (ctx->sigfrag) {

--- a/src/filters/unittests/ut_dasher.c
+++ b/src/filters/unittests/ut_dasher.c
@@ -1,0 +1,26 @@
+#include "tests.h"
+#include <gpac/filters.h>
+
+Bool dasher_scte35_boundary_due(u64 packet_cts, u32 packet_timescale, u32 sap_type, u64 boundary_time);
+
+unittest(dasher_scte35_boundary_uses_first_sap_at_or_after_splice)
+{
+	const u64 splice_time_90k = 6330602;
+
+	/* A predictive packet after the cue cannot start an independently decodable
+	 * HLS segment. */
+	assert_false(dasher_scte35_boundary_due(6332400, 90000, GF_FILTER_SAP_NONE, splice_time_90k));
+
+	/* A SAP before the requested splice point is still too early. */
+	assert_false(dasher_scte35_boundary_due(6330000, 90000, GF_FILTER_SAP_1, splice_time_90k));
+
+	/* Exact and slightly-later SAPs are valid boundaries. The latter models the
+	 * real broadcast sample where the cue is about 20 ms before the IDR. */
+	assert_true(dasher_scte35_boundary_due(6330602, 90000, GF_FILTER_SAP_1, splice_time_90k));
+	assert_true(dasher_scte35_boundary_due(6332400, 90000, GF_FILTER_SAP_1, splice_time_90k));
+
+	/* Comparison is timescale-safe. 70.36 s in a 1 kHz stream is after the
+	 * 70.340022 s SCTE splice time. */
+	assert_true(dasher_scte35_boundary_due(70360, 1000, GF_FILTER_SAP_1, splice_time_90k));
+	assert_false(dasher_scte35_boundary_due(70300, 1000, GF_FILTER_SAP_1, splice_time_90k));
+}


### PR DESCRIPTION
## Problem

For HLS SSAI, translating SCTE-35 to manifest tags is not sufficient when the splice falls inside an already-formed media segment. The media needs a usable segment boundary near the splice point.

GPAC already supports `DashCue=inband`, but that mode is cue-driven segmentation: normal duration-based segment boundaries are suppressed while the segmenter waits for cue points. With a six-second target and a first SCTE cue around 70 seconds, using cue-only segmentation can therefore create an initial segment roughly 70 seconds long.

That is not the desired SCTE behavior. SCTE should add a splice boundary to the normal HLS cadence, not replace the cadence.

A second practical detail is that the SCTE splice timestamp may be slightly before the next encoded random-access packet. In the real broadcast sample used to reproduce the issue:

- normalized SCTE OUT time: `70.340022 s`
- next usable video RAP: `70.360 s`
- delta: about `19.98 ms`

Stream-copy packaging cannot manufacture an IDR at 70.340022 s. The first decodable segment boundary is the RAP at 70.360 s.

## Fix

When dasher parses a new SCTE event that requires an IDR/RAP on a visual representation:

- retain normal duration-based segmentation;
- remember the break start and, when a finite break duration is present, the planned return time;
- keep each boundary pending through predictive packets;
- force an additional segment boundary on the first SAP at or after the SCTE boundary;
- re-anchor the normal segment cadence at that SAP so following segments retain normal target-duration behavior;
- leave explicit source-driven, in-band-cue-only, and cue-list segmentation modes unchanged.

Repeated copies of the same SCTE event are already de-duplicated by the existing event-ID handling and therefore do not repeatedly reset the pending boundary.

## Unit test

Adds `dasher_scte35_boundary_uses_first_sap_at_or_after_splice`.

The test verifies that:

- a predictive packet after the splice is not used as a boundary;
- a SAP before the splice is not used;
- a SAP exactly at the splice is accepted;
- the first SAP slightly after the splice is accepted;
- comparison remains correct when packet and SCTE clocks use different timescales.

## Integration validation

Using the real MPEG-TS SCTE-35 sample with a six-second HLS target:

- SCTE OUT: `70.340022 s`
- new segment start: `70.360 s`
- CUE-OUT: immediately before that segment
- planned SCTE return: `312.340022 s`
- return segment start: `312.360 s`
- CUE-IN: immediately before that segment

Normal segmentation remained active before, during, and after the break. Around the first cue, the video segment timeline was:

- `61.480 -> 67.840`
- `67.840 -> 70.360` (shortened to reach the splice RAP)
- `70.360 -> 76.720`
- `76.720 -> 83.080`

Around the return:

- `299.320 -> 305.680`
- `305.680 -> 312.360`
- `312.360 -> 318.720`

## Rationale

SCTE signaling describes an intended splice time, while independently decodable HLS segments must begin on a usable random-access point. Choosing the first SAP at or after the cue avoids replacing program material early and preserves decodeability without transcoding.

Re-anchoring the normal cadence at the splice prevents the forced boundary from creating an immediately short follow-on segment.

## Scope

This is deliberately not a general segmentation-policy rewrite. It only adds an SCTE-derived RAP boundary when GPAC is otherwise using ordinary duration-based segmentation.
