### PR TITLE
Preserve SCTE-35 markers across repeated HLS playlist serialization

### DIFF
--- a/src/media_tools/mpd.c
+++ b/src/media_tools/mpd.c
@@ -4359,6 +4359,18 @@ static void hls_insert_scte35_info(FILE *out, u64 ast, const GF_MPD_Period *peri
 static GF_Err gf_mpd_write_m3u8_playlist(const GF_MPD *mpd, const GF_MPD_Period *period, const GF_MPD_AdaptationSet *as, GF_MPD_Representation *rep, char *m3u8_name, u32 hls_version, Double max_part_dur_session, const char *force_base_url, Bool delta_update, Bool is_last, FILE* out_file)
 {
 	u32 i, count;
+	u32 event_stream_index = 0;
+	GF_MPD_EventStream *event_stream;
+
+	/* Event entry state is scratch state used while serializing one HLS playlist.
+	 * Dynamic playlists are regenerated from the retained segment window, so a
+	 * previous serialization must not suppress SCTE-35 tags on a later rewrite. */
+	while (period->event_streams && (event_stream = gf_list_enum(period->event_streams, &event_stream_index))) {
+		u32 event_index = 0;
+		GF_MPD_EventStreamEntry *event_entry;
+		while ((event_entry = gf_list_enum(event_stream->entries, &event_index)))
+			event_entry->state = 0;
+	}
 	GF_DASH_SegmentContext *sctx;
 	FILE *out = out_file;
 	char *force_url=NULL;

--- a/src/media_tools/unittests/ut_mpd.c
+++ b/src/media_tools/unittests/ut_mpd.c
@@ -5,6 +5,86 @@
 #include "../m3u8.c"
 void gf_xml_dump_string(FILE* file, const char *before, const char *str, const char *after) {}
 
+/*************************************/
+
+static Bool hls_output_contains(FILE *output, const char *marker)
+{
+	char text[4096];
+	size_t bytes_read;
+
+	fflush(output);
+	rewind(output);
+	memset(text, 0, sizeof(text));
+	bytes_read = fread(text, 1, sizeof(text) - 1, output);
+	text[bytes_read] = 0;
+	return strstr(text, marker) ? GF_TRUE : GF_FALSE;
+}
+
+unittest(mpd_hls_scte35_dynamic_rewrite_preserves_cues)
+{
+	GF_MPD mpd = {0};
+	GF_MPD_Period period = {0};
+	GF_MPD_AdaptationSet adaptation_set = {0};
+	GF_MPD_Representation representation = {0};
+	GF_DASH_SegmentContext segment = {0};
+	GF_MPD_EventStream event_stream = {0};
+	GF_MPD_EventStreamEntry event_entry = {0};
+	FILE *first_playlist;
+	FILE *second_playlist;
+	GF_Err error;
+
+	period.event_streams = gf_list_new();
+	event_stream.entries = gf_list_new();
+	representation.state_seg_list = gf_list_new();
+	assert_true(period.event_streams != NULL);
+	assert_true(event_stream.entries != NULL);
+	assert_true(representation.state_seg_list != NULL);
+
+	mpd.type = GF_MPD_TYPE_DYNAMIC;
+	representation.timescale = 1000;
+	representation.hls_max_seg_dur.num = 6;
+	representation.hls_max_seg_dur.den = 1;
+
+	segment.time = 0;
+	segment.dur = 6000;
+	segment.seg_num = 1;
+	segment.filename = "segment1.m4s";
+	gf_list_add(representation.state_seg_list, &segment);
+
+	event_stream.timescale = 1000;
+	event_entry.presentation_time = 0;
+	event_entry.duration = 20000;
+	event_entry.id = 662;
+	gf_list_add(event_stream.entries, &event_entry);
+	gf_list_add(period.event_streams, &event_stream);
+
+	first_playlist = tmpfile();
+	assert_true(first_playlist != NULL);
+	error = gf_mpd_write_m3u8_playlist(&mpd, &period, &adaptation_set, &representation,
+		"first.m3u8", 7, 0, NULL, GF_FALSE, GF_FALSE, first_playlist);
+	assert_true(error == GF_OK);
+	assert_true(hls_output_contains(first_playlist, "#EXT-X-CUE-OUT:20"));
+	assert_equal(event_entry.state, 1, "%u");
+	fclose(first_playlist);
+
+	/* A dynamic playlist is rebuilt from retained segments. The same cue must be
+	 * serialized again; state left by the previous write must not hide it. */
+	second_playlist = tmpfile();
+	assert_true(second_playlist != NULL);
+	error = gf_mpd_write_m3u8_playlist(&mpd, &period, &adaptation_set, &representation,
+		"second.m3u8", 7, 0, NULL, GF_FALSE, GF_FALSE, second_playlist);
+	assert_true(error == GF_OK);
+	assert_true(hls_output_contains(second_playlist, "#EXT-X-CUE-OUT:20"));
+	assert_equal(event_entry.state, 1, "%u");
+	fclose(second_playlist);
+
+	gf_list_del(representation.state_seg_list);
+	gf_list_del(event_stream.entries);
+	gf_list_del(period.event_streams);
+}
+
+/*************************************/
+
 unittest(mpd_event_streams)
 {
 	GF_DOMParser *dom = gf_xml_dom_new();


### PR DESCRIPTION
## Problem

The HLS SCTE-35 writer uses `GF_MPD_EventStreamEntry::state` to track whether a cue-out has been emitted while walking the segments of one playlist. The state is stored on the MPD event entry itself and therefore survives after that playlist serialization finishes.

This becomes incorrect when the same period/event list is serialized again, as happens for dynamic HLS playlist rewrites and for multiple HLS variant playlists sharing the same event stream. A cue emitted during the first write can leave the event in the "already emitted" state, causing a later full playlist serialization to omit the same `EXT-X-DATERANGE` / `EXT-X-CUE-OUT` marker even though the applicable segment is still present.

The issue was observed in a live HLS stream: the SCTE decoder reported the real splice event, but a later dynamic playlist rewrite no longer contained the cue marker. Static one-shot serialization did not show the problem.

## Root cause

`GF_MPD_EventStreamEntry::state` is serialization scratch state, but it is retained across calls to `gf_mpd_write_m3u8_playlist()`.

The state is needed while walking the segments of one playlist so the writer can pair CUE-OUT and CUE-IN. It must not carry the result of a previous playlist write into the next complete serialization.

## Fix

Reset event-entry serialization state at the start of each HLS variant playlist write, before walking that playlist's retained segment list.

The change is deliberately limited to HLS playlist serialization. It does not alter SCTE parsing, event timing, media segmentation, DASH output, or media payloads.

## Unit test

Adds `mpd_hls_scte35_dynamic_rewrite_preserves_cues`.

The test creates one SCTE event whose break extends beyond the current segment and serializes the same dynamic HLS playlist twice:

1. the first write emits `#EXT-X-CUE-OUT:20` and leaves the event state active while that playlist is being walked;
2. the second full playlist write must emit the same CUE-OUT again because it is a new serialization of the retained media window.

With the test added but the fix removed, the second assertion fails because the cue is suppressed by the state left from the first write. With the fix present, both writes contain the cue.

## Validation

Against base commit `239c20cdfe9dad19580e87f98ca0fd8b55fe560b`:

## Rationale

A full HLS playlist rewrite must be deterministic from the current MPD/event and retained-segment state. The result should not depend on whether another variant or an earlier dynamic rewrite happened to serialize the same event first.

## Scope

This patch fixes only repeated HLS serialization state. Cue timing normalization, cue/segment association, and SCTE-driven segment boundaries are separate changes in the patch series and are intentionally not included here.
